### PR TITLE
[Configs] Add sequence_parallel_size and SequenceParallelSampler to configs

### DIFF
--- a/xtuner/configs/deepseek/deepseek_coder_6_7b_base/deepseek_coder_6_7b_base_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/deepseek/deepseek_coder_6_7b_base/deepseek_coder_6_7b_base_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.deepseek_coder
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_coder_6_7b_base/deepseek_coder_6_7b_base_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/deepseek/deepseek_coder_6_7b_base/deepseek_coder_6_7b_base_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_coder_6_7b_instruct/deepseekcoder_6_7b_instruct_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/deepseek/deepseek_coder_6_7b_instruct/deepseekcoder_6_7b_instruct_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.deepseek_coder
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_coder_6_7b_instruct/deepseekcoder_6_7b_instruct_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/deepseek/deepseek_coder_6_7b_instruct/deepseekcoder_6_7b_instruct_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_full_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_full_oasst1_e3.py
@@ -14,6 +14,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -29,9 +30,13 @@ prompt_template = PROMPT_TEMPLATE.deepseek_moe
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -85,11 +90,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_full_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_full_oasst1_e3.py
@@ -90,13 +90,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_qlora_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_qlora_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_base/deepseek_moe_16b_base_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.deepseek_moe
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_full_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_full_oasst1_e3.py
@@ -14,6 +14,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -29,9 +30,13 @@ prompt_template = PROMPT_TEMPLATE.deepseek_moe
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -85,11 +90,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_full_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_full_oasst1_e3.py
@@ -90,13 +90,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_qlora_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_qlora_oasst1_e3.py
+++ b/xtuner/configs/deepseek/deepseek_moe_16b_chat/deepseek_moe_16b_chat_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.deepseek_moe
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_full_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_full_alpaca_e3.py
@@ -14,6 +14,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -29,9 +30,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -85,11 +90,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_full_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_full_alpaca_e3.py
@@ -90,13 +90,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_1_8b/internlm2_1_8b_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_full_finetune_custom_dataset_e1.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_full_finetune_custom_dataset_e1.py
@@ -49,12 +49,16 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 32768
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 # batch size per device, set to 1 if `use_varlen_attn` = True
 # To clarify, enlarging the batch size essentially enlarges the `max_length`.
 # For example, doubling the max length is tantamount to doubling the batch size
 batch_size = 1
 accumulative_counts = 1  # 1bs * 1acc * 64gpu = 64 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 4
 max_epochs = 1
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_arxiv_gentitle_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -140,11 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_arxiv_gentitle_e3.py
@@ -145,13 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_colorist_e5.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_colorist_e5.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_colorist_e5.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_colorist_e5.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 5
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_lawyer_e3.py
@@ -134,13 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_lawyer_e3.py
@@ -19,6 +19,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -36,9 +37,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -129,11 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_msagent_react_e3_gpu8.py
@@ -40,6 +40,7 @@ sequence_parallel_size = 1
 # Scheduler & Optimizer
 batch_size = 8  # per_device
 accumulative_counts = 1
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 2
 max_epochs = 3
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_msagent_react_e3_gpu8.py
@@ -128,13 +128,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_msagent_react_e3_gpu8.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,6 +33,9 @@ data_path = 'damo/MSAgent-Bench'
 prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = False
+
+# parallel
+sequence_parallel_size = 1
 
 # Scheduler & Optimizer
 batch_size = 8  # per_device
@@ -123,11 +127,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_512_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_512_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 512
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_sql_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_sql_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_sql_e3.py
+++ b/xtuner/configs/internlm/internlm2_20b/internlm2_20b_qlora_sql_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_full_finetune_custom_dataset_e1.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_full_finetune_custom_dataset_e1.py
@@ -42,7 +42,6 @@ from xtuner.utils import PROMPT_TEMPLATE
 # Model
 pretrained_model_name_or_path = 'internlm/internlm2-7b'
 use_varlen_attn = True
-sequence_parallel_size = 1
 
 # Data
 data_files = ['/path/to/json/file.json']
@@ -50,12 +49,16 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 32768
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 # batch size per device, set to 1 if `use_varlen_attn` = True
 # To clarify, enlarging the batch size essentially enlarges the `max_length`.
 # For example, doubling the max length is tantamount to doubling the batch size
 batch_size = 1
 accumulative_counts = 1  # 1bs * 1acc * 64gpu = 64 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 4
 max_epochs = 1
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_full_finetune_custom_dataset_e1_sequence_parallel_4.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_full_finetune_custom_dataset_e1_sequence_parallel_4.py
@@ -42,7 +42,6 @@ from xtuner.utils import PROMPT_TEMPLATE
 # Model
 pretrained_model_name_or_path = 'internlm/internlm2-7b'
 use_varlen_attn = True
