### PR TITLE
[Feature] Support load_json_file with json.load

### DIFF
--- a/xtuner/dataset/__init__.py
+++ b/xtuner/dataset/__init__.py
@@ -6,6 +6,7 @@ from .huggingface import process_hf_dataset
 from .intern_repo import (build_packed_dataset,
                           load_intern_repo_tokenized_dataset,
                           load_intern_repo_untokenized_dataset)
+from .json_dataset import load_json_file
 from .llava import LLaVADataset
 from .modelscope import process_ms_dataset
 from .moss_sft import MOSSSFTDataset
@@ -17,19 +18,11 @@ from .utils import decode_base64_to_image, expand2square, load_image
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 __all__ = [
-    'process_hf_dataset',
-    'ConcatDataset',
-    'MOSSSFTDataset',
-    'process_ms_dataset',
-    'LLaVADataset',
-    'expand2square',
-    'decode_base64_to_image',
-    'load_image',
-    'process_ms_dataset',
+    'process_hf_dataset', 'ConcatDataset', 'MOSSSFTDataset',
+    'process_ms_dataset', 'LLaVADataset', 'expand2square',
+    'decode_base64_to_image', 'load_image', 'process_ms_dataset',
     'load_intern_repo_tokenized_dataset',
-    'load_intern_repo_untokenized_dataset',
-    'build_packed_dataset',
-    'RefCOCOJsonDataset',
-    'RefCOCOJsonEvalDataset',
-    'InvRefCOCOJsonDataset',
+    'load_intern_repo_untokenized_dataset', 'build_packed_dataset',
+    'RefCOCOJsonDataset', 'RefCOCOJsonEvalDataset', 'InvRefCOCOJsonDataset',
+    'load_json_file'
 ]

--- a/xtuner/dataset/json_dataset.py
+++ b/xtuner/dataset/json_dataset.py
@@ -1,0 +1,24 @@
+import json
+import os
+
+from datasets import Dataset, concatenate_datasets
+
+
+def load_json_file(data_files=None, data_dir=None, suffix=None):
+    assert (data_files is not None) != (data_dir is not None)
+    if data_dir is not None:
+        data_files = os.listdir(data_dir)
+        data_files = [os.path.join(data_dir, fn) for fn in data_files]
+        if suffix is not None:
+            data_files = [fp for fp in data_files if fp.endswith(suffix)]
+    elif isinstance(data_files, str):
+        data_files = [data_files]
+
+    dataset_list = []
+    for fp in data_files:
+        with open(fp, encoding='utf-8') as file:
+            data = json.load(file)
+        ds = Dataset.from_list(data)
+        dataset_list.append(ds)
+    dataset = concatenate_datasets(dataset_list)
+    return dataset


### PR DESCRIPTION
# Usage

```python
from mmengine.config import ConfigDict
from xtuner.registry import BUILDER
from xtuner.dataset.huggingface import load_json_file

# Case 1 : load one json file
cfg = ConfigDict(type=load_json_file, data_files='/path/to/your/json.json')
ds = BUILDER.build(cfg)

# Case 2 : load several json files
cfg = ConfigDict(type=load_json_file, data_files=['/path/to/your/json1.json', 
                                                  '/path/to/your/json2.json'])
ds = BUILDER.build(cfg)

# Case 3: load all the files in specific dir
cfg = ConfigDict(type=load_json_file, data_dir='/path/to/your/dir')
ds = BUILDER.build(cfg)

# Case 4: load all the files in specific dir whose suffix is `specific_suffix`
cfg = ConfigDict(type=load_json_file, data_dir='/path/to/your/dir', suffix='.json.cot')
ds = BUILDER.build(cfg)
```