### PR TITLE
[bugFix] append eos_token_ids in rollout worker manually

### DIFF
--- a/ci/scripts/test_grpo_trainer.py
+++ b/ci/scripts/test_grpo_trainer.py
@@ -38,6 +38,7 @@ from xtuner.v1.train.rl_trainer import RLTrainer
 MODEL_PATH = os.environ["ROLLOUT_MODEL_PATH"]
 TRAIN_DATA_PATH = os.environ["ROLLOUT_DATA_PATH"]
 TEST_DATA_PATH = os.environ["ROLLOUT_TEST_DATA_PATH"]
+os.environ['XTUNER_USE_FA3'] = "1"
 
 def parse_args():
     parser = argparse.ArgumentParser(description="VLLM Rollout Test Script")

--- a/xtuner/v1/ray/config/worker.py
+++ b/xtuner/v1/ray/config/worker.py
@@ -78,7 +78,7 @@ class RolloutConfig(BaseModel):
     ] = "lmdeploy"
     model_path: Annotated[str | Path, Parameter(group=infer_group, help="Path to the SGLang model.")]
     model_name: Annotated[str, Parameter(group=infer_group, help="Name of the model to be used in the LMDeploy.")]
-    tokenizer_path: Annotated[str, Parameter(group=infer_group, help="Path to the tokenizer for the model.")] = ""
+    tokenizer_path: Annotated[str, Parameter(group=infer_group, help="Path to the tokenizer for the model.")]
     api_key: Annotated[
         Optional[Union[List[str], str]],
         Parameter(


### PR DESCRIPTION
Append eos_token_ids in rollout worker according to finish reason manually, and this logic will be removed when lmdeploy supports to return stop_tokens