### PR TITLE
[Fix] Temporarily limit the version of `transformers`

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -9,5 +9,5 @@ scipy
 SentencePiece
 tiktoken
 torch
-transformers>=4.32.1
+transformers>=4.32.1,<=4.34.0
 transformers_stream_generator


### PR DESCRIPTION
Main reasons:
1. ChatGLM3 tokenizer `save_pretrained` error: https://github.com/InternLM/xtuner/issues/199#issuecomment-1791853794
2. The expected signatures of `gradient_checkpointing_enable` have been changed: https://github.com/huggingface/transformers/pull/27020, https://github.com/huggingface/transformers/pull/27073

