### PR TITLE
[Feature] Add Pretraining Example

### DIFF
--- a/examples/v1/pretrain_qwen3_tiny.py
+++ b/examples/v1/pretrain_qwen3_tiny.py
@@ -1,0 +1,67 @@
+from xtuner.v1.config import (
+    AdamWConfig,
+    LRConfig,
+)
+from xtuner.v1.train import TrainerConfig
+from xtuner.v1.datasets.pt_tokenize_fn import PretrainTokenizeFunctionConfig
+from xtuner.v1.model import Qwen3Dense4BConfig
+from xtuner.v1.loss import CELossConfig
+from xtuner.v1.datasets.config import DatasetConfig, DataloaderConfig
+
+# model config
+model_cfg = Qwen3Dense4BConfig()
+
+# dataset and dataloader config
+sample_max_length = 4096
+pack_max_length = 4096
+
+dataset_config = [
+    {
+        "dataset": DatasetConfig(
+            name="source1",
+            # jsonl file with {"content": "<text>"}
+            # or directory containing such jsonl files
+            anno_path="tests/resource/pretrain_example_data.jsonl",
+            sample_ratio=10000.0,
+        ),
+        "tokenize_fn": PretrainTokenizeFunctionConfig(
+            add_special_tokens=True,
+            add_eos_token=True,
+        ),
+    },
+    {
+        "dataset": DatasetConfig(
+            name="source2",
+            # jsonl file with {"content": "<text>"}
+            # or directory containing such jsonl files
+            anno_path="tests/resource/pretrain_example_data.jsonl",
+            sample_ratio=20000.0,
+        ),
+        "tokenize_fn": PretrainTokenizeFunctionConfig(
+            add_special_tokens=False,
+            add_eos_token=True,
+        ),
+    },
+]
+dataloader_config = DataloaderConfig(
+    pack_max_length=pack_max_length
+)
+
+# optimizer and lr config
+optim_cfg = AdamWConfig(lr=1e-4, foreach=False)
+lr_cfg = LRConfig(lr_type="constant", warmup_ratio=0)
+
+# trainer config
+trainer = TrainerConfig(
+    model_cfg=model_cfg,
+    optim_cfg=optim_cfg,
+    dataset_cfg=dataset_config,
+    dataloader_cfg=dataloader_config,
+    tokenizer_path="Qwen/Qwen3-4B",
+    lr_cfg=lr_cfg,
+    loss_cfg=CELossConfig(mode="chunk", chunk_size=1024),
+    global_batch_size=8,
+    total_epoch=1,
+    work_dir="work_dir/pretrain_qwen3_tiny",
+    # load_from="Qwen/Qwen3-4B",
+)

--- a/examples/v1/pretrain_qwen3_tiny.py
+++ b/examples/v1/pretrain_qwen3_tiny.py
@@ -25,7 +25,7 @@ dataset_config = [
             sample_ratio=10000.0,
         ),
         "tokenize_fn": PretrainTokenizeFunctionConfig(
-            add_special_tokens=True,
+            add_bos_token=False,
             add_eos_token=True,
         ),
     },
@@ -38,13 +38,14 @@ dataset_config = [
             sample_ratio=20000.0,
         ),
         "tokenize_fn": PretrainTokenizeFunctionConfig(
-            add_special_tokens=False,
+            add_bos_token=False,
             add_eos_token=True,
         ),
     },
 ]
 dataloader_config = DataloaderConfig(
-    pack_max_length=pack_max_length
+    pack_max_length=pack_max_length,
+    num_workers=4,
 )
 
 # optimizer and lr config

--- a/tests/resource/pretrain_example_data.jsonl
+++ b/tests/resource/pretrain_example_data.jsonl
@@ -1,0 +1,3 @@
+{"content": "Stay hydrated by drinking plenty of water throughout the day.\n"}
+{"content": "Incorporate regular physical activity into your routine, such as walking or exercising.\n"}
+{"content": "Eat a balanced diet rich in fruits, vegetables, whole grains, and lean proteins.\n"}

--- a/xtuner/v1/datasets/pt_tokenize_fn/__init__.py
+++ b/xtuner/v1/datasets/pt_tokenize_fn/__init__.py
@@ -1,0 +1,1 @@
+from .text import PretrainTokenizeFunction, PretrainTokenizeFunctionConfig

--- a/xtuner/v1/datasets/pt_tokenize_fn/text.py
+++ b/xtuner/v1/datasets/pt_tokenize_fn/text.py
@@ -57,7 +57,7 @@ class PretrainTokenizeFunction(CachableTokenizeFunction[DataItem]):
             self._hash = f"{_tokenizer_hash}_{_source_hash}_{self.add_special_tokens}_{self.add_eos_token}"
         else:
             assert isinstance(self._hash, str), (
-                "hash is not a valid string, it means `FtdpTokenizeFunction._hash` is modified by user."
+                "hash is not a valid string, it means `PretrainTokenizeFunction._hash` is modified by user."
             )
 
         return self._hash

--- a/xtuner/v1/datasets/pt_tokenize_fn/text.py
+++ b/xtuner/v1/datasets/pt_tokenize_fn/text.py
@@ -39,8 +39,13 @@ class PretrainTokenizeFunction(CachableTokenizeFunction[DataItem]):
 
         input_ids = self.tokenizer.encode(text, add_special_tokens=False)
         num_tokens = len(input_ids)
