### PR TITLE
[Fix] Fix tokenization hash

### DIFF
--- a/xtuner/_lite/algorithms/ppo/dataset.py
+++ b/xtuner/_lite/algorithms/ppo/dataset.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import hashlib
 import json
 
 import numpy as np
@@ -143,6 +144,15 @@ class PPOTokenizeFunction(SftTokenizeFunction):
         tokenized = msg.tokenize(self.tokenizer, self.chat_template)
 
         return tokenized
+
+    def hash(self):
+        _sys_prompt_hash = (
+            hashlib.sha256(repr(self.sys_prompt).encode()).hexdigest()[:16]
+            if self.sys_prompt is not None
+            else "None"
+        )
+
+        return super().hash() + f"_{_sys_prompt_hash}"
 
 
 class RewardBufferCollator(SftCollator):

--- a/xtuner/_lite/algorithms/sft/dataset.py
+++ b/xtuner/_lite/algorithms/sft/dataset.py
@@ -9,8 +9,7 @@ from transformers import PreTrainedTokenizer
 from xtuner._lite import get_logger
 from xtuner._lite.chat.messages.chat import ChatTemplate
 from xtuner._lite.datasets import OPENAI_CONVERT_MAP
-from xtuner._lite.datasets.jsonl import CachableTokenizeFunction
-from xtuner._lite.datasets.utils.utils import tokenizer_hash
+from xtuner._lite.datasets.cache import CachableTokenizeFunction, tokenizer_hash
 
 logger = get_logger()
 

--- a/xtuner/_lite/datasets/cache.py
+++ b/xtuner/_lite/datasets/cache.py
@@ -1,0 +1,40 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import hashlib
+import tempfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, TypedDict
+
+from transformers import PreTrainedTokenizer
+
+
+class CacheObj(TypedDict, total=False):
+    num_tokens: int
+
+
+class CachableTokenizeFunction(ABC):
+    @abstractmethod
+    def __call__(self, item: Any) -> CacheObj:
+        raise NotImplementedError
+
+    @abstractmethod
+    def hash(self) -> str:
+        raise NotImplementedError
+
+
+def calculate_file_sha256(path):
+    with open(path, "rb") as f:
+        file_hash = hashlib.sha256()
+        file_hash.update(f.read())
+    return file_hash.hexdigest()
+
+
+def tokenizer_hash(tokenizer: PreTrainedTokenizer):
+    with tempfile.TemporaryDirectory() as tokenizer_tempdir:
+        tokenizer.save_pretrained(tokenizer_tempdir)
+        tokenizer_files = sorted(Path(tokenizer_tempdir).iterdir())
+        file_hash = hashlib.sha256()
+        for file in tokenizer_files:
+            with open(file, "rb") as f:
+                file_hash.update(f.read())
+        return file_hash.hexdigest()

--- a/xtuner/_lite/datasets/json.py
+++ b/xtuner/_lite/datasets/json.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 from xtuner._lite import get_logger
 
-from .cache import CachableTokenizeFunction, CacheObj, calculate_jsonl_sha256
+from .cache import CachableTokenizeFunction, CacheObj, calculate_file_sha256
 
 logger = get_logger()
 
@@ -40,7 +40,7 @@ class JsonDataset(torch.utils.data.Dataset):
             else:
                 mkdir_or_exist(cache_dir)
 
-            file_hash = calculate_jsonl_sha256(path)
+            file_hash = calculate_file_sha256(path)
             file_cache_dir = os.path.join(cache_dir, file_hash)
 
             if file_hash not in os.listdir(cache_dir):

--- a/xtuner/_lite/datasets/jsonl.py
+++ b/xtuner/_lite/datasets/jsonl.py
@@ -1,13 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import hashlib
 import json
 import math
 import multiprocessing
 import os
 import random
-from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor
-from typing import Any, Callable, TypedDict
+from typing import Any, Callable
 
 import numpy as np
 import torch
@@ -17,28 +15,9 @@ from tqdm import tqdm
 
 from xtuner._lite import get_logger
 
