### PR TITLE
[Feature]Add dataset sequential

### DIFF
--- a/mmchat/datasets/__init__.py
+++ b/mmchat/datasets/__init__.py
@@ -1,3 +1,4 @@
+from .concat_dataset import ConcatDataset
 from .huggingface import process_hf_dataset
 
-__all__ = ['process_hf_dataset']
+__all__ = ['process_hf_dataset', 'ConcatDataset']

--- a/mmchat/datasets/concat_dataset.py
+++ b/mmchat/datasets/concat_dataset.py
@@ -1,0 +1,25 @@
+from torch.utils.data import ConcatDataset as _ConcatDataset
+
+from mmchat.registry import DATASETS
+
+
+class ConcatDataset(_ConcatDataset):
+
+    def __init__(self, tokenizer, datasets_cfg):
+        datasets = []
+        names = []
+        for name, cfg in datasets_cfg.items():
+            if cfg.get('tokenizer', None) is None:
+                cfg['tokenizer'] = tokenizer
+            datasets.append(DATASETS.build(cfg))
+            names.append(name)
+        self.names = names
+        super().__init__(datasets=datasets)
+
+    def __repr__(self):
+        main_str = 'Dataset as a concatenation of multiple datasets. \n'
+        main_str += '\n'.join([
+            f'{name}: {repr(dataset)},'
+            for name, dataset in zip(self.names, self.datasets)
+        ])
+        return main_str

--- a/mmchat/datasets/huggingface.py
+++ b/mmchat/datasets/huggingface.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-from torch.utils.data import ConcatDataset
-
 from mmchat.registry import DATASETS, TOKENIZER
 from .utils import Concatenator, encode_fn
 
@@ -36,23 +34,3 @@ def process_hf_dataset(dataset,
             batched=True,
             remove_columns=column_names)
     return dataset[mode]
-
-
-class HfDatasets(ConcatDataset):
-
-    def __init__(self, datasets_cfg):
-        datasets = []
-        names = []
-        for name, cfg in datasets_cfg.items():
-            datasets.append(DATASETS.build(cfg))
-            names.append(name)
-        self.names = names
-        super().__init__(datasets=datasets)
-
-    def __repr__(self):
-        main_str = 'Dataset as a concatenation of multiple datasets. \n'
-        main_str += '\n'.join([
-            f'{name}: {repr(dataset)},'
-            for name, dataset in zip(self.names, self.datasets)
-        ])
-        return main_str


### PR DESCRIPTION
```
from mmchat.datasets import process_hf_dataset
from transformers import AutoTokenizer
from datasets import load_dataset
from mmchat.datasets.map_fns import oasst1_map_fn
pretrained_model_name_or_path = '/share/gaojianfei/merged_chinese_lora_7b'
tokenizer = dict(
    type=AutoTokenizer.from_pretrained,
    pretrained_model_name_or_path=pretrained_model_name_or_path,
    use_fast=False,
    padding_side='right')
oasst1 = dict(
    type=process_hf_dataset,
    dataset=dict(type=load_dataset, path='timdettmers/openassistant-guanaco'),
    tokenizer=tokenizer,
    max_length=2048,
    map_fn=oasst1_map_fn,
    concat_to_max_length=False)
datasets_cfg = dict(oasst1=oasst1, oasst1_2=oasst1)
ds = HfDatasets(datasets_cfg)
print(ds)

Dataset as a concatenation of multiple datasets. 
{
oasst1: Dataset({
    features: ['text', 'input', 'output', 'input_ids', 'labels'],
    num_rows: 9846
})
oasst1_2: Dataset({
    features: ['text', 'input', 'output', 'input_ids', 'labels'],
    num_rows: 9846
})
```