-sequence_parallel_size = 4
 
 # Data
 data_files = ['/path/to/json/file.json']
@@ -50,10 +49,14 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 32768
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 4
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 # accumulative_counts = accumulative_counts * sequence_parallel_size
-accumulative_counts = 4
+accumulative_counts = 1
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 4
 max_epochs = 1
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_arxiv_gentitle_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -140,11 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_arxiv_gentitle_e3.py
@@ -145,13 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_colorist_e5.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_colorist_e5.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_colorist_e5.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_colorist_e5.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 5
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_json_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_json_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_json_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_json_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_lawyer_e3.py
@@ -134,13 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_lawyer_e3.py
@@ -19,6 +19,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -36,9 +37,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -129,11 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_msagent_react_e3_gpu8.py
@@ -40,6 +40,7 @@ sequence_parallel_size = 1
 # Scheduler & Optimizer
 batch_size = 8  # per_device
 accumulative_counts = 1
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 2
 max_epochs = 3
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_msagent_react_e3_gpu8.py
@@ -128,13 +128,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_msagent_react_e3_gpu8.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,6 +33,9 @@ data_path = 'damo/MSAgent-Bench'
 prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = False
+
+# parallel
+sequence_parallel_size = 1
 
 # Scheduler & Optimizer
 batch_size = 8  # per_device
@@ -123,11 +127,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_512_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_512_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 512
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_sql_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_sql_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_sql_e3.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_qlora_sql_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_w_tokenized_dataset.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_w_tokenized_dataset.py
@@ -29,12 +29,16 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 32768
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 # batch size per device, set to 1 if `use_varlen_attn` = True
 # To clarify, enlarging the batch size essentially enlarges the `max_length`.
 # For example, doubling the max length is tantamount to doubling the batch size
 batch_size = 1
 accumulative_counts = 1  # 1bs * 1acc * 64gpu = 64 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 4
 max_epochs = 1
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_7b/internlm2_7b_w_untokenized_dataset.py
+++ b/xtuner/configs/internlm/internlm2_7b/internlm2_7b_w_untokenized_dataset.py
@@ -30,12 +30,16 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 32768
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 # batch size per device, set to 1 if `use_varlen_attn` = True
 # To clarify, enlarging the batch size essentially enlarges the `max_length`.
 # For example, doubling the max length is tantamount to doubling the batch size
 batch_size = 1
 accumulative_counts = 1  # 1bs * 1acc * 64gpu = 64 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 4
 max_epochs = 1
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_full_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_full_alpaca_e3.py
@@ -90,13 +90,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_full_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_full_alpaca_e3.py
@@ -14,6 +14,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -29,9 +30,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -85,11 +90,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_1_8b/internlm2_chat_1_8b_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_full_finetune_custom_dataset_e1.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_full_finetune_custom_dataset_e1.py
@@ -49,12 +49,16 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 32768
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 # batch size per device, set to 1 if `use_varlen_attn` = True
 # To clarify, enlarging the batch size essentially enlarges the `max_length`.
 # For example, doubling the max length is tantamount to doubling the batch size
 batch_size = 1
 accumulative_counts = 1  # 1bs * 1acc * 64gpu = 64 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 4
 max_epochs = 1
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_lawyer_e3.py
@@ -19,6 +19,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -36,9 +37,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -129,11 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_lawyer_e3.py
@@ -134,13 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_512_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 512
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_512_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_20b/internlm2_chat_20b_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_full_finetune_custom_dataset_e1.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_full_finetune_custom_dataset_e1.py
@@ -49,12 +49,16 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 32768
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 # batch size per device, set to 1 if `use_varlen_attn` = True
 # To clarify, enlarging the batch size essentially enlarges the `max_length`.
 # For example, doubling the max length is tantamount to doubling the batch size
 batch_size = 1
 accumulative_counts = 1  # 1bs * 1acc * 64gpu = 64 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 4
 max_epochs = 1
 optim_type = AdamW

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_lawyer_e3.py
@@ -19,6 +19,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -36,9 +37,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -129,11 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_lawyer_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_lawyer_e3.py
@@ -134,13 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_512_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 512
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_512_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_e3.py
+++ b/xtuner/configs/internlm/internlm2_chat_7b/internlm2_chat_7b_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.internlm2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_70b/llama2_70b_full_wizardlm_e1.py
+++ b/xtuner/configs/llama/llama2_70b/llama2_70b_full_wizardlm_e1.py
@@ -91,13 +91,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_70b/llama2_70b_full_wizardlm_e1.py
+++ b/xtuner/configs/llama/llama2_70b/llama2_70b_full_wizardlm_e1.py
@@ -15,6 +15,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -30,9 +31,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 4  # 1bs * 4acc * 32gpu = 128 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -86,11 +91,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_70b/llama2_70b_int8_lora_open_platypus_e1.py
+++ b/xtuner/configs/llama/llama2_70b/llama2_70b_int8_lora_open_platypus_e1.py
@@ -16,6 +16,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -31,9 +32,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -97,11 +102,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_70b/llama2_70b_int8_lora_open_platypus_e1.py
+++ b/xtuner/configs/llama/llama2_70b/llama2_70b_int8_lora_open_platypus_e1.py
@@ -102,13 +102,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_70b/llama2_70b_qlora_open_platypus_e1.py
+++ b/xtuner/configs/llama/llama2_70b/llama2_70b_qlora_open_platypus_e1.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -106,11 +111,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_70b/llama2_70b_qlora_open_platypus_e1.py
+++ b/xtuner/configs/llama/llama2_70b/llama2_70b_qlora_open_platypus_e1.py
@@ -111,13 +111,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp1.py
@@ -97,13 +97,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp1.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 from datasets import load_dataset
+from mmengine.dataset import DefaultSampler
 from mmengine.hooks import (CheckpointHook, DistSamplerSeedHook, IterTimerHook,
                             LoggerHook, ParamSchedulerHook)
 from mmengine.optim import AmpOptimWrapper, CosineAnnealingLR, LinearLR
