### PR TITLE
[Fix] Enhance `split_list` to support `value` at the beginning

### DIFF
--- a/xtuner/engine/hooks/dataset_info_hook.py
+++ b/xtuner/engine/hooks/dataset_info_hook.py
@@ -9,7 +9,7 @@ def split_list(lst, value):
     res = []
     tmp_res = []
     for i in lst:
-        if tmp_res and i == value:
+        if i == value:
             res.append(tmp_res)
             tmp_res = []
         else:


### PR DESCRIPTION
Before:
`split_list([-200, 123, 123], -200)` returns `[[-200, 123, 123]]`

After:
`split_list([-200, 123, 123], -200)` returns `[[], [123, 123]]`
