### PR TITLE
Enhance LLaVA dataset processing with optional text preprocessing

### DIFF
--- a/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/finetune/llava_phi3_mini_4k_instruct_full_clip_vit_large_p14_336_e1_gpu8_finetune.py
+++ b/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/finetune/llava_phi3_mini_4k_instruct_full_clip_vit_large_p14_336_e1_gpu8_finetune.py
@@ -86,7 +86,7 @@ model = dict(
     llm=dict(
         type=AutoModelForCausalLM.from_pretrained,
         pretrained_model_name_or_path=llm_name_or_path,
-        trust_remote_code=True,
+        trust_remote_code=False,
     ),
     visual_encoder=dict(
         type=CLIPVisionModel.from_pretrained,
@@ -107,6 +107,7 @@ llava_dataset = dict(
     template_map_fn=dict(type=template_map_fn_factory, template=prompt_template),
     max_length=max_length,
     pad_image_to_square=True,
+    preprocess_text_data=False,
 )
 
 train_dataloader = dict(

--- a/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/finetune/llava_phi3_mini_4k_instruct_full_clip_vit_large_p14_336_full_e2_gpu8_internvl_finetune.py
+++ b/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/finetune/llava_phi3_mini_4k_instruct_full_clip_vit_large_p14_336_full_e2_gpu8_internvl_finetune.py
@@ -115,7 +115,7 @@ model = dict(
     llm=dict(
         type=AutoModelForCausalLM.from_pretrained,
         pretrained_model_name_or_path=llm_name_or_path,
-        trust_remote_code=True,
+        trust_remote_code=False,
     ),
     visual_encoder=dict(
         type=CLIPVisionModel.from_pretrained,
@@ -136,6 +136,7 @@ sharegpt4v_caption_dataset = dict(
     template_map_fn=dict(type=template_map_fn_factory, template=prompt_template),
     max_length=max_length,
     pad_image_to_square=True,
+    preprocess_text_data=False,
 )
 
 llava_dataset = dict(

--- a/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/pretrain/llava_phi3_mini_4k_instruct_clip_vit_large_p14_336_e1_gpu8_pretrain.py
+++ b/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/pretrain/llava_phi3_mini_4k_instruct_clip_vit_large_p14_336_e1_gpu8_pretrain.py
@@ -83,7 +83,7 @@ model = dict(
     llm=dict(
         type=AutoModelForCausalLM.from_pretrained,
         pretrained_model_name_or_path=llm_name_or_path,
-        trust_remote_code=True,
+        trust_remote_code=False,
     ),
     visual_encoder=dict(
         type=CLIPVisionModel.from_pretrained,
@@ -104,6 +104,7 @@ llava_dataset = dict(
     template_map_fn=dict(type=template_map_fn_factory, template=prompt_template),
     max_length=max_length,
     pad_image_to_square=False,
+    preprocess_text_data=False,
 )
 
 train_dataloader = dict(

--- a/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/pretrain/llava_phi3_mini_4k_instruct_clip_vit_large_p14_336_e1_gpu8_sharegpt4v_pretrain.py
+++ b/xtuner/configs/llava/phi3_mini_4k_instruct_clip_vit_large_p14_336/pretrain/llava_phi3_mini_4k_instruct_clip_vit_large_p14_336_e1_gpu8_sharegpt4v_pretrain.py
@@ -83,7 +83,7 @@ model = dict(
     llm=dict(
         type=AutoModelForCausalLM.from_pretrained,
         pretrained_model_name_or_path=llm_name_or_path,
-        trust_remote_code=True,
+        trust_remote_code=False,
     ),
     visual_encoder=dict(
         type=CLIPVisionModel.from_pretrained,
@@ -104,6 +104,7 @@ llava_dataset = dict(
     template_map_fn=dict(type=template_map_fn_factory, template=prompt_template),
     max_length=max_length,
     pad_image_to_square=False,
+    preprocess_text_data=False,
 )
 
 train_dataloader = dict(

--- a/xtuner/dataset/llava.py
+++ b/xtuner/dataset/llava.py
@@ -8,13 +8,14 @@ from datasets import Dataset as HFDataset
 from datasets import DatasetDict, load_from_disk
 from mmengine import print_log
 from mmengine.config import Config, ConfigDict
+from mmengine.utils.misc import get_object_from_string
 from PIL import Image
 from torch.utils.data import Dataset
 
-from xtuner.registry import BUILDER
+from xtuner.registry import BUILDER, MAP_FUNC
 
 from .huggingface import process_hf_dataset
-from .utils import expand2square
+from .utils import encode_fn, expand2square
 
 
 def load_jsonl(json_file):
@@ -39,6 +40,7 @@ class LLaVADataset(Dataset):
         template_map_fn=None,
         max_length=2048,
         pad_image_to_square=False,
+        preprocess_text_data=True,
     ):
         super().__init__()
 
@@ -54,7 +56,7 @@ class LLaVADataset(Dataset):
             )
 
         if offline_processed_text_folder is not None:
-            self.text_data = load_from_disk(offline_processed_text_folder)
+            self.data = load_from_disk(offline_processed_text_folder)
         else:
             if data_path.endswith(".json"):
                 json_data = json.load(open(data_path))
@@ -63,22 +65,53 @@ class LLaVADataset(Dataset):
             else:
                 raise NotImplementedError
 
-            for idx in range(len(json_data)):
-                if isinstance(json_data[idx]["id"], int):
-                    json_data[idx]["id"] = str(json_data[idx]["id"])
-            json_data = DatasetDict({"train": HFDataset.from_list(json_data)})
-            self.text_data = process_hf_dataset(
-                dataset=json_data,
-                tokenizer=tokenizer,
-                max_length=max_length,
-                dataset_map_fn=dataset_map_fn,
-                template_map_fn=template_map_fn,
-                split="train",
-                max_dataset_length=max_dataset_length,
-                remove_unused_columns=False,
-                pack_to_max_length=False,
-                with_image_token=True,
-            )
+            if preprocess_text_data:
+                for idx in range(len(json_data)):
+                    if isinstance(json_data[idx]["id"], int):
+                        json_data[idx]["id"] = str(json_data[idx]["id"])
+                json_data = DatasetDict({"train": HFDataset.from_list(json_data)})
+                text_data = process_hf_dataset(
+                    dataset=json_data,
+                    tokenizer=tokenizer,
+                    max_length=max_length,
+                    dataset_map_fn=dataset_map_fn,
+                    template_map_fn=template_map_fn,
+                    split="train",
+                    max_dataset_length=max_dataset_length,
+                    remove_unused_columns=False,
+                    pack_to_max_length=False,
+                    with_image_token=True,
+                )
+                self.data = text_data
+            else:
+                if isinstance(tokenizer, dict) or isinstance(tokenizer, Config) or isinstance(tokenizer, ConfigDict):
+                    tokenizer = BUILDER.build(tokenizer)
+
+                if isinstance(dataset_map_fn, str):
+                    map_fn_obj = MAP_FUNC.get(dataset_map_fn) or get_object_from_string(dataset_map_fn)
+                    if map_fn_obj is not None:
+                        dataset_map_fn = map_fn_obj
+                    else:
+                        raise TypeError(
+                            "dataset_map_fn must be a function or a "
+                            "registered function's string in MAP_FUNC, "
+                            f"but got a string of '{dataset_map_fn}'"
+                        )
+
+                if (
+                    isinstance(template_map_fn, dict)
+                    or isinstance(template_map_fn, Config)
+                    or isinstance(template_map_fn, ConfigDict)
+                ):
+                    template_map_fn = BUILDER.build(template_map_fn)
+
+                self.dataset_map_fn = dataset_map_fn
+                self.template_map_fn = template_map_fn
+                self.tokenizer = tokenizer
+                self.data = json_data
+
+        self.max_length = max_length
+        self.preprocess_text_data = preprocess_text_data
 
         self.image_folder = image_folder
         if (
@@ -94,37 +127,45 @@ class LLaVADataset(Dataset):
     @property
     def modality_length(self):
         length_list = []
-        for data_dict in self.text_data:
-            cur_len = len(data_dict["input_ids"])
+        for data_dict in self.data:
+            if self.preprocess_text_data:
+                cur_len = len(data_dict["input_ids"])
+            else:
+                cur_len = sum(len(conv["value"].split()) for conv in data_dict["conversations"])
             if data_dict.get("image", None) is None:
                 cur_len = -cur_len
             length_list.append(cur_len)
         return length_list
 
     def __len__(self):
-        return len(self.text_data)
+        return len(self.data)
+
+    def process_text_data(self, data_dict, with_image_token=True):
+        if self.preprocess_text_data:
+            return data_dict
+
+        if self.dataset_map_fn is not None:
+            data_dict = self.dataset_map_fn(data_dict)
+        if self.template_map_fn is not None:
+            data_dict = self.template_map_fn(data_dict)
+        data_dict = encode_fn(data_dict, self.tokenizer, self.max_length, True, with_image_token)
+        return data_dict
 
     def __getitem__(self, index):
-        data_dict = self.text_data[index]
+        data_dict = self.data[index]
         if data_dict.get("image", None) is not None:
             image_file = data_dict["image"]
-            image = Image.open(os.path.join(self.image_folder, image_file)).convert(
-                "RGB"
-            )
+            image = Image.open(os.path.join(self.image_folder, image_file)).convert("RGB")
             if self.pad_image_to_square:
-                image = expand2square(
-                    image, tuple(int(x * 255) for x in self.image_processor.image_mean)
-                )
-            image = self.image_processor.preprocess(image, return_tensors="pt")[
-                "pixel_values"
-            ][0]
+                image = expand2square(image, tuple(int(x * 255) for x in self.image_processor.image_mean))
+            image = self.image_processor.preprocess(image, return_tensors="pt")["pixel_values"][0]
             data_dict["pixel_values"] = image
+            data_dict.update(self.process_text_data(data_dict, with_image_token=True))
         else:
             if hasattr(self.image_processor, "crop_size"):
                 crop_size = self.image_processor.crop_size
             else:
                 crop_size = self.image_processor.size
-            data_dict["pixel_values"] = torch.zeros(
-                3, crop_size["height"], crop_size["width"]
-            )
+            data_dict["pixel_values"] = torch.zeros(3, crop_size["height"], crop_size["width"])
+            data_dict.update(self.process_text_data(data_dict, with_image_token=False))
         return data_dict

--- a/xtuner/dataset/llava.py
+++ b/xtuner/dataset/llava.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
 import json
 import logging
 import os
@@ -152,7 +153,7 @@ class LLaVADataset(Dataset):
         return data_dict
 
     def __getitem__(self, index):
-        data_dict = self.data[index]
+        data_dict = copy.deepcopy(self.data[index])
         if data_dict.get("image", None) is not None:
             image_file = data_dict["image"]
             image = Image.open(os.path.join(self.image_folder, image_file)).convert("RGB")

--- a/xtuner/tools/train.py
+++ b/xtuner/tools/train.py
@@ -161,6 +161,12 @@ def main():
 
     check_cfg(cfg, args)
 
+    if args.resume == 'auto':
+        from mmengine.runner import find_latest_checkpoint
+        args.resume = find_latest_checkpoint(args.work_dir)
+
+        print_log(f"Auto resumed from the latest checkpoint {args.resume}.", logger="current")
+
     if cfg.get("framework", "mmengine").lower() == "huggingface":
         # set default training_args
         if cfg.get("training_args", None) is None:


### PR DESCRIPTION
Dear XTuner Contributors,

Thank you for providing the open-source code for MLLM. I noticed that the process_hf_dataset function in the LLaVADataset takes several minutes to preprocess text data each time the program starts. In contrast, some other repositories (e.g., Original LLaVA, LLaVA-Next) handle text data preprocessing during training.

To address this, I have proposed an enhancement to the LLaVA dataset processing by introducing optional text preprocessing. This modification eliminates the need to preprocess text data at runtime, improving efficiency.

I kindly request you review my code and consider merging my PR.

Best regards,

wanghao9610