@@ -41,9 +42,13 @@ max_length = 65536
 max_position_embeddings = 65536
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 8
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -92,11 +97,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=SequenceParallelSampler, seed=1024),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp4.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp4.py
@@ -96,13 +96,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp4.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_full_pgbooks_400iters_sp4.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 from datasets import load_dataset
+from mmengine.dataset import DefaultSampler
 from mmengine.hooks import (CheckpointHook, DistSamplerSeedHook, IterTimerHook,
                             LoggerHook, ParamSchedulerHook)
 from mmengine.optim import AmpOptimWrapper, CosineAnnealingLR, LinearLR
@@ -22,7 +23,6 @@ from xtuner.utils import PROMPT_TEMPLATE
 # Model
 pretrained_model_name_or_path = 'meta-llama/Llama-2-7b-hf'
 use_varlen_attn = False
-sequence_parallel_size = 4
 
 # Data
 data_path = 'emozilla/pg_books-tokenized-bos-eos-chunked-65536'
@@ -41,9 +41,13 @@ max_length = 65536
 max_position_embeddings = 65536
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 4
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
-accumulative_counts = 32
+accumulative_counts = 8
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -92,11 +96,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=SequenceParallelSampler, seed=1024),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_full_wizardlm_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_full_wizardlm_e1.py
@@ -91,13 +91,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_full_wizardlm_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_full_wizardlm_e1.py
@@ -15,6 +15,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -30,9 +31,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 2  # per_device
 accumulative_counts = 16  # 2bs * 16acc * 4gpu = 128 batchsize
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -86,11 +91,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_e3.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -122,11 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_e3.py
@@ -127,13 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_oasst1_e3.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -35,9 +36,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -137,11 +142,13 @@ oasst1 = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[alpaca_en, alpaca_zh, oasst1])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_enzh_oasst1_e3.py
@@ -142,13 +142,13 @@ oasst1 = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[alpaca_en, alpaca_zh, oasst1])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_zh_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_zh_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_zh = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_zh,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_zh_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_alpaca_zh_e3.py
@@ -110,13 +110,13 @@ alpaca_zh = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_zh,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_arxiv_gentitle_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -140,11 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_arxiv_gentitle_e3.py
@@ -145,13 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_colorist_e5.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_colorist_e5.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_colorist_e5.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_colorist_e5.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 5
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_lawyer_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_lawyer_e3.py
@@ -19,6 +19,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -36,9 +37,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -129,11 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_lawyer_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_lawyer_e3.py
@@ -134,13 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_medical_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_medical_e1.py
@@ -112,13 +112,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_medical_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_medical_e1.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -33,9 +34,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -107,11 +112,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e1.py
@@ -15,6 +15,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -31,9 +32,13 @@ moss_sft_no_plugins_path = './data/moss-003-sft-no-tools.jsonl'
 moss_sft_plugins_path = './data/conversations_with_tools_with_inner_instruction_no_text2image_train_all_random_meta0.5_0.1_0.01_moss_0709.jsonl'  # noqa: E501
 max_length = 2048
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -109,11 +114,13 @@ moss_sft_plugins = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[moss_sft_no_plugins, moss_sft_plugins])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e1.py
@@ -114,13 +114,13 @@ moss_sft_plugins = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[moss_sft_no_plugins, moss_sft_plugins])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e2_gpu8.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e2_gpu8.py
@@ -38,6 +38,7 @@ sequence_parallel_size = 1
 # Scheduler & Optimizer
 batch_size = 8  # per_device
 accumulative_counts = 1
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 2
 max_epochs = 2
 optim_type = AdamW

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e2_gpu8.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e2_gpu8.py
@@ -114,13 +114,13 @@ moss_sft_plugins = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[moss_sft_no_plugins, moss_sft_plugins])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e2_gpu8.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_all_e2_gpu8.py
@@ -15,6 +15,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -30,6 +31,9 @@ use_varlen_attn = False
 moss_sft_no_plugins_path = './data/moss-003-sft-no-tools.jsonl'
 moss_sft_plugins_path = './data/conversations_with_tools_with_inner_instruction_no_text2image_train_all_random_meta0.5_0.1_0.01_moss_0709.jsonl'  # noqa: E501
 max_length = 2048
