### PR TITLE
Add Ascend NPU as a backend

### DIFF
--- a/xtuner/engine/_strategy/deepspeed.py
+++ b/xtuner/engine/_strategy/deepspeed.py
@@ -6,7 +6,7 @@ from mmengine._strategy import DeepSpeedStrategy as MMEngineDeepSpeedStrategy
 from xtuner import DS_CEPH_DIR
 from xtuner.parallel.sequence import init_sequence_parallel
 from xtuner.utils.fileio import patch_fileio
-
+from xtuner.utils.device import get_device
 
 class DeepSpeedStrategy(MMEngineDeepSpeedStrategy):
 
@@ -27,7 +27,7 @@ class DeepSpeedStrategy(MMEngineDeepSpeedStrategy):
         # When utilizing Zero3, the model isn't allocated to CUDA within the
         # `deepspeed.initialize` process.
         assert hasattr(wrapper.model, 'data_preprocessor')
-        wrapper.model.data_preprocessor.cuda()
+        wrapper.model.data_preprocessor.to(get_device())
         return wrapper
 
     def save_checkpoint(self, *args, **kwargs) -> None:

--- a/xtuner/engine/hooks/varlen_attn_args_to_messagehub_hook.py
+++ b/xtuner/engine/hooks/varlen_attn_args_to_messagehub_hook.py
@@ -5,6 +5,8 @@ from mmengine import MessageHub
 from mmengine.dist import get_rank
 from mmengine.hooks import Hook
 
+from xtuner.utils.device import get_device
+
 DATA_BATCH = Optional[Union[dict, tuple, list]]
 
 
@@ -22,7 +24,7 @@ class VarlenAttnArgsToMessageHubHook(Hook):
 
         cumulative_len = data.pop('cumulative_len')
         assert len(cumulative_len) == 1
-        cumulative_len = cumulative_len[0].cuda()
+        cumulative_len = cumulative_len[0].to(get_device())
         message_hub.update_info(f'cumulative_len_rank_{rank}', cumulative_len)
 
         max_seqlen = data.pop('max_seqlen')
@@ -59,7 +61,7 @@ class VarlenAttnArgsToMessageHubHook(Hook):
 
         cumulative_len = data.pop('cumulative_len')
         assert len(cumulative_len) == 1
-        cumulative_len = cumulative_len[0].cuda()
+        cumulative_len = cumulative_len[0].to(get_device())
         message_hub.update_info(f'cumulative_len_rank_{rank}', cumulative_len)
 
         max_seqlen = data.pop('max_seqlen')

--- a/xtuner/model/llava.py
+++ b/xtuner/model/llava.py
@@ -19,13 +19,13 @@ from transformers.integrations import is_deepspeed_zero3_enabled
 
 from xtuner.registry import BUILDER
 from xtuner.utils import DEFAULT_IMAGE_TOKEN
+from xtuner.utils.device import get_torch_device
 from .modules import ProjectorConfig, ProjectorModel, dispatch_modules
 from .modules.dispatch import SUPPORT_FLASH1, SUPPORT_FLASH2
 from .utils import (LoadWoInit, find_all_linear_names,
                     get_peft_model_state_dict, guess_load_checkpoint,
                     make_inputs_require_grad,
                     prepare_inputs_labels_for_multimodal, traverse_dict)
-
 
 def convert_state_dict_to_hf(state_dict, mapping):
     new_state_dict = {}
@@ -230,7 +230,7 @@ class LLaVAModel(BaseModel):
                                'Starcoder2Config', 'Phi3Config')
 
         torch_dtype = torch.bfloat16 if (
-            torch.cuda.is_available() and torch.cuda.is_bf16_supported()) \
+            get_torch_device().is_available() and get_torch_device().is_bf16_supported()) \
             else torch.float16
 
         if getattr(cfg, 'attn_implementation', None) is not None:
@@ -253,7 +253,7 @@ class LLaVAModel(BaseModel):
             return cfg
 
         torch_dtype = torch.bfloat16 if (
-            torch.cuda.is_available() and torch.cuda.is_bf16_supported()) \
+            get_torch_device().is_available() and get_torch_device().is_bf16_supported()) \
             else torch.float16
 
         cfg.torch_dtype = torch_dtype

--- a/xtuner/model/modules/dispatch/triton_kernels/rotary.py
+++ b/xtuner/model/modules/dispatch/triton_kernels/rotary.py
@@ -6,6 +6,7 @@ import torch
 import triton
 import triton.language as tl
 