-        labels = copy.deepcopy(input_ids)
-        labels[0] = -100
+
+        if num_tokens == 0:
+            labels = []
+        else:
+            labels = copy.deepcopy(input_ids)
+            labels[0] = -100
+
         return {"input_ids": input_ids, "labels": labels, "num_tokens": num_tokens}
 
     def hash(self) -> str:

--- a/xtuner/v1/datasets/pt_tokenize_fn/text.py
+++ b/xtuner/v1/datasets/pt_tokenize_fn/text.py
@@ -1,0 +1,83 @@
+import copy
+import hashlib
+import inspect
+from typing import Annotated, Union
+
+from cyclopts import Parameter
+from pydantic import BaseModel
+
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+from xtuner.v1.datasets.data_item import CacheItem, DataItem
+
+from ..utils import CachableTokenizeFunction, tokenizer_xxhash
+
+
+class PretrainTokenizeFunction(CachableTokenizeFunction[DataItem]):
+    def __init__(
+        self,
+        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+        add_eos_token: bool = True,
+        add_special_tokens: bool = False,
+        tokenizer_hash: str | None = None,
+        hash: str | None = None,
+    ):
+        self.tokenizer = tokenizer
+        self.add_eos_token = add_eos_token
+        self.add_special_tokens = add_special_tokens
+        self._tokenizer_hash = tokenizer_hash
+        self._hash = hash
+
+    def __call__(self, item: dict, **kwargs) -> DataItem | CacheItem:
+        text = item["content"]
+
+        # if self.add_bos_token:
+        #     text = self.tokenizer.bos_token + text
+        if self.add_eos_token:
+            text = text + self.tokenizer.eos_token
+
+        input_ids = self.tokenizer.encode(text, add_special_tokens=self.add_special_tokens)
+        num_tokens = len(input_ids)
+        labels = copy.deepcopy(input_ids)
+        labels[0] = -100
+        return {"input_ids": input_ids, "labels": labels, "num_tokens": num_tokens}
+
+    def hash(self) -> str:
+        if self._hash is None:
+            # truncate to 16 characters prevent too long cache directory
+            if self._tokenizer_hash is None:
+                _tokenizer_hash = tokenizer_xxhash(self.tokenizer)[:16]
+            else:
+                _tokenizer_hash = self._tokenizer_hash
+
+            _source_hash = (
+                hashlib.sha256(inspect.getsource(self.__class__.__call__).encode()).hexdigest()[:16]
+                + hashlib.sha256(inspect.getsource(self.__class__.__init__).encode()).hexdigest()[:16]
+            )
+
+            self._hash = f"{_tokenizer_hash}_{_source_hash}_{self.add_special_tokens}_{self.add_eos_token}"
+        else:
+            assert isinstance(self._hash, str), (
+                "hash is not a valid string, it means `FtdpTokenizeFunction._hash` is modified by user."
+            )
+
+        return self._hash
+
+
+class PretrainTokenizeFunctionConfig(BaseModel):
+    add_eos_token: Annotated[bool, Parameter(group="tokenize_fn")] = True
+    add_special_tokens: Annotated[bool, Parameter(group="tokenize_fn")] = False
+    hash: Annotated[str | None, Parameter(group="tokenize_fn")] = None
+
+    def build(
+        self,
+        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+        tokenizer_hash: str | None = None,
+        anno_name: str | None = None,
+        **kwargs,
+    ) -> PretrainTokenizeFunction:
+        return PretrainTokenizeFunction(
+            tokenizer=tokenizer,
+            add_eos_token=self.add_eos_token,
+            add_special_tokens=self.add_special_tokens,
+            tokenizer_hash=tokenizer_hash,
+        )

--- a/xtuner/v1/datasets/pt_tokenize_fn/text.py
+++ b/xtuner/v1/datasets/pt_tokenize_fn/text.py
@@ -80,4 +80,5 @@ class PretrainTokenizeFunctionConfig(BaseModel):
             add_eos_token=self.add_eos_token,
             add_special_tokens=self.add_special_tokens,
             tokenizer_hash=tokenizer_hash,
+            hash=self.hash,
         )


### PR DESCRIPTION
This pull request introduces a new example script for pretraining a Qwen3 model using the `xtuner` v1 API, and adds supporting components for dataset tokenization. The main changes include the implementation of a configurable pretraining tokenization function, updates to the dataset module structure, and the addition of a sample dataset for testing.

**New pretraining example and dataset:**

* Added a new example script `pretrain_qwen3_tiny.py` that demonstrates how to configure and launch a pretraining run for the Qwen3 model, including model, optimizer, dataset, dataloader, and trainer configurations.
* Added a small sample dataset `pretrain_example_data.jsonl` with example text data for pretraining demonstrations and tests.

**Tokenization function and configuration:**

* Implemented `PretrainTokenizeFunction` and its config class in `pt_tokenize_fn/text.py`, providing a flexible and hashable tokenization function for pretraining datasets, with options for adding EOS and special tokens.
* Exposed `PretrainTokenizeFunction` and `PretrainTokenizeFunctionConfig` in the `pt_tokenize_fn` module's `__init__.py` for easier imports.