### PR TITLE
Remove test info in DatasetInfoHook

### DIFF
--- a/xtuner/engine/hooks/dataset_info_hook.py
+++ b/xtuner/engine/hooks/dataset_info_hook.py
@@ -42,16 +42,12 @@ class DatasetInfoHook(Hook):
     def before_train(self, runner) -> None:
         do_train = runner.train_loop is not None
         do_eval = runner.val_loop is not None
-        do_test = runner.test_loop is not None
         if do_train:
             train_dataset = runner.train_dataloader.dataset
             self.log(runner, train_dataset, mode='train')
         if do_eval:
             eval_dataset = runner.val_dataloader.dataset
             self.log(runner, eval_dataset, mode='eval')
-        if do_test:
-            test_dataset = runner.test_dataloader.dataset
-            self.log(runner, test_dataset, mode='test')
 
     def before_val(self, runner) -> None:
         eval_dataset = runner.val_dataloader.dataset


### PR DESCRIPTION
During the training process, if the test loop is configured in the user settings, it will trigger the construction of the test dataset, which is unexpected.
