### PR TITLE
rm abused `name` param for `cyclopts.App`

### DIFF
--- a/xtuner/v1/train/cli/sft.py
+++ b/xtuner/v1/train/cli/sft.py
@@ -11,7 +11,6 @@ from xtuner.v1.utils import Config
 
 
 app = App(
-    name="entrypoint of sft & pretrain",
     help="XTuner's entry point for fine-tuning and training, launched using configuration files or arguments.",
 )
 


### PR DESCRIPTION
In `cyclopts.App` instantiation, `name` parameter is used as a name for the script per se. Using this param would cause the program to print the following in the cli helper mode

```
Usage: entrypoint of sft & pretrain [OPTIONS]
```