### PR TITLE
add wizard_coder templates

### DIFF
--- a/xtuner/utils/templates.py
+++ b/xtuner/utils/templates.py
@@ -45,6 +45,11 @@ PROMPT_TEMPLATE = ConfigDict(
                 'helpful, detailed, and polite answers to the '
                 'user\'s questions. {system}\n'),
         INSTRUCTION=('USER: {input} ASSISTANT: ')),
+    wizard_coder=dict(
+        SYSTEM=('Below is an instruction that describes a task. '
+                'Write a response that appropriately completes the request.\n\n'
+                '{system}\n'),
+        INSTRUCTION=('### Instruction:\n{input}\n\n### Response:')),        
 )
 
 SYSTEM_TEMPLATE = ConfigDict(


### PR DESCRIPTION
由于WizardLM_WizardCoder-Python-13B-V1.0、WizardLM_WizardCoder-Python-34B-V1.0系列wizardcoder模型，对话模版有区别于wizardlm，新增了wizard_coder的对话模板，测试13B训练是可行的。

参考：
https://github.com/nlpxucan/WizardLM/blob/main/demo/wizardcoder_demo.py