### PR TITLE
[Fix] Fix extract_json_objects

### DIFF
--- a/xtuner/dataset/map_fns/dataset_map_fns/msagent_map_fn.py
+++ b/xtuner/dataset/map_fns/dataset_map_fns/msagent_map_fn.py
@@ -42,7 +42,9 @@ def extract_json_objects(text, decoder=json.JSONDecoder()):
             result, index = decoder.raw_decode(text[match:])
             if 'name' in result and 'description' in result:
                 results.append(result)
-            pos = match + index
+                pos = match + index
+            else:
+                pos = match + 1
         except ValueError:
             pos = match + 1
     return results
@@ -55,7 +57,7 @@ def msagent_react_map_fn(example):
     input_text = ''
     for t in text:
         if t['from'] == 'system':
-            system_text += """你是一个可以调用外部工具的助手，可以使用的工具包括：\n"""
+            system_text += '你是一个可以调用外部工具的助手，可以使用的工具包括：\n'
             json_objects = extract_json_objects(t['value'])
             api_dict = {}
             for obj in json_objects:
@@ -69,15 +71,15 @@ def msagent_react_map_fn(example):
                 except Exception:
                     pass
             system_text += f'{api_dict}\n'
-            system_text += f"""
-                如果使用工具请遵循以下格式回复：\n```\n
-                Thought:思考你当前步骤需要解决什么问题，是否需要使用工具\n
-                Action:工具名称，你的工具必须从 [{str(list(api_dict.keys()))}] 选择\n
-                Action Input:工具输入参数\n```\n工具返回按照以下格式回复：\n```\n
-                Response:调用工具后的结果\n```\n如果你已经知道了答案，或者你不需要工具，
-                请遵循以下格式回复\n```\n
-                Thought:给出最终答案的思考过程\n
-                Final Answer:最终答案\n```\n开始!\n"""
+            system_text += (
+                '如果使用工具请遵循以下格式回复：\n```\n'
+                'Thought:思考你当前步骤需要解决什么问题，是否需要使用工具\n'
+                f'Action:工具名称，你的工具必须从 [{str(list(api_dict.keys()))}] 选择\n'
+                'Action Input:工具输入参数\n```\n工具返回按照以下格式回复：\n```\n'
+                'Response:调用工具后的结果\n```\n如果你已经知道了答案，或者你不需要工具，'
+                '请遵循以下格式回复\n```\n'
+                'Thought:给出最终答案的思考过程\n'
+                'Final Answer:最终答案\n```\n开始!\n')
         elif t['from'] == 'user':
             input_text += f"{t['value']}\n"
         elif t['from'] == 'assistant':


### PR DESCRIPTION
使用修改后得到的数据如下所示：

```json
{
    "conversation": [
        {
            "system": "你是一个可以调用外部工具的助手，可以使用的工具包括：\n{'modelscope_text-address': \"针对中文的地址信息，识别出里面的元素，包括省、市、区、镇、社区、道路、路号、POI、楼栋号、户室号等\\n输入参数: {'text': '用户输入的地址信息'}\"}\n如果使用工具请遵循以下格式回复：\n```\nThought:思考你当前步骤需要解决什么问题，是否需要使用工具\nAction:工具名称，你的工具必须从 [['modelscope_text-address']] 选择\nAction Input:工具输入参数\n```\n工具返回按照以下格式回复：\n```\nResponse:调用工具后的结果\n```\n如果你已经知道了答案，或者你不需要工具，请遵循以下格式回复\n```\nThought:给出最终答案的思考过程\nFinal Answer:最终答案\n```\n开始!\n",
            "input": "现在我给你另一条地址，请识别出里面的元素。输入地址：北京市海淀区中关村大街27号\n",
            "output": "Action:modelscope_text-address\nAction Input:{'text': '北京市海淀区中关村大街27号'}\n\n\n\n"
        },
        {
            "system": "Response:{'prov': '北京市', 'city': '北京市', 'district': '海淀区', 'road': '中关村大街', 'number': '27号'}\n",
            "output": "Final Answer:地址识别json表示：{\"prov\": \"北京市\", \"city\": \"北京市\", \"district\": \"海淀区\", \"road\": \"中关村大街\", \"number\": \"27号\"}。我使用的模型是ModelScope的'damo/mgeo_geographic_elements_tagging_chinese_base'模型。这是基于达摩院联合高德发布的多任务多模态地址预训练底座MGeo模型微调得到的。\n"
        },
        {
            "system": "",
            "input": "请识别以下地址中的元素。包括：省、市、区、镇、社区、道路、路号、POI、楼栋号、户室号等。输入地址：北京市海淀区上地十街10号院\n",
            "output": "Action:modelscope_text-address\nAction Input:{'text': '北京市海淀区上地十街10号院'}\n\n\n\n"
        },
        {
            "system": "Response:{'prov': '北京市', 'city': '北京市', 'district': '海淀区', 'town': '上地街道', 'community': '十街10号院'}\n",
            "output": "Final Answer:地址识别结果json表示：{\"prov\": \"北京市\", \"city\": \"北京市\", \"district\": \"海淀区\", \"town\": \"上地街道\", \"community\": \"十街10号院\"}。本API使用的是ModelScope的'damo/mgeo_geographic_elements_tagging_chinese_base'模型，为了更好地提高模型的训练效果，我们在达摩院联合高德发布的多任务多模态地址预训练底座MGeo模型上进行了微调。\n"
        }
    ]
}
```