+
+# parallel
+sequence_parallel_size = 1
 
 # Scheduler & Optimizer
 batch_size = 8  # per_device
@@ -109,11 +113,13 @@ moss_sft_plugins = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[moss_sft_no_plugins, moss_sft_plugins])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_plugins_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_plugins_e1.py
@@ -103,13 +103,13 @@ train_dataset = dict(
     tokenizer=tokenizer,
     max_length=max_length)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_plugins_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_moss_sft_plugins_e1.py
@@ -15,6 +15,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -30,9 +31,13 @@ use_varlen_attn = False
 moss_sft_plugins_path = './data/conversations_with_tools_with_inner_instruction_no_text2image_train_all_random_meta0.5_0.1_0.01_moss_0709.jsonl'  # noqa: E501
 max_length = 2048
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -98,11 +103,13 @@ train_dataset = dict(
     tokenizer=tokenizer,
     max_length=max_length)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_msagent_react_e3_gpu8.py
@@ -40,6 +40,7 @@ sequence_parallel_size = 1
 # Scheduler & Optimizer
 batch_size = 8  # per_device
 accumulative_counts = 1
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 2
 max_epochs = 3
 optim_type = AdamW

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_msagent_react_e3_gpu8.py
@@ -128,13 +128,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_msagent_react_e3_gpu8.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_msagent_react_e3_gpu8.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,6 +33,9 @@ data_path = 'damo/MSAgent-Bench'
 prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = False
+
+# parallel
+sequence_parallel_size = 1
 
 # Scheduler & Optimizer
 batch_size = 8  # per_device
