### PR TITLE
[Feature] Support the DatasetInfoHook of DPO training

### DIFF
--- a/xtuner/configs/dpo/internlm/internlm2_chat_1_8b_dpo_full.py
+++ b/xtuner/configs/dpo/internlm/internlm2_chat_1_8b_dpo_full.py
@@ -11,7 +11,7 @@ from xtuner.dataset.collate_fns.preference_collate_fn import \
     preference_collate_fn
 from xtuner.dataset.preference_dataset import (build_preference_dataset,
                                                orpo_dpo_mix_40k_map_fn)
-from xtuner.engine.hooks import (EvaluateChatHook,
+from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model.dpo import DPO
@@ -141,7 +141,7 @@ train_cfg = dict(type=TrainLoop, max_epochs=max_epochs)
 #######################################################################
 # Log the dialogue periodically during the training process, optional
 custom_hooks = [
-    # dict(type=DatasetInfoHook, tokenizer=tokenizer),
+    dict(type=DatasetInfoHook, tokenizer=tokenizer),
     dict(
         type=EvaluateChatHook,
         tokenizer=tokenizer,

--- a/xtuner/configs/dpo/internlm/internlm2_chat_1_8b_dpo_full_varlenattn.py
+++ b/xtuner/configs/dpo/internlm/internlm2_chat_1_8b_dpo_full_varlenattn.py
@@ -11,7 +11,7 @@ from xtuner.dataset.collate_fns.preference_collate_fn import \
     preference_collate_fn
 from xtuner.dataset.preference_dataset import (build_preference_dataset,
                                                orpo_dpo_mix_40k_map_fn)
-from xtuner.engine.hooks import (EvaluateChatHook,
+from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model.dpo import DPO
@@ -151,7 +151,7 @@ train_cfg = dict(type=TrainLoop, max_epochs=max_epochs)
 #######################################################################
 # Log the dialogue periodically during the training process, optional
 custom_hooks = [
-    # dict(type=DatasetInfoHook, tokenizer=tokenizer),
+    dict(type=DatasetInfoHook, tokenizer=tokenizer),
     dict(
         type=EvaluateChatHook,
         tokenizer=tokenizer,

--- a/xtuner/configs/dpo/internlm/internlm2_chat_1_8b_dpo_full_varlenattn_jsonl_dataset.py
+++ b/xtuner/configs/dpo/internlm/internlm2_chat_1_8b_dpo_full_varlenattn_jsonl_dataset.py
@@ -10,7 +10,7 @@ from xtuner.dataset.collate_fns.preference_collate_fn import \
     preference_collate_fn
 from xtuner.dataset.preference_dataset import (build_preference_dataset,
                                                load_jsonl_dataset)
-from xtuner.engine.hooks import (EvaluateChatHook,
+from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model.dpo import DPO
@@ -155,7 +155,7 @@ train_cfg = dict(type=TrainLoop, max_epochs=max_epochs)
 #######################################################################
 # Log the dialogue periodically during the training process, optional
 custom_hooks = [
-    # dict(type=DatasetInfoHook, tokenizer=tokenizer),
+    dict(type=DatasetInfoHook, tokenizer=tokenizer),
     dict(
         type=EvaluateChatHook,
         tokenizer=tokenizer,

--- a/xtuner/configs/dpo/internlm/internlm2_chat_7b_dpo_qlora_varlenattn.py
+++ b/xtuner/configs/dpo/internlm/internlm2_chat_7b_dpo_qlora_varlenattn.py
@@ -14,7 +14,7 @@ from xtuner.dataset.collate_fns.preference_collate_fn import \
     preference_collate_fn
 from xtuner.dataset.preference_dataset import (build_preference_dataset,
                                                orpo_dpo_mix_40k_map_fn)
-from xtuner.engine.hooks import (EvaluateChatHook,
+from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model.dpo import DPO
@@ -170,7 +170,7 @@ train_cfg = dict(type=TrainLoop, max_epochs=max_epochs)
 #######################################################################
 # Log the dialogue periodically during the training process, optional
 custom_hooks = [
-    # dict(type=DatasetInfoHook, tokenizer=tokenizer),
+    dict(type=DatasetInfoHook, tokenizer=tokenizer),
     dict(
         type=EvaluateChatHook,
         tokenizer=tokenizer,

--- a/xtuner/configs/dpo/llama/llama3_8b_instruct_dpo_qlora_varlenattn.py
+++ b/xtuner/configs/dpo/llama/llama3_8b_instruct_dpo_qlora_varlenattn.py
@@ -14,7 +14,7 @@ from xtuner.dataset.collate_fns.preference_collate_fn import \
     preference_collate_fn
 from xtuner.dataset.preference_dataset import (build_preference_dataset,
                                                orpo_dpo_mix_40k_map_fn)
-from xtuner.engine.hooks import (EvaluateChatHook,
+from xtuner.engine.hooks import (DatasetInfoHook, EvaluateChatHook,
                                  VarlenAttnArgsToMessageHubHook)
 from xtuner.engine.runner import TrainLoop
 from xtuner.model.dpo import DPO
@@ -170,7 +170,7 @@ train_cfg = dict(type=TrainLoop, max_epochs=max_epochs)
 #######################################################################
 # Log the dialogue periodically during the training process, optional
 custom_hooks = [
-    # dict(type=DatasetInfoHook, tokenizer=tokenizer),
+    dict(type=DatasetInfoHook, tokenizer=tokenizer),
     dict(
         type=EvaluateChatHook,
         tokenizer=tokenizer,

--- a/xtuner/engine/hooks/dataset_info_hook.py
+++ b/xtuner/engine/hooks/dataset_info_hook.py
@@ -25,7 +25,8 @@ class DatasetInfoHook(Hook):
         self.is_intern_repo_dataset = is_intern_repo_dataset
 
     def log(self, runner, dataset, mode='train'):
-        def _log(input_ids, log_prefix=""):
+
+        def _log(input_ids, log_prefix=''):
             if self.is_intern_repo_dataset:
                 input_ids = [abs(x) for x in input_ids]
             # Try to split list to be compatible with IMAGE token
@@ -40,8 +41,8 @@ class DatasetInfoHook(Hook):
         runner.logger.info(f'Num {mode} samples {len(dataset)}')
         runner.logger.info(f'{mode} example:')
         if 'chosen_ids' in dataset[0]:
-            _log(dataset[0]['chosen_ids'], log_prefix="chosen: ")
-            _log(dataset[0]['rejected_ids'], log_prefix="rejected: ")
+            _log(dataset[0]['chosen_ids'], log_prefix='chosen: ')
+            _log(dataset[0]['rejected_ids'], log_prefix='rejected: ')
         else:
             _log(dataset[0]['input_ids'])
 

--- a/xtuner/engine/hooks/dataset_info_hook.py
+++ b/xtuner/engine/hooks/dataset_info_hook.py
@@ -25,19 +25,25 @@ class DatasetInfoHook(Hook):
         self.is_intern_repo_dataset = is_intern_repo_dataset
 
     def log(self, runner, dataset, mode='train'):
+        def _log(input_ids, log_prefix=""):
+            if self.is_intern_repo_dataset:
+                input_ids = [abs(x) for x in input_ids]
+            # Try to split list to be compatible with IMAGE token
+            input_ids = split_list(input_ids, IMAGE_TOKEN_INDEX)
+            text = log_prefix
+            for idx, ids in enumerate(input_ids):
+                text += self.tokenizer.decode(ids)
+                if idx != len(input_ids) - 1:
+                    text += DEFAULT_IMAGE_TOKEN
+            runner.logger.info(text)
+
         runner.logger.info(f'Num {mode} samples {len(dataset)}')
         runner.logger.info(f'{mode} example:')
-        input_ids = dataset[0]['input_ids']
-        if self.is_intern_repo_dataset:
-            input_ids = [abs(x) for x in input_ids]
-        # Try to split list to be compatible with IMAGE token
-        input_ids = split_list(input_ids, IMAGE_TOKEN_INDEX)
-        text = ''
-        for idx, ids in enumerate(input_ids):
-            text += self.tokenizer.decode(ids)
-            if idx != len(input_ids) - 1:
-                text += DEFAULT_IMAGE_TOKEN
-        runner.logger.info(text)
+        if 'chosen_ids' in dataset[0]:
+            _log(dataset[0]['chosen_ids'], log_prefix="chosen: ")
+            _log(dataset[0]['rejected_ids'], log_prefix="rejected: ")
+        else:
+            _log(dataset[0]['input_ids'])
 
     def before_train(self, runner) -> None:
         do_train = runner.train_loop is not None


### PR DESCRIPTION
`DatasetInfoHook` gets error when dpo training.
<!--  with `use_varlen_attn=False` -->

DPO dataset get `chosen_ids` and `rejected_ids` instead of `input_ids`.

https://github.com/InternLM/xtuner/blob/8adc8d4a5d6f5a33474f85093d8bb43c24c2b32e/xtuner/engine/hooks/dataset_info_hook.py#L30

## To Reproduce

You can reproduce with any dpo training, such as [internlm2_chat_1_8b_dpo_full](https://github.com/InternLM/xtuner/blob/main/xtuner/configs/dpo/internlm/internlm2_chat_1_8b_dpo_full.py)
