### PR TITLE
support offline process llava data

### DIFF
--- a/docs/zh_cn/user_guides/llava_offline.md
+++ b/docs/zh_cn/user_guides/llava_offline.md
@@ -1,0 +1,50 @@
+# 离线处理 Llava 训练数据集
+
+当训练数据量非常大时，每次训练的时候都先在线处理数据可能会极为耗时。我们可以先对原始数据进行离线处理并保存至本地，随后的多次训练可以读入本地离线处理好的数据后直接开始训练。
+
+## Step 1, 导出模板 config 文件
+
+可使用以下命令查看 XTuner 中提供的 Llava 训练相关的 config：
+
+```
+xtuner list-cfg -p llava
+```
+
+找到需要使用的 config 文件并导出至当前目录下：
+
+```
+xtuner copy-cfg ${CONFIG_NAME} .
+```
+
+## Step 2, 离线处理数据集
+
+使用以下命令可离线处理训练数据集中的文本数据：
+
+```
+python xtuner/tools/process_untokenized_llava_data.py \
+    ${CONFIG_PATH} \
+    --save-folder /folder/to/save/processed/dataset
+```
+
+其中，${CONFIG_PATH} 为第一步中导出的 config 文件路径，`/folder/to/save/processed/dataset` 则需要指定为离线处理数据的保存路径。
+
+## Step 3, 修改 config 文件
+
+对 Step 1 中导出的 config 文件做如下修改：
+
+```diff
+#######################################################################
+#                      PART 3  Dataset & Dataloader                   #
+#######################################################################
+llava_dataset = dict(
+-   data_path=data_path,
+-   tokenizer=tokenizer,
++   offline_processed_text_folder=/folder/to/save/processed/dataset
+    ...)
+```
+
+其中，`/folder/to/save/processed/dataset` 为 Step 2 保存的离线处理数据路径。
+
+## Step 4，开始训练
+
+使用 Step 3 修改得到的 config 训练即可。

--- a/xtuner/dataset/llava.py
+++ b/xtuner/dataset/llava.py
@@ -1,10 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import json
+import logging
 import os
 
 import torch
 from datasets import Dataset as HFDataset
 from datasets import DatasetDict, load_from_disk
+from mmengine import print_log
 from mmengine.config import Config, ConfigDict
 from PIL import Image
 from torch.utils.data import Dataset
@@ -30,6 +32,14 @@ class LLaVADataset(Dataset):
         super().__init__()
 
         assert offline_processed_text_folder or (data_path and tokenizer)
+        if offline_processed_text_folder and data_path:
+            print_log(
+                'Both `offline_processed_text_folder` and '
+                '`data_path` are set, and we load dataset from'
+                '`offline_processed_text_folder` '
+                f'({offline_processed_text_folder})',
+                logger='current',
+                level=logging.WARNING)
 
         if offline_processed_text_folder is not None:
             self.text_data = load_from_disk(offline_processed_text_folder)

--- a/xtuner/tools/process_untokenized_llava_data.py
+++ b/xtuner/tools/process_untokenized_llava_data.py
@@ -1,0 +1,33 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import argparse
+import warnings
+
+from mmengine import Config
+
+from xtuner.registry import BUILDER
+
+# ignore FutureWarning in hf datasets
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('config', help='config file name or path.')
+    parser.add_argument('--save-folder', help='The folder to save data order.')
+    args = parser.parse_args()
+    return args
+
+
+def build_llava_dataset(config):
+    dataset = BUILDER.build(config.train_dataloader.dataset)
+    return dataset
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    cfg = Config.fromfile(args.config)
+
+    llava_dataset = build_llava_dataset(cfg)
+    text_data = llava_dataset.text_data
+
+    text_data.save_to_disk(args.save_folder)


### PR DESCRIPTION
离线处理llava数据可以尝试在XTuner main分支基础上
修改：
1. xtuner/dataset/llava.py
2. xtuner/dataset/map_fns/dataset_map_fns/llava_map_fn.py
新增：
1. xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_llava.py
2. xtuner/tools/process_untokenized_llava_data.py

- 首先通过xtuner/tools/process_untokenized_llava_data.py离线处理llava训练数据中的文本部分
```
python xtuner/tools/process_untokenized_llava_data.py llava_cfg.py --save-folder llava_data
```
- 处理后可以读取数据集查看是否符合预期
```
from datasets import load_from_disk
ds = load_from_disk('llava_data')
print(ds)
```
- 之后修改 llava_cfg.py 配置文件中的llava_dataset，新增 `offline_processed_text_folder = ${save-folder}` 字段就可以直接读取离线处理后的数据了