+from xtuner.utils.device import get_torch_device
 
 @triton.jit
 def rotary_kernel(
@@ -231,7 +232,7 @@ def apply_rotary(
     # Need this, otherwise Triton tries to launch from cuda:0 and we get
     # ValueError: Pointer argument (at 0) cannot be accessed from Triton
     # (cpu tensor?)
-    with torch.cuda.device(x.device.index):
+    with get_torch_device().device(x.device.index):
         rotary_kernel[grid](
             output,  # data ptrs
             x,

--- a/xtuner/model/reward.py
+++ b/xtuner/model/reward.py
@@ -25,6 +25,7 @@ from xtuner.parallel.sequence import (gather_forward_split_backward,
                                       get_sequence_parallel_world_size,
                                       split_for_sequence_parallel)
 from xtuner.registry import BUILDER
+from xtuner.utils.device import get_torch_device
 from .modules import dispatch_modules
 from .modules.dispatch import SUPPORT_FLASH1, SUPPORT_FLASH2
 from .utils import (LoadWoInit, find_all_linear_names,
@@ -220,7 +221,7 @@ class RewardModel(BaseModel):
                                'Starcoder2Config', 'Phi3Config')
 
         torch_dtype = torch.bfloat16 if (
-            torch.cuda.is_available() and torch.cuda.is_bf16_supported()) \
+            get_torch_device().is_available() and get_torch_device().is_bf16_supported()) \
             else torch.float16
 
         if getattr(cfg, 'attn_implementation', None) is not None:
@@ -243,7 +244,7 @@ class RewardModel(BaseModel):
             return cfg
 
         torch_dtype = torch.bfloat16 if (
-            torch.cuda.is_available() and torch.cuda.is_bf16_supported()) \
+            get_torch_device().is_available() and get_torch_device().is_bf16_supported()) \
             else torch.float16
 
         cfg.torch_dtype = torch_dtype

--- a/xtuner/model/sft.py
+++ b/xtuner/model/sft.py
@@ -18,6 +18,7 @@ from xtuner.parallel.sequence import (get_sequence_parallel_group,
                                       reduce_sequence_parallel_loss,
                                       split_for_sequence_parallel)
 from xtuner.registry import BUILDER
+from xtuner.utils.device import get_torch_device
 from .modules import dispatch_modules
 from .modules.dispatch import SUPPORT_FLASH1, SUPPORT_FLASH2
 from .utils import (LoadWoInit, find_all_linear_names,
@@ -196,7 +197,7 @@ class SupervisedFinetune(BaseModel):
                                'DeepseekV2Config')
 
         torch_dtype = torch.bfloat16 if (
-            torch.cuda.is_available() and torch.cuda.is_bf16_supported()) \
+            get_torch_device().is_available() and get_torch_device().is_bf16_supported()) \
             else torch.float16
 
         if getattr(cfg, 'attn_implementation', None) is not None:
@@ -219,7 +220,7 @@ class SupervisedFinetune(BaseModel):
             return cfg
 
         torch_dtype = torch.bfloat16 if (
-            torch.cuda.is_available() and torch.cuda.is_bf16_supported()) \
+            get_torch_device().is_available() and get_torch_device().is_bf16_supported()) \
             else torch.float16
 
         cfg.torch_dtype = torch_dtype

--- a/xtuner/model/transformers_models/mixtral/modeling_mixtral.py
+++ b/xtuner/model/transformers_models/mixtral/modeling_mixtral.py
@@ -792,7 +792,7 @@ class MixtralSdpaAttention(MixtralAttention):
 
         # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
         # Reference: https://github.com/pytorch/pytorch/issues/112577.
-        if query_states.device.type == 'cuda' and attention_mask is not None:
+        if query_states.device.type != 'cpu' and attention_mask is not None:
             query_states = query_states.contiguous()
             key_states = key_states.contiguous()
             value_states = value_states.contiguous()

--- a/xtuner/parallel/sequence/comm.py
+++ b/xtuner/parallel/sequence/comm.py
@@ -133,7 +133,7 @@ def gather_for_sequence_parallel(input, dim: int, sp_group: dist.ProcessGroup):
         return input
 
     tensor_list = [torch.empty_like(input) for _ in range(world_size)]
-    assert input.device.type == 'cuda'
+    assert input.device.type != 'cpu'
     dist.all_gather(tensor_list, input, group=sp_group)
 
     output = torch.cat(tensor_list, dim=dim).contiguous()

--- a/xtuner/tools/model_converters/merge.py
+++ b/xtuner/tools/model_converters/merge.py
@@ -7,7 +7,7 @@ from transformers import (AutoModelForCausalLM, AutoTokenizer,
                           CLIPImageProcessor, CLIPVisionModel)
 
 from xtuner.model.utils import LoadWoInit
-
+from xtuner.utils.device import get_device_name
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -32,8 +32,8 @@ def parse_args():
         help='Indicate if using `safe_serialization`')
     parser.add_argument(
         '--device',
-        default='cuda',
-        choices=('cuda', 'cpu', 'auto'),
+        default=get_device_name(),
+        choices=('cuda', 'cpu', 'npu', 'auto'),
         help='Indicate the device')
 
     args = parser.parse_args()

--- a/xtuner/tools/model_converters/split.py
+++ b/xtuner/tools/model_converters/split.py
@@ -9,6 +9,7 @@ import shutil
 import torch
 from mmengine.utils import mkdir_or_exist
 