+from .cache import CachableTokenizeFunction, CacheObj, calculate_jsonl_sha256
+
 logger = get_logger()
-
-
-def calculate_jsonl_sha256(path):
-    with open(path, "rb") as f:
-        file_hash = hashlib.sha256()
-        file_hash.update(f.read())
-    return file_hash.hexdigest()
-
-
-class CacheObj(TypedDict, total=False):
-    num_tokens: int
-
-
-class CachableTokenizeFunction(ABC):
-    @abstractmethod
-    def __call__(self, item: Any) -> CacheObj:
-        raise NotImplementedError
-
-    @abstractmethod
-    def hash(self) -> str:
-        raise NotImplementedError
 
 
 class JsonlDataset(torch.utils.data.Dataset):
@@ -46,7 +25,7 @@ class JsonlDataset(torch.utils.data.Dataset):
         self,
         path,
         sample_ratio: float = 1.0,
-        tokenize_fn: Callable[[Any], CacheObj] | None = None,
+        tokenize_fn: Callable[[Any], "CacheObj"] | None = None,
         cache_dir: str | None = None,
         max_length: int | None = None,
     ):

--- a/xtuner/_lite/datasets/jsonl.py
+++ b/xtuner/_lite/datasets/jsonl.py
@@ -1,21 +1,25 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import datetime
 import json
 import math
 import multiprocessing
 import os
 import random
+import signal
+import sys
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any, Callable
 
 import numpy as np
 import torch
+from filelock import SoftFileLock
 from mmengine import mkdir_or_exist
 from torch import distributed as dist
 from tqdm import tqdm
 
 from xtuner._lite import get_logger
 
-from .cache import CachableTokenizeFunction, CacheObj, calculate_jsonl_sha256
+from .cache import CachableTokenizeFunction, CacheObj, calculate_file_sha256
 
 logger = get_logger()
 
@@ -25,7 +29,7 @@ class JsonlDataset(torch.utils.data.Dataset):
         self,
         path,
         sample_ratio: float = 1.0,
-        tokenize_fn: Callable[[Any], "CacheObj"] | None = None,
+        tokenize_fn: Callable[[Any], CacheObj] | None = None,
         cache_dir: str | None = None,
         max_length: int | None = None,
     ):
@@ -41,17 +45,22 @@ class JsonlDataset(torch.utils.data.Dataset):
             else:
                 mkdir_or_exist(cache_dir)
 
-            file_hash = calculate_jsonl_sha256(path)
+            file_hash = calculate_file_sha256(path)
             file_cache_dir = os.path.join(cache_dir, file_hash)
 
             if file_hash not in os.listdir(cache_dir):
                 mkdir_or_exist(file_cache_dir)
 
-            if "offsets.npy" in os.listdir(file_cache_dir):
-                _cached_file = os.path.join(file_cache_dir, "offsets.npy")
-                offsets = np.load(_cached_file)
-            else:
-                offsets = self.count_offsets(file_cache_dir)
+            _file_lock = self._cache_acquire(file_cache_dir)
+
+            _cached_file = os.path.join(file_cache_dir, "offsets.npy")
+            if not dist.is_initialized() or dist.get_rank() == 0:
+                if not os.path.exists(_cached_file):
+                    offsets = self.count_offsets(file_cache_dir)
+
+            if dist.is_initialized():
+                dist.barrier()
+            offsets = np.load(_cached_file)
 
             if tokenize_fn and isinstance(tokenize_fn, CachableTokenizeFunction):
                 tok_hash = tokenize_fn.hash()
@@ -65,13 +74,18 @@ class JsonlDataset(torch.utils.data.Dataset):
                 else:
                     num_tokens = self.count_tokens(offsets, tok_cache_dir)
             elif tokenize_fn:
+                logger.warning(
+                    f"{tokenize_fn.__name__} is not an instance of "
+                    "`CachableTokenizeFunction`, data will always "
+                    "be re-tokenized during training!"
+                )
                 num_tokens = self.count_tokens(offsets)
             else:
                 num_tokens = None
 
             offsets = offsets
             num_tokens = num_tokens
