### PR TITLE
[Improve] Add `broadcast_from_master` argument for `process_hf_dataset`

### DIFF
--- a/xtuner/dataset/huggingface.py
+++ b/xtuner/dataset/huggingface.py
@@ -151,8 +151,8 @@ def process(dataset,
     return dataset
 
 
-def process_hf_dataset(master_only=True, *args, **kwargs):
-    if master_only and dist.is_available() and dist.is_initialized():
+def process_hf_dataset(broadcast_from_master=True, *args, **kwargs):
+    if broadcast_from_master and dist.is_available() and dist.is_initialized():
         if dist.get_rank() == 0:
             dataset = process(*args, **kwargs)
             objects = [dataset]


### PR DESCRIPTION
In some multi-node environment, there is no shared file system for each node. Furthermore, the `broadcast_object_list` will lead to an error.
To prevent this, we can set `broadcast_from_master=False` to disable the `process-broadcast` behavior, and separately process data in each rank.
