### PR TITLE
[Improve] Support the export of various LLaVA formats with `pth_to_hf`

### DIFF
--- a/xtuner/configs/llava/llama3_8b_instruct_clip_vit_large_p14_336/README.md
+++ b/xtuner/configs/llava/llama3_8b_instruct_clip_vit_large_p14_336/README.md
@@ -285,11 +285,11 @@ xtuner train llava_llama3_8b_instruct_quant_clip_vit_large_p14_336_e1_gpu1_pretr
 xtuner train llava_llama3_8b_instruct_qlora_clip_vit_large_p14_336_e1_gpu1_finetune --deepspeed deepspeed_zero2 --seed 1024
 ```
 
-## Model Conversion (and Merge)
+## Model Conversion
 
-### Step 0. Convert `.pth` file to LLaVA model in xtuner format ([xtuner/llava-llama-3-8b-v1_1](https://huggingface.co/xtuner/llava-llama-3-8b-v1_1))
+After training, we will obtain a set of weights (*i.e.*, `iter_xxx.pth`), which are not in the universal HuggingFace format. We first need to convert them to the LLaVA model.
 
-After training, we will obtain a set of weights (*i.e.*, `iter_xxx.pth`), which are not in the universal HuggingFace format. We first need to convert them to the LLaVA model in xtuner format.
+### Convert `.pth` file to LLaVA model in xtuner format ([xtuner/llava-llama-3-8b-v1_1](https://huggingface.co/xtuner/llava-llama-3-8b-v1_1))
 
 ```bash
 xtuner convert pth_to_hf $FINETUNE_CFG $PTH_PATH $SAVE_PATH
@@ -328,7 +328,7 @@ It includes the full-finetuned LLM weights, projector weights, and LoRA weights 
     └── README.md
 ```
 
-At this time, the LLaVA model of xtuner-format can engage in conversation using xtuner chat, by
+LLaVA model in xtuner format can engage in conversation using xtuner chat, by
 
 ```bash
 xtuner chat ./iter_39620_xtuner \
@@ -359,31 +359,17 @@ wget https://opencompass.openxlab.space/utils/VLMEval/MMBench_TEST_CN.tsv
 wget https://opencompass.openxlab.space/utils/VLMEval/CCBench.tsv
 ```
 
-### Step 1. Merge ViT LoRA into the original ViT
-
-Because LoRA fine-tuning is applied to ViT during the fine-tuning, it is necessary to first merge LoRA into ViT.
+### Convert `.pth` file to LLaVA model in official format ([xtuner/llava-llama-3-8b-v1_1-hf](https://huggingface.co/xtuner/llava-llama-3-8b-v1_1-hf))
 
 ```bash
-xtuner convert merge openai/clip-vit-large-patch14-336 ./iter_39620_xtuner/visual_encoder_adapter ./iter_39620_visual_encoder --is-clip
+xtuner convert pth_to_hf $FINETUNE_CFG $PTH_PATH $SAVE_PATH --save-format official
+# e.g., xtuner convert pth_to_hf llava_llama3_8b_instruct_full_clip_vit_large_p14_336_lora_e1_gpu8_internvl_finetune ./iter_39620.pth ./iter_39620_official --save-format official
 ```
 
-### Step 2. Convert LLaVA in xtuner format to official LLaVA format or HuggingFace LLaVA format
-
-- The official LLaVA format is structured similarly to the architecture of the [liuhaotian/llava-v1.5-7b](https://huggingface.co/liuhaotian/llava-v1.5-7b) model.
-- The HuggingFace LLaVA format is structured similarly to the architecture of the [llava-hf/llava-1.5-7b-hf](https://huggingface.co/llava-hf/llava-1.5-7b-hf) model.
-
-#### To official LLaVA format ([xtuner/llava-llama-3-8b-v1_1-hf](https://huggingface.co/xtuner/llava-llama-3-8b-v1_1-hf))
-
-We can utilize the following command to obtain the LLaVA model in the official LLaVA format.
-
-```bash
-python ./convert_xtuner_weights_to_llava.py --text_model_id ./iter_39620_xtuner --vision_model_id ./iter_39620_visual_encoder --projector_weight ./iter_39620_xtuner/projector/model.safetensors --save_path ./iter_39620_llava
-```
-
-Here, the converted LLaVA model in official LLaVA format is saved to `./iter_39620_llava`.
+Here, the converted LLaVA model in official LLaVA format is saved to `./iter_39620_official`.
 
 ```
-./iter_39620_llava
+./iter_39620_official
 ├── config.json
 ├── generation_config.json
 ├── model-00001-of-00009.safetensors
@@ -402,18 +388,17 @@ Here, the converted LLaVA model in official LLaVA format is saved to `./iter_396
 └── tokenizer.json
 ```
 