-
+            self._cache_release(_file_lock)
         else:
             offsets = self.count_offsets()
             num_tokens = None
@@ -115,7 +129,7 @@ class JsonlDataset(torch.utils.data.Dataset):
 
         offsets = np.array(offsets)
 
-        if dist.get_rank() == 0 and cache_dir:
+        if cache_dir and (not dist.is_initialized() or dist.get_rank() == 0):
             save_path = os.path.join(cache_dir, "offsets.npy")
             np.save(save_path, offsets)
 
@@ -130,7 +144,7 @@ class JsonlDataset(torch.utils.data.Dataset):
     def count_tokens(self, offsets, cache_dir=None):
         num_samples = len(offsets)
 
-        if dist.is_available():
+        if dist.is_initialized():
             world_size = dist.get_world_size()
             rank = dist.get_rank()
         else:
@@ -163,9 +177,18 @@ class JsonlDataset(torch.utils.data.Dataset):
         _num_tokens = [data["num_tokens"] for data in tokenized]
         _num_tokens = np.array(_num_tokens)
 
-        if dist.is_available():
+        if dist.is_initialized():
+            # TODO:
+            # This is a workaround for `all_gather_object` would hang when
+            # using `nccl` backend. Maybe we could find a better way to
+            # synchronize the `num_tokens` since datasets are not always initialized
+            # with the world size.
+            if "gloo" in (backend := dist.get_backend()):
+                tokenize_group = dist.new_group(backend=backend)
+            else:
+                tokenize_group = dist.new_group()
             num_tokens = [None] * world_size
-            dist.all_gather_object(num_tokens, _num_tokens)
+            dist.all_gather_object(num_tokens, _num_tokens, group=tokenize_group)
             num_tokens = np.concatenate(num_tokens, axis=0)
         else:
             num_tokens = _num_tokens
@@ -199,3 +222,63 @@ class JsonlDataset(torch.utils.data.Dataset):
             return tokenized_data
         else:
             return raw_data
+
+    def _cache_acquire(self, lock_dir: str):
+        """Acquires a cache lock to prevent simultaneous read/write operations
+        on the cache directory.
+
+        This function is designed to handle scenarios where multiple independent processes are performing
+        data caching, such as when multiple training tasks are started simultaneously. These training tasks
+        are independent of each other, and simultaneous read/write operations on the cache can lead to bugs.
+
+        To avoid such issues, `_cache_acquire` ensures that only one training task is processing data at any
+        given time. Within the same training task, distributed initialization with predefined ranks is used
+        to avoid simultaneous read/write operations.
+        """  # noqa: E501
+        if dist.is_initialized():
+            if "gloo" in (backend := dist.get_backend()):
+                _cache_lock_group = dist.new_group(
+                    backend=backend, timeout=datetime.timedelta(seconds=30)
+                )
+            else:
+                _cache_lock_group = dist.new_group(
+                    timeout=datetime.timedelta(seconds=30)
+                )
+            rank = dist.get_rank()
+        else:
+            rank = 0
+
+        lock_dir = os.path.join(lock_dir, "__lock")
+        mkdir_or_exist(lock_dir)
+
+        if rank == 0:
+            logger.info(
+                f"Acquiring lock for lock_dir, if it hangs over 30m, please remove {lock_dir} it manually."
+            )
+
+        _filelock = SoftFileLock(os.path.join(lock_dir, f"{rank}.lock"))
+
+        # Register a signal handler for SIGINT (Ctrl+C) and SIGTERM
+        def release_lock_on_signal(signum, frame):
+            if _filelock.is_locked:
+                _filelock.release()
+            sys.exit(0)
+
+        # TODO: Overwrite the default signal handler for SIGINT and SIGTERM is
+        # not recommended. We should find a better way to handle this.
+        signal.signal(signal.SIGINT, release_lock_on_signal)
+        signal.signal(signal.SIGTERM, release_lock_on_signal)
+
+        # Make sure only one training task will acquire the lock
+        if rank == 0:
+            _filelock.acquire()
+
+        if dist.is_initialized():
+            dist.barrier(group=_cache_lock_group)  # type: ignore
+
+        if rank != 0:
+            _filelock.acquire()
+        return _filelock
+
+    def _cache_release(self, filelock: SoftFileLock):
+        filelock.release()