@@ -123,11 +127,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_512_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 512
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_512_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_open_platypus_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_open_platypus_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_open_platypus_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_open_platypus_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_openorca_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_openorca_e1.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_openorca_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_openorca_e1.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_sql_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_sql_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_sql_e3.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_sql_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_tiny_codes_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_tiny_codes_e1.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_tiny_codes_e1.py
+++ b/xtuner/configs/llama/llama2_7b/llama2_7b_qlora_tiny_codes_e1.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_e3.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -122,11 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_e3.py
@@ -127,13 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_oasst1_e3.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -35,9 +36,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -137,11 +142,13 @@ oasst1 = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[alpaca_en, alpaca_zh, oasst1])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_enzh_oasst1_e3.py
@@ -142,13 +142,13 @@ oasst1 = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[alpaca_en, alpaca_zh, oasst1])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_zh_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_zh_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_zh = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_zh,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_zh_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_alpaca_zh_e3.py
@@ -110,13 +110,13 @@ alpaca_zh = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_zh,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_arxiv_gentitle_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -140,11 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_arxiv_gentitle_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_arxiv_gentitle_e3.py
@@ -145,13 +145,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_code_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_code_alpaca_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_code_alpaca_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_colorist_e5.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_colorist_e5.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_colorist_e5.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_colorist_e5.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 5
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_lawyer_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_lawyer_e3.py
@@ -19,6 +19,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -36,9 +37,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -129,11 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_lawyer_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_lawyer_e3.py
@@ -134,13 +134,13 @@ law_reference_data = dict(
 train_dataset = dict(
     type=ConcatDataset, datasets=[crime_kg_assitant, law_reference_data])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_medical_e1.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_medical_e1.py
@@ -112,13 +112,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_medical_e1.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_medical_e1.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -33,9 +34,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -107,11 +112,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_512_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 512
 pack_to_max_length = False
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_512_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_512_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_oasst1_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_open_platypus_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_open_platypus_e3.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_open_platypus_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_open_platypus_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_openorca_e1.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_openorca_e1.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -105,11 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_openorca_e1.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_openorca_e1.py
@@ -110,13 +110,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_sql_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_sql_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_sql_e3.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_sql_e3.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_tiny_codes_e1.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_tiny_codes_e1.py
@@ -114,13 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_tiny_codes_e1.py
+++ b/xtuner/configs/llama/llama2_7b_chat/llama2_7b_chat_qlora_tiny_codes_e1.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.llama2_chat
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 1
 optim_type = AdamW
@@ -109,11 +114,13 @@ train_dataset = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/yi/yi_34b/yi_34b_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/yi/yi_34b/yi_34b_qlora_alpaca_enzh_e3.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -122,11 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/yi/yi_34b/yi_34b_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/yi/yi_34b/yi_34b_qlora_alpaca_enzh_e3.py
@@ -127,13 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/yi/yi_6b/yi_6b_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/yi/yi_6b/yi_6b_qlora_alpaca_enzh_e3.py
@@ -18,6 +18,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -34,9 +35,13 @@ prompt_template = PROMPT_TEMPLATE.default
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -122,11 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/yi/yi_6b/yi_6b_qlora_alpaca_enzh_e3.py
+++ b/xtuner/configs/yi/yi_6b/yi_6b_qlora_alpaca_enzh_e3.py
@@ -127,13 +127,13 @@ alpaca_zh = dict(
 
 train_dataset = dict(type=ConcatDataset, datasets=[alpaca_en, alpaca_zh])
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=train_dataset,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/zephyr/zephyr_7b_beta_qlora_alpaca_e3.py
+++ b/xtuner/configs/zephyr/zephyr_7b_beta_qlora_alpaca_e3.py
@@ -17,6 +17,7 @@ from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model import SupervisedFinetune
+from xtuner.parallel.sequence import SequenceParallelSampler
 from xtuner.utils import PROMPT_TEMPLATE, SYSTEM_TEMPLATE
 
 #######################################################################
@@ -32,9 +33,13 @@ prompt_template = PROMPT_TEMPLATE.zephyr
 max_length = 2048
 pack_to_max_length = True
 
+# parallel
+sequence_parallel_size = 1
+
 # Scheduler & Optimizer
 batch_size = 1  # per_device
 accumulative_counts = 16
+accumulative_counts *= sequence_parallel_size
 dataloader_num_workers = 0
 max_epochs = 3
 optim_type = AdamW
@@ -105,11 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
+sampler = dict(type=SequenceParallelSampler) \
+    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=dict(type=DefaultSampler, shuffle=True),
+    sampler=sampler,
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################

--- a/xtuner/configs/zephyr/zephyr_7b_beta_qlora_alpaca_e3.py
+++ b/xtuner/configs/zephyr/zephyr_7b_beta_qlora_alpaca_e3.py
@@ -110,13 +110,13 @@ alpaca_en = dict(
     pack_to_max_length=pack_to_max_length,
     use_varlen_attn=use_varlen_attn)
 
-sampler = dict(type=SequenceParallelSampler) \
-    if sequence_parallel_size > 1 else dict(type=DefaultSampler)
+sampler = SequenceParallelSampler \
+    if sequence_parallel_size > 1 else DefaultSampler
 train_dataloader = dict(
     batch_size=batch_size,
     num_workers=dataloader_num_workers,
     dataset=alpaca_en,
-    sampler=sampler,
+    sampler=dict(type=sampler, shuffle=True),
     collate_fn=dict(type=default_collate_fn, use_varlen_attn=use_varlen_attn))
 
 #######################################################################


### PR DESCRIPTION
Modified configs: deepseek, llama2, internlm2, yi and zephyr.

1. Add `sequence_parallel_size` to configs
2. accumulative_counts = accumulative_counts * sequence_parallel_size. Suppose I aim to employ a training strategy using a batch size per device of 1 with a maximum length of `max_length` on N GPUs. Upon setting the sequence parallelism dimension to `SP`, the accumulative counts have to be adjusted to `SP` times the original value. This modification is essential to assure training equivalence, as the sequence of `max_length` length will be segmented into `SP` parts, with each part being allocated to its respective GPU among the `SP` GPUs for parallelized training.
3. If `sequence_parallel_size` is greater than 1, use SequenceParallelSampler, otherwise use DefaultSampler.