### PR TITLE
[Fix] Fix the building and dumping of

### DIFF
--- a/xtuner/v1/engine/vision_compose_train_engine.py
+++ b/xtuner/v1/engine/vision_compose_train_engine.py
@@ -56,6 +56,7 @@ class VisionComposeConfigProtocol(Protocol):
 
     def build(self) -> VisionComposeModelProtocol: ...
 
+    @property
     def hf_config(self) -> PretrainedConfig | None: ...
 
 

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from cyclopts import Parameter
+from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict
 from torch import nn
 from torch.distributed._functional_collectives import all_reduce
@@ -51,7 +52,7 @@ class MoEModelOutputs(ModelOutputs):
     tokens_per_expert_global: NotRequired[torch.Tensor]
 
 
-class BalancingLossConfig(BaseModel):
+class BalancingLossConfig(PydanticBaseModel):
     balancing_loss_alpha: float = 0.001
     balancing_loss_global_average: bool = True
 
@@ -63,7 +64,7 @@ class BalancingLossConfig(BaseModel):
         )
 
 
-class ZLossConfig(BaseModel):
+class ZLossConfig(PydanticBaseModel):
     z_loss_alpha: float = 0.001
     z_loss_global_average: bool = True
 


### PR DESCRIPTION
1. Fix bug. `BalancingLossConfig` and `ZLossConfig` should inherit from `pydantic.BaseModel `rather than `xtuner.v1.model.BaseModel`
2. Fix bug. `VisionComposeConfigProtocol.hf_config` should be `property`, otherwise it will fail the building for `TrainerConfig`