--- a/xtuner/_lite/datasets/utils/convert.py
+++ b/xtuner/_lite/datasets/utils/convert.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import re
+from typing import Callable, Dict
 
 from xtuner._lite.chat import ChatMessages
 
@@ -186,7 +187,7 @@ def official_openai(data):
         return ChatMessages.from_dict({"messages": data})
 
 
-OPENAI_CONVERT_MAP = {
+OPENAI_CONVERT_MAP: Dict[str, Callable[..., ChatMessages]] = {
     "llava": llava_to_openai,
     "llava_interleave": llava_to_openai_interleave,
     "alpaca": Alpaca2Openai.convert,

--- a/xtuner/_lite/datasets/utils/utils.py
+++ b/xtuner/_lite/datasets/utils/utils.py
@@ -1,25 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import hashlib
-import tempfile
 from collections.abc import Mapping
-from pathlib import Path
 
 import torch
 from PIL import Image
-from transformers import PreTrainedTokenizer
 
 _EXIF_ORIENT = 274  # exif 'Orientation' tag
-
-
-def tokenizer_hash(tokenizer: PreTrainedTokenizer):
-    with tempfile.TemporaryDirectory() as tokenizer_tempdir:
-        tokenizer.save_pretrained(tokenizer_tempdir)
-        tokenizer_files = sorted(Path(tokenizer_tempdir).iterdir())
-        file_hash = hashlib.sha256()
-        for file in tokenizer_files:
-            with open(file, "rb") as f:
-                file_hash.update(f.read())
-        return file_hash.hexdigest()
 
 
 def apply_exif_orientation(image):

--- a/xtuner/_lite/datasets/utils/utils.py
+++ b/xtuner/_lite/datasets/utils/utils.py
@@ -1,10 +1,25 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import hashlib
+import tempfile
 from collections.abc import Mapping
+from pathlib import Path
 
 import torch
 from PIL import Image
+from transformers import PreTrainedTokenizer
 
 _EXIF_ORIENT = 274  # exif 'Orientation' tag
+
+
+def tokenizer_hash(tokenizer: PreTrainedTokenizer):
+    with tempfile.TemporaryDirectory() as tokenizer_tempdir:
+        tokenizer.save_pretrained(tokenizer_tempdir)
+        tokenizer_files = sorted(Path(tokenizer_tempdir).iterdir())
+        file_hash = hashlib.sha256()
+        for file in tokenizer_files:
+            with open(file, "rb") as f:
+                file_hash.update(f.read())
+        return file_hash.hexdigest()
 
 
 def apply_exif_orientation(image):

--- a/xtuner/_lite/parallel/setup.py
+++ b/xtuner/_lite/parallel/setup.py
@@ -25,10 +25,10 @@ def mlu_reduce_scatter_tensor(
         return origin_reduce_scatter_tensor(output, input, op, group, async_op)
 
 
-def setup_parallel():
+def setup_parallel(backend="cpu:gloo,cuda:nccl"):
     if not dist.is_initialized():
         dist_launcher = infer_launcher()
-        init_dist(dist_launcher)
+        init_dist(dist_launcher, backend=backend)
 
     device = get_device()
 


### PR DESCRIPTION
1. Make `SftTokenizeFunction` and `PPOTokenizeFunction` inherit from `CachableTokenizeFunction` to facilitate hash calculation, making cached tokenized data more accurate
2. Fix issues in `JsonlDataset` and `JsonlDataset` where `num_tokens` still has a probability of being `None` when `tokenize_fn` is passed
3. Fix minor docformatter issues in CI