### PR TITLE
[Fix] Fix OOM when qlora converting

### DIFF
--- a/xtuner/tools/model_converters/pth_to_hf.py
+++ b/xtuner/tools/model_converters/pth_to_hf.py
@@ -101,6 +101,7 @@ def main():
             else:
                 raise e
     else:
+        cfg.model.llm.device_map = 'auto'
         model = BUILDER.build(cfg.model)
 
     backend = get_file_backend(args.pth_model)


### PR DESCRIPTION
If the LLM is too big to be loaded in a single GPU, we need `device_map = 'auto'` to avoid OOM.

According to the issue #715.