### PR TITLE
[Feature][Fix] Enhance gradient handling for hybrid/tensor parallelism

### DIFF
--- a/xtuner/_lite/patches/base.py
+++ b/xtuner/_lite/patches/base.py
@@ -47,7 +47,6 @@ def _group_tensors_by_mesh(
 @_no_grad
 def clip_grad_norm_(
     parameters,
-    fsdp_mesh,
     max_norm: float,
     norm_type: float = 2.0,
     error_if_nonfinite: bool = False,

--- a/xtuner/_lite/patches/llama.py
+++ b/xtuner/_lite/patches/llama.py
@@ -1128,7 +1128,7 @@ class CUDAPatchedLlamaForCausalLM(PatchedCausalLM, GenerateMixin):
             if self.tp_mesh.size() > 1:
                 outputs.loss = DTensor.from_local(
                     outputs.loss, self.tp_mesh, placements=(Partial(),)
-                )
+                ).full_tensor()
             if sequence_parallel_mesh and sequence_parallel_mesh.size() > 1:
                 outputs.loss = dist.nn.all_reduce(
                     outputs.loss, group=sequence_parallel_mesh.get_group()

--- a/xtuner/_lite/patches/llama.py
+++ b/xtuner/_lite/patches/llama.py
@@ -1249,9 +1249,7 @@ class CUDAPatchedLlamaForCausalLM(PatchedCausalLM, GenerateMixin):
             for param in self.trainable_parameters():
                 param.grad.div_(self.tp_mesh.size())
 
-        grad_norm = clip_grad_norm_(
-            self.trainable_parameters(), self.world_mesh, max_norm
-        )
+        grad_norm = clip_grad_norm_(self.trainable_parameters(), max_norm)
         return grad_norm
 
 

--- a/xtuner/_lite/patches/llama.py
+++ b/xtuner/_lite/patches/llama.py
@@ -961,6 +961,8 @@ class CUDAPatchedLlamaForCausalLM(PatchedCausalLM, GenerateMixin):
 
             else:
                 logits = self.lm_head(hidden_states)
+                if isinstance(logits, DTensor):
+                    logits = logits.to_local()
 
                 if label_shifted:
                     shift_logits = logits


### PR DESCRIPTION
This PR introduces improvements for gradient computation and clipping in hybrid/tensor parallel environments, addressing critical issues in tensor parallelism scenarios.

### 1. Hybrid Device Mesh Gradient Clipping
**Problem**: Existing `_foreach` operators fail when parameters reside on different device meshes (common in hybrid parallelism setups like FSDP+TP).  
**Solution**: Implement mesh-aware gradient clipping by:
1. Grouping parameters by device mesh
2. Applying mesh-wise norm calculations
3. Performing global reduction

Enables proper clipping for models combining different parallel strategies (e.g., ViT with pure FSDP and LM with FSDP+TP).

---

### 2. Critical Fixes for Tensor Parallelism

#### Fix 1: CrossEntropy DTensor Compatibility
**Issue**: `RuntimeError` when using tensor parallelism (`tp_size > 1`) without Liger kernel  
**Root Cause**: Mismatched tensor types between `DTensor` logits and regular `Tensor` labels  
**Resolution**: Convert logits to local tensor before loss calculation via `logits.to_local()`

#### Fix 2: Gradient Correctness (tp_size > 1)
Addresses two interrelated issues:

**2.1 AllReduce Gradient Scaling**  
- **Problem**: `dist.nn.all_reduce` unexpectedly scales gradients by `tp_size` ([PyTorch Issue #58005](https://github.com/pytorch/pytorch/issues/58005))
- **Previous Workaround**: Manual scaling in `clip_grad_norm`  
- **New Approach**: Decouple gradient scaling from clipping logic  
  → Ensures correct gradients **even when users omit grad clipping**

**2.2 Layout Misassignment in Causal TP Plan**  
- **Affected Parameters**: `lm_head.weight`, `model.norm.weight`  
- **Issue**: Incorrect `Replicate()` input/output layout specification instead of `Shard(1)`  
- **Consequences**:  
  1. Broken DTensor gradient propagation  
  2. Erroneous `reduce_mean` instead of `reduce_sum` in manual sync  
- **Resolution**:  
  1. Correct layout annotations in `causal_tp_plan`  
  2. Remove fragile manual synchronization  
  3. Add Liger kernel gradient placement safeguards

---

**Key Improvements**:
1. **Stability**: Eliminates hidden dependency on grad clipping for correctness
2. **Accuracy**: Fixes silent gradient errors in TP configurations
3. **Maintainability**: Removes fragile workarounds in favor of proper DTensor propagation

**Note for Liger Kernel Users**:  
When using custom CUDA kernels (Liger), explicit gradient placement handling remains required for `lm_head.weight` due to kernel limitations in DTensor support.