+from xtuner.utils.device import get_device_name, get_torch_device
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -41,7 +42,7 @@ def main():
     checkpoints = set(index['weight_map'].values())
     for ckpt in checkpoints:
         state_dict = torch.load(
-            osp.join(args.src_dir, ckpt), map_location='cuda')
+            osp.join(args.src_dir, ckpt), map_location=get_device_name())
         keys = sorted(list(state_dict.keys()))
         for k in keys:
             new_state_dict_name = 'pytorch_model-{:05d}-of-{:05d}.bin'.format(
@@ -52,7 +53,7 @@ def main():
                        osp.join(args.dst_dir, new_state_dict_name))
             cnt += 1
         del state_dict
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
     with open(osp.join(args.dst_dir, 'pytorch_model.bin.index.json'),
               'w') as f:
         json.dump(new_index, f)

--- a/xtuner/tools/utils.py
+++ b/xtuner/tools/utils.py
@@ -8,6 +8,7 @@ from transformers import PreTrainedTokenizerFast, StoppingCriteriaList
 from transformers.generation.streamers import BaseStreamer
 
 from xtuner.utils import StopWordStoppingCriteria
+from xtuner.utils.device import get_torch_device
 
 
 def get_base_model(model):
@@ -151,15 +152,15 @@ def get_stop_criteria(
 def auto_dtype_of_deepspeed_config(ds_config):
     if ds_config.get('fp16') and not ds_config.get('bf16'):
         if ds_config.get('fp16').get('enabled') == 'auto':
-            ds_config['fp16']['enabled'] = torch.cuda.is_available()
+            ds_config['fp16']['enabled'] = get_torch_device().is_available()
     elif not ds_config.get('fp16') and ds_config.get('bf16'):
         if ds_config.get('bf16').get('enabled') == 'auto':
-            ds_config['bf16']['enabled'] = torch.cuda.is_bf16_supported()
+            ds_config['bf16']['enabled'] = get_torch_device().is_bf16_supported()
     elif ds_config.get('fp16') and ds_config.get('bf16'):
         if ds_config.get('fp16').get('enabled') == 'auto':
-            ds_config['fp16']['enabled'] = torch.cuda.is_available()
+            ds_config['fp16']['enabled'] = get_torch_device().is_available()
         if ds_config.get('bf16').get('enabled') == 'auto':
-            ds_config['bf16']['enabled'] = torch.cuda.is_bf16_supported()
+            ds_config['bf16']['enabled'] = get_torch_device().is_bf16_supported()
         if (ds_config['fp16']['enabled'] is True
                 and ds_config['bf16']['enabled'] is True):
             ds_config['fp16']['enabled'] = False

--- a/xtuner/utils/device.py
+++ b/xtuner/utils/device.py
@@ -1,0 +1,82 @@
+# This code is inspired by the torchtune.
+# https://github.com/pytorch/torchtune/blob/main/torchtune/utils/_device.py
+
+import os
+import logging
+from enum import Enum
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def is_torch_npu_available() -> bool:
+    """Check the availability of NPU"""
+    try:
+        import torch_npu  # noqa: F401
+
+        return torch.npu.is_available()
+    except ImportError:
+        return False
+
+
+is_cuda_available = torch.cuda.is_available()
+is_npu_available = is_torch_npu_available()
+
+
+def get_device_name() -> str:
+    """Function that gets the torch.device based on the current machine.
+
+    This currently only supports CPU, CUDA, NPU.
+
+    Returns:
+        device
+    """
+    if is_cuda_available:
+        device = "cuda"
+    elif is_npu_available:
+        device = "npu"
+    else:
+        device = "cpu"
+    return device
+
+
+def get_device(device_name: Optional[str] = None) -> torch.device:
+    """Function that takes an optional device string, verifies it's correct and available given the machine and
+    distributed settings, and returns a :func:`~torch.device`. If device string is not provided, this function will
+    infer the device based on the environment.
+
+    If CUDA-like is available and being used, this function also sets the CUDA-like device.
+
+    Args:
+        device (Optional[str]): The name of the device to use, e.g. "cuda" or "cpu" or "npu".
+
+    Example:
+        >>> device = get_device("cuda")
+        >>> device
+        device(type='cuda', index=0)
+
+    Returns:
+        torch.device: Device
+    """
+    if device_name is None:
+        device_name = get_device_name()
+    device = torch.device(device_name)
+    return device
+
+
+def get_torch_device() -> any:
+    """Return the corresponding torch attribute based on the device type string.
+
+    Returns:
+        module: The corresponding torch device namespace, or torch.cuda if not found.
+    """
+    device_name = get_device_name()
+    try:
+        return getattr(torch, device_name)
+    except AttributeError:
+        logger.warning(
+            f"Device namespace '{device_name}' not found in torch, try to load torch.cuda."
+        )
+        return torch.cuda


### PR DESCRIPTION
# What does this PR do?

## Overview
🚀This PR enables the users of xtuner to leverage the Ascend NPU for fine-tuning .
 This PR primarily addresses the initial refactoring of device-independent code, enabling users of xtuner to perform fine-tuning on NPU devices. Currently, this PR involves the following modules: single-device LoRA fine-tuning, single-device full-parameter fine-tuning, LoRA merging, and model conversation.