### PR TITLE
[Feature] add HFCheckpointHook to auto save hf model after the whole training phase

### DIFF
--- a/xtuner/engine/hooks/__init__.py
+++ b/xtuner/engine/hooks/__init__.py
@@ -1,10 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .dataset_info_hook import DatasetInfoHook
 from .evaluate_chat_hook import EvaluateChatHook
+from .hf_checkpoint_hook import HFCheckpointHook
 from .throughput_hook import ThroughputHook
 from .varlen_attn_args_to_messagehub_hook import VarlenAttnArgsToMessageHubHook
 
 __all__ = [
     'EvaluateChatHook', 'DatasetInfoHook', 'ThroughputHook',
-    'VarlenAttnArgsToMessageHubHook'
+    'VarlenAttnArgsToMessageHubHook', 'HFCheckpointHook'
 ]

--- a/xtuner/engine/hooks/hf_checkpoint_hook.py
+++ b/xtuner/engine/hooks/hf_checkpoint_hook.py
@@ -1,0 +1,59 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
+from pathlib import Path
+from typing import Optional, Union
+
+import torch.distributed as dist
+from mmengine.hooks import Hook
+from mmengine.model import is_model_wrapper
+
+DATA_BATCH = Optional[Union[dict, tuple, list]]
+
+
+class HFCheckpointHook(Hook):
+
+    priority = 95  # lower than CheckpointHook in MMEngine
+
+    def __init__(self, out_dir: Optional[Union[str, Path]] = None) -> None:
+        self.out_dir = out_dir
+
+    @staticmethod
+    def _get_deepspeed_z3_state_dict(model):
+        import deepspeed
+
+        def get_state_dict(module, state_dict, prefix=''):
+            for name, param in module.named_parameters(
+                    prefix=prefix[:-1], recurse=False):
+                gather_param = None
+                with deepspeed.zero.GatheredParameters(param, modifier_rank=0):
+                    if dist.get_rank() == 0:
+                        gather_param = param.to(device='cpu')
+                    else:
+                        gather_param = param.to(device='meta')
+                state_dict[name] = gather_param
+            for name, buffer in module.named_buffers(
+                    prefix=prefix[:-1], recurse=False):
+                if dist.get_rank() == 0:
+                    buffer = buffer.to(device='cpu')
+                else:
+                    buffer = buffer.to(device='meta')
+                state_dict[name] = buffer
+
+            for name, child in module._modules.items():
+                if child is not None:
+                    get_state_dict(child, state_dict, prefix + name + '.')
+
+        state_dict = {}
+        get_state_dict(model, state_dict)
+        return state_dict
+
+    def after_run(self, runner) -> None:
+        if self.out_dir is None:
+            self.out_dir = osp.join(runner.work_dir, 'hf_model')
+        model = runner.model
+        if is_model_wrapper(model):
+            model = model.module
+        llm = model.llm
+        state_dict = self._get_deepspeed_z3_state_dict(llm)
+        if dist.get_rank() == 0:
+            llm.save_pretrained(self.out_dir, state_dict=state_dict)

--- a/xtuner/engine/hooks/hf_checkpoint_hook.py
+++ b/xtuner/engine/hooks/hf_checkpoint_hook.py
@@ -61,8 +61,9 @@ class HFCheckpointHook(Hook):
 
         wrapped_model = runner.strategy.model
         if wrapped_model.zero_optimization_partition_weights():
-            assert wrapped_model.zero_gather_16bit_weights_on_model_save(
-            ), 'Please set `gather_16bit_weights_on_model_save=True` in your DeepSpeed config.'
+            assert wrapped_model.zero_gather_16bit_weights_on_model_save(), \
+                ('Please set `gather_16bit_weights_on_model_save=True` '
+                 'in your DeepSpeed config.')
             state_dict = wrapped_model._zero3_consolidated_16bit_state_dict()
         else:
             state_dict = wrapped_model.module_state_dict(

--- a/xtuner/engine/hooks/hf_checkpoint_hook.py
+++ b/xtuner/engine/hooks/hf_checkpoint_hook.py
@@ -44,7 +44,7 @@ class HFCheckpointHook(Hook):
         if is_model_wrapper(model):
             model = model.module
         llm = model.llm
-        if dist.get_rank() == 0:
+        if (not dist.is_initialized()) or dist.get_rank() == 0:
             # keys in state_dict are prefixed with 'llm.'
             keys = list(state_dict.keys())
             for k in keys:

--- a/xtuner/engine/hooks/hf_checkpoint_hook.py
+++ b/xtuner/engine/hooks/hf_checkpoint_hook.py
@@ -19,36 +19,6 @@ class HFCheckpointHook(Hook):
     def __init__(self, out_dir: Optional[Union[str, Path]] = None) -> None:
         self.out_dir = out_dir
 
-    @staticmethod
-    def _get_deepspeed_z3_state_dict(model):
-        import deepspeed
-
-        def get_state_dict(module, state_dict, prefix=''):
-            for name, param in module.named_parameters(
-                    prefix=prefix[:-1], recurse=False):
-                gather_param = None
-                with deepspeed.zero.GatheredParameters(param, modifier_rank=0):
-                    if dist.get_rank() == 0:
-                        gather_param = param.to(device='cpu')
-                    else:
-                        gather_param = param.to(device='meta')
-                state_dict[name] = gather_param
-            for name, buffer in module.named_buffers(
-                    prefix=prefix[:-1], recurse=False):
-                if dist.get_rank() == 0:
-                    buffer = buffer.to(device='cpu')
-                else:
-                    buffer = buffer.to(device='meta')
-                state_dict[name] = buffer
-
-            for name, child in module._modules.items():
-                if child is not None:
-                    get_state_dict(child, state_dict, prefix + name + '.')
-
-        state_dict = {}
-        get_state_dict(model, state_dict)
-        return state_dict
-
     def after_run(self, runner) -> None:
         assert isinstance(runner,
                           FlexibleRunner), 'Runner should be `FlexibleRunner`'

--- a/xtuner/engine/hooks/hf_checkpoint_hook.py
+++ b/xtuner/engine/hooks/hf_checkpoint_hook.py
@@ -45,4 +45,9 @@ class HFCheckpointHook(Hook):
             model = model.module
         llm = model.llm
         if dist.get_rank() == 0:
+            # keys in state_dict are prefixed with 'llm.'
+            keys = list(state_dict.keys())
+            for k in keys:
+                val = state_dict.pop(k)
+                state_dict[k[4:]] = val
             llm.save_pretrained(self.out_dir, state_dict=state_dict)


### PR DESCRIPTION
# Usage

```diff
custom_hooks = [
+    dict(type=HFCheckpointHook),
]
```

The HF model will be saved at `work_dir/timestamp/hf_model`

# Notes

1. As the priority of `HFCheckpointHook` is 95 which is lower than `CheckpointHook` in MMEngine, the hf model is saved only after the normal checkpoint saving process is complete. So feel free to use it.