### PR TITLE
[Fix] Inconsistent BatchSize of `LengthGroupedSampler`

### DIFF
--- a/xtuner/dataset/samplers/length_grouped.py
+++ b/xtuner/dataset/samplers/length_grouped.py
@@ -90,7 +90,9 @@ class LengthGroupedSampler(Sampler):
         self.round_up = round_up
 
         if self.round_up:
-            self.num_samples = math.ceil(len(self.dataset) / world_size)
+            num_iters = math.ceil(
+                len(self.dataset) / world_size / per_device_batch_size)
+            self.num_samples = num_iters * per_device_batch_size
             self.total_size = self.num_samples * self.world_size
         else:
             self.num_samples = math.ceil(


### PR DESCRIPTION
E.g.,
```
n_data = 10003
world_size = 8
per_device_batch_size = 16
round_up = True
```

```
num_samplers = ceil(10003 / 8) = 1251
total_size = 1251 * 8 = 10008

iteration = ceil(10008 / 16 / 8) = 79
Iter 0-77, bs = 8 * 16 = 128
Iter 78, bs = 10008 - 128 * 78 = 24
```
This inconsistent BatchSize (128 v.s. 24) leads to an error when using DeepSpeed,
```
Invalidate trace cache @ step 305: expected module 4, but got module 2
```

After fix
```
num_samplers = ceil(10003 / 8 / 16) * 16 = 1264
total_size = 1264 * 8 = 10112

iteration = ceil(10112 / 16 / 8) = 79
Iter 0-77, bs = 8 * 16 = 128
Iter 78, bs = 10112 - 128 * 78 = 128
```




