### PR TITLE
[fix] fix save eval result failed with mutil-node pretrain

### DIFF
--- a/xtuner/engine/hooks/evaluate_chat_hook.py
+++ b/xtuner/engine/hooks/evaluate_chat_hook.py
@@ -3,6 +3,8 @@ import os
 import warnings
 
 import torch
+from mmengine.dist import master_only
+from mmengine.utils import mkdir_or_exist
 from mmengine.hooks import Hook
 from mmengine.model import is_model_wrapper
 from mmengine.utils.misc import get_object_from_string
@@ -92,9 +94,11 @@ class EvaluateChatHook(Hook):
 
         self.is_first_run = True
 
+    @master_only
     def _save_eval_output(self, runner, eval_outputs):
         save_path = os.path.join(runner.log_dir, 'vis_data',
                                  f'eval_outputs_iter_{runner.iter}.txt')
+        mkdir_or_exist(os.path.dirname(save_path))
         with open(save_path, 'w', encoding='utf-8') as f:
             for i, output in enumerate(eval_outputs):
                 f.write(f'Eval output {i + 1}:\n{output}\n\n')


### PR DESCRIPTION
在运行 4 节点 32卡的 LLaVA-InternLM2-20B 的预训练时，每次到eval阶段除master节点之外都会报错 FileNotExist，经过阅读 xtuner 和 mmengine 的代码后定位到问题：

mmengine在多节点训练时，默认只在master节点保存log/vis_data等信息，这会导致worker节点的没有 vis_data 这个文件夹，但是 xtuner 在保存eval结果的时候是每个节点都保存一份，而且在打开文件的时候没有做父文件夹是否存在的验证，因此导致了除master节点外都因为文件夹不存在而挂掉。。。

修复方式也很简单：保证只在master节点存储结果（利用mmengine提供的 `master_only` 装饰器），每次保存前利用mmengine提供的接口 `mkdir_or_exist` 进行文件夹存在性检查。