-#### To HuggingFace LLaVA format ([xtuner/llava-llama-3-8b-v1_1-transformers](https://huggingface.co/xtuner/llava-llama-3-8b-v1_1-transformers))
-
-We can utilize the following command to obtain the LLaVA model in the HuggingFace LLaVA format.
+### Convert `.pth` file to LLaVA model in HuggingFace format ([xtuner/llava-llama-3-8b-v1_1-transformers](https://huggingface.co/xtuner/llava-llama-3-8b-v1_1-transformers))
 
 ```bash
-python ./convert_xtuner_weights_to_hf.py --text_model_id ./iter_39620_xtuner --vision_model_id ./iter_39620_visual_encoder --projector_weight ./iter_39620_xtuner/projector/model.safetensors --save_path ./iter_39620_hf
+xtuner convert pth_to_hf $FINETUNE_CFG $PTH_PATH $SAVE_PATH --save-format huggingface
+# e.g., xtuner convert pth_to_hf llava_llama3_8b_instruct_full_clip_vit_large_p14_336_lora_e1_gpu8_internvl_finetune ./iter_39620.pth ./iter_39620_huggingface --save-format huggingface
 ```
 
-Here, the converted LLaVA model in HuggingFace LLaVA format is saved to `./iter_39620_hf`.
+Here, the converted LLaVA model in HuggingFace LLaVA format is saved to `./iter_39620_huggingface`.
 
 ```
-./iter_39620_hf
+./iter_39620_huggingface
 ├── config.json
 ├── generation_config.json
 ├── model-00001-of-00004.safetensors

--- a/xtuner/model/sft.py
+++ b/xtuner/model/sft.py
@@ -303,3 +303,23 @@ class SupervisedFinetune(BaseModel):
             return super().__getattr__(name)
         except AttributeError:
             return getattr(self.llm, name)
+
+    def to_hf(self,
+              cfg,
+              save_dir,
+              fp32=False,
+              save_pretrained_kwargs={},
+              **kwargs):
+        self.llm.config.use_cache = True
+        if not fp32:
+            print_log('Convert LLM to float16', 'current')
+            self.llm.half()
+        if self.use_lora:
+            print_log(f'Saving adapter to {save_dir}', 'current')
+        else:
+            print_log(f'Saving LLM tokenizer to {save_dir}', 'current')
+            tokenizer = BUILDER.build(cfg.tokenizer)
+            tokenizer.save_pretrained(save_dir)
+            print_log(f'Saving LLM to {save_dir}', 'current')
+        self.llm.save_pretrained(save_dir, **save_pretrained_kwargs)
+        self.llm.config.use_cache = False

--- a/xtuner/tools/model_converters/pth_to_hf.py
+++ b/xtuner/tools/model_converters/pth_to_hf.py
@@ -4,11 +4,12 @@ import os.path as osp
 import shutil
 import warnings
 
-import torch
 from accelerate import init_empty_weights
 from accelerate.utils import set_module_tensor_to_device
+from mmengine import print_log
 from mmengine.config import Config, DictAction
 from mmengine.fileio import PetrelBackend, get_file_backend
+from mmengine.utils import mkdir_or_exist
 from tqdm import tqdm
 
 from xtuner.configs import cfgs_name_path
@@ -37,6 +38,11 @@ def parse_args():
         '--safe-serialization',
         action='store_true',
         help='Indicate if using `safe_serialization`')
+    parser.add_argument(
+        '--save-format',
+        default='xtuner',
+        choices=('xtuner', 'official', 'huggingface'),
+        help='Only applicable for LLaVAModel. Indicate the save format.')
     parser.add_argument(
         '--cfg-options',
         nargs='+',
@@ -68,24 +74,31 @@ def main():
 
     model_name = cfg.model.type if isinstance(cfg.model.type,
                                               str) else cfg.model.type.__name__
+    use_meta_init = True
+
     if 'LLaVAModel' in model_name:
         cfg.model.pretrained_pth = None
+        if args.save_format != 'xtuner':
+            use_meta_init = False
 
-    try:
-        # Initializing the model with meta-tensor can reduce unwanted memory
-        # usage.
-        with init_empty_weights():
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    'ignore', message='.*non-meta.*', category=UserWarning)
+    if use_meta_init:
+        try:
+            # Initializing the model with meta-tensor can reduce unwanted
+            # memory usage.
+            with init_empty_weights():
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        'ignore', message='.*non-meta.*', category=UserWarning)
+                    model = BUILDER.build(cfg.model)
+        except NotImplementedError as e:
+            # Cannot initialize the model with meta tensor if the model is
+            # quantized.
+            if 'Cannot copy out of meta tensor' in str(e):
                 model = BUILDER.build(cfg.model)
-    except NotImplementedError as e:
-        # Cannot initialize the model with meta tensor if there is lora
-        # in the model.
-        if 'Cannot copy out of meta tensor' in str(e):
-            model = BUILDER.build(cfg.model)
-        else:
-            raise e
+            else:
+                raise e
+    else:
+        model = BUILDER.build(cfg.model)
 
     backend = get_file_backend(args.pth_model)
     if isinstance(backend, PetrelBackend):
@@ -96,72 +109,27 @@ def main():
         state_dict = guess_load_checkpoint(args.pth_model)
 
     for name, param in tqdm(state_dict.items(), desc='Load State Dict'):
-        set_module_tensor_to_device(model, name, 'cpu', param, torch.float16)
+        set_module_tensor_to_device(model, name, 'cpu', param)
 
     model.llm.config.use_cache = True
 
-    print(f'Load PTH model from {args.pth_model}')
+    print_log(f'Load PTH model from {args.pth_model}', 'current')
 
-    if 'LLaVAModel' in model_name:
-        if cfg.model.get('llm') and (not cfg.model.get('freeze_llm', False)
-                                     or cfg.model.get('llm_lora')):
-            if 'PeftModel' in model.llm.__class__.__name__:
-                llm_path = osp.join(args.save_dir, 'llm_adapter')
-                print(f'Saving LLM adapter to {llm_path}')
-            else:
-                llm_path = args.save_dir
-                print(f'Saving LLM tokenizer to {llm_path}')
-                tokenizer = BUILDER.build(cfg.tokenizer)
-                tokenizer.save_pretrained(llm_path)
-                print(f'Saving LLM to {llm_path}')
-            if not args.fp32:
-                print('Convert LLM to float16')
-                model.llm.half()
-            model.llm.save_pretrained(
-                llm_path, max_shard_size=args.max_shard_size)
+    mkdir_or_exist(args.save_dir)
 
-        if cfg.model.get('visual_encoder') and (
-                not cfg.model.get('freeze_visual_encoder', False)
-                or cfg.model.get('visual_encoder_lora')):
-            if 'PeftModel' in model.visual_encoder.__class__.__name__:
-                visual_encoder_path = osp.join(args.save_dir,
-                                               'visual_encoder_adapter')
-                print(
-                    f'Saving visual_encoder adapter to {visual_encoder_path}')
-            else:
-                visual_encoder_path = osp.join(args.save_dir, 'visual_encoder')
-                print('Saving visual_encoder image_processor to'
-                      f'{visual_encoder_path}')
-                image_processor = BUILDER.build(cfg.image_processor)
-                image_processor.save_pretrained(visual_encoder_path)
-                print(f'Saving visual_encoder to {visual_encoder_path}')
-            model.visual_encoder.save_pretrained(
-                visual_encoder_path, max_shard_size=args.max_shard_size)
-
-        if hasattr(model, 'projector'):
-            projector_path = osp.join(args.save_dir, 'projector')
-            print(f'Saving projector to {projector_path}')
-            model.projector.save_pretrained(
-                projector_path, max_shard_size=args.max_shard_size)
-    else:
-        llm_path = args.save_dir
-        if 'PeftModel' in model.llm.__class__.__name__:
-            print(f'Saving adapter to {llm_path}')
-        else:
-            print(f'Saving LLM tokenizer to {llm_path}')
-            tokenizer = BUILDER.build(cfg.tokenizer)
-            tokenizer.save_pretrained(llm_path)
-            print(f'Saving LLM to {llm_path}')
-        if not args.fp32:
-            print('Convert LLM to float16')
-            model.llm.half()
-        model.llm.save_pretrained(
-            llm_path,
-            max_shard_size=args.max_shard_size,
-            safe_serialization=args.safe_serialization)
+    save_pretrained_kwargs = {
+        'max_shard_size': args.max_shard_size,
+        'safe_serialization': args.safe_serialization
+    }
+    model.to_hf(
+        cfg=cfg,
+        save_dir=args.save_dir,
+        fp32=args.fp32,
+        save_pretrained_kwargs=save_pretrained_kwargs,
+        save_format=args.save_format)
 
     shutil.copyfile(args.config, osp.join(args.save_dir, 'xtuner_config.py'))
-    print('All done!')
+    print_log('All done!', 'current')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
xtuner pth_to_hf $CONFIG $PTH $SAVE_PATH --save-format [xtuner, official, huggingface]
```

More details can be found on https://github.com/LZHgrla/xtuner/blob/a1a0ce8f7f47d1e1079d9bc17876980225dbb4df/xtuner/configs/llava/llama3_8b_instruct_clip_vit_large_p14_336/README.md#model-conversion
