### PR TITLE
[bugFix] fix multi_judger, ray dependency on sft and sglang launch method

### DIFF
--- a/tests/ray/test_judger.py
+++ b/tests/ray/test_judger.py
@@ -100,7 +100,6 @@ class TestJudgerController(unittest.TestCase):
         self.assertEqual(res2[0].reward["score"], 1.0)
         self.assertEqual(res2[1].reward["score"], 1.0)
 
-    @unittest.skip("暂时不支持一个judger配置创建多个实例")
     def test_gsm8k_multi_judger(self):
         from xtuner.v1.ray.judger.gsm8k import GSM8KJudgerConfig
         # 支持一个GSM8KJudgerConfig创建多个实例
@@ -110,11 +109,12 @@ class TestJudgerController(unittest.TestCase):
             reward_judger_configs=[
                 gsm8k_judger_config_1,
                 gsm8k_judger_config_2
-            ]
+            ],
+            enable_weighted_judgers=True,
         )
         judger_controller = JudgerController.remote(judger_cfg)
         res3 = ray.get(judger_controller.run.remote(FAKE_JUDGER_INPUT_ITEM_MULTI_SOURCE))
-        self.assertEqual(res3.reward["score"], 1.0) # weighted_reward为固定字段，表示加权后的reward
+        self.assertEqual(res3.reward["weighted_score"], 1.0) # weighted_score为固定字段，表示加权后的reward
         
     def test_gsm8k_judger_score(self):
         """Test the judger functionality with single and multiple data sources."""

--- a/tests/ray/test_rollout.py
+++ b/tests/ray/test_rollout.py
@@ -58,6 +58,7 @@ class TestRollout(unittest.TestCase):
             expert_parallel_size=1,
             gpus_per_node=8, # gpu: 8, npu: 16
             dtype="bfloat16",
+            launch_server_method="ray",
         )
         from xtuner.v1.ray.judger.gsm8k import GSM8KJudgerConfig
         gsm8k_judger_config = GSM8KJudgerConfig(judger_name="openai/gsm8k")
@@ -170,6 +171,7 @@ class TestRollout(unittest.TestCase):
     @unittest.skipIf(os.environ.get("XTUNER_USE_SGLANG", "0") == "0", "lmdeploy backend is not enabled")
     def test_sglang_generate(self):
         from xtuner.v1.ray.rollout import SGLangWorker
+        self.rollout_cfg.launch_server_method="multiprocessing"
         rollout_workers_map = AutoAcceleratorWorkers.from_placement_group(
             SGLangWorker, self.rollout_cfg, self.pg
         )
@@ -183,6 +185,7 @@ class TestRollout(unittest.TestCase):
     @unittest.skipIf(os.environ.get("XTUNER_USE_SGLANG", "0") == "0", "lmdeploy backend is not enabled")
     def test_sglang_dataflow(self):
         self.dataflow_cfg.enable_partial_rollout = 0
+        self.rollout_cfg.launch_server_method="multiprocessing"
         self.test_env = SingleTurnEnvironment.remote(
             "test_env",
             self.pg,

--- a/xtuner/v1/ray/dataflow/replay_buffer.py
+++ b/xtuner/v1/ray/dataflow/replay_buffer.py
@@ -1,27 +1,108 @@
 import itertools
 from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from uuid import uuid4
 
 import ray
 from cyclopts import Parameter
 from pydantic import BaseModel, ConfigDict
+from ray import ObjectRef
 from typing_extensions import Annotated
 
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 from xtuner.v1.data_proto.rl_data import (
-    ReplayMeta,
     RLDataFlowItem,
     RLDatasetItem,
     RLExtraDataItem,
     RLUIDItem,
-    mapping_dataitem_to_replaymeta,
-    mapping_replaymeta_to_dataitem,
 )
 from xtuner.v1.datasets import build_dataloader, build_datasets
 from xtuner.v1.datasets.config import DataloaderConfig
 from xtuner.v1.utils import get_logger
+
+
+@dataclass
+class ReplayMeta:
+    """ReplayMeta aggregates all versions of data related to a single prompt in
+    the replay buffer.
+
+    Attributes:
+        env (str): Name or identifier of the environment.
+        root_id (int): Identifier for grouping related prompts (e.g., for GRPO or multi-turn scenarios).
+        action_id (int): Unique identifier for the prompt. If the prompt changes (such as in a multi-turn scenario), a new action_id is assigned.
+        action_ref (ObjectRef): Ray object reference to the prompt data (corresponds to RLDatasetItem in RLDataFlowItem).
+        observation_ids (List[int]): IDs for different responses to the same prompt. Each response has a unique observation_id.
+        observation_refs (List[ObjectRef]): Ray object references to environment data for each observation (corresponds to RLEnvDataItem in RLDataFlowItem).
+        observation_versions (List[int]): Version numbers for each observation, supporting async rollout.
+        state (str): Overall state of the prompt (e.g., "paused" for partial rollout, or other rollout states).
+        extra_info (Dict[str, Any]): Additional metadata or information.
+    """
+
+    env: str = ""
+    root_id: int = 0
+    action_id: int = 0  # same prompt share the same action_id
+    action_ref: ObjectRef = None
+    observation_ids: List[int] = field(default_factory=list)  # observation IDs for different versions
+    observation_refs: List[ObjectRef] = field(default_factory=list)
+    observation_versions: List[int] = field(default_factory=list)  # reserved for async rollout
+    state: str = ""  # overall state, e.g., for partial rollout
+    extra_info: Dict[str, Any] = field(default_factory=dict)
+
+
+def mapping_dataitem_to_replaymeta(grouped_dataitem: List[RLDataFlowItem]) -> ReplayMeta:
+    assert len(grouped_dataitem) > 0
+
+    env_str = grouped_dataitem[0].uid.env
+    root_id = grouped_dataitem[0].uid.root_id
+    action_id = grouped_dataitem[0].uid.action_id
+    data = grouped_dataitem[0].data
+    observation_ids = []
+    observation_refs = []
+    observation_versions = []
+
+    group_states = []
+    for item in grouped_dataitem:
+        version = item.uid.version
+        observation_ids.append(item.uid.observation_id)
+        observation_refs.append(ray.put(item.env))
+        observation_versions.append(version)
+        group_states.append(item.env.rollout.finish_reason)
+
+    state_str = "paused" if "paused" in group_states else "returned"
+    replay_meta = ReplayMeta(
+        env=env_str,
+        root_id=root_id,
+        action_id=action_id,
+        action_ref=ray.put(data),
+        observation_ids=observation_ids,
+        observation_refs=observation_refs,
+        observation_versions=observation_versions,
+        state=state_str,  # 指代一个prompt的整体状态，用于partial rollout
+        extra_info={},
+    )
+    return replay_meta
+
+
+def mapping_replaymeta_to_dataitem(replay_meta: ReplayMeta) -> List[RLDataFlowItem]:
+    env_str = replay_meta.env
+    root_id = replay_meta.root_id
+    action_id = replay_meta.action_id
+    data_ref = ray.get(replay_meta.action_ref)
+    group_data_item = []
+    for obs_id, obs_ref, version in zip(
+        replay_meta.observation_ids, replay_meta.observation_refs, replay_meta.observation_versions
+    ):
+        env_data = ray.get(obs_ref)
+        item = RLDataFlowItem(
+            uid=RLUIDItem(env=env_str, root_id=root_id, action_id=action_id, observation_id=obs_id, version=version),
+            data=data_ref,
+            env=env_data,
+            extra_info=RLExtraDataItem(),
+        )
+        group_data_item.append(item)
+    return group_data_item
 
 
 class ReplayBufferConfig(BaseModel):

--- a/xtuner/v1/ray/judger/controller.py
+++ b/xtuner/v1/ray/judger/controller.py
@@ -96,6 +96,28 @@ class JudgerController:
         )
         self.logger = get_logger(log_dir=judger_config.worker_log_dir, tag="Judger")
 
+    async def _call_single_reward_judger(self, judger: NativeJudger, group_data_item: List[RLDataFlowItem]):
+        """Call a single custom reward judger to calculate rewards.
+
+        Args:
+            judger (NativeJudger): An instance of a custom judger.
+            responses (List[str]): A list of model-generated responses.
+            labels (List[str]): A list of ground-truth labels.
+
+        Returns:
+            List[RLJudgerResponseItem]: A list of RLJudgerResponseItem containing
+                calculated rewards for each sample.
+        """
+        tasks = []
+        if self.judger_config.enable_batch_reward:
+            task = judger.judge(group_data_item)
+            tasks.append(task)
+        else:
+            for data_item in group_data_item:
+                task = judger.judge([data_item])
+                tasks.append(task)
+        return tasks
+
     async def _call_custom_reward_judger(
         self,
         active_judgers: List[NativeJudger],
@@ -113,39 +135,36 @@ class JudgerController:
             Dict[str, List[float]]: A dictionary where keys are judger names
                 and values are lists of calculated rewards for each sample.
         """
-        results = []
-        if self.judger_config.enable_batch_reward:
-            tasks = [judger.judge(group_data_item) for judger in active_judgers]
-            results = await asyncio.gather(*tasks)
-        else:
-            tasks_per_sample = [
-                [(judger.judge([group_data_item[i]])) for judger in active_judgers]
-                for i in range(len(group_data_item))
-            ]
+        active_judgers_len = len(active_judgers)
+        task_len_list = [0]
+        judger_list = []
+        all_tasks = []
+        for judger in active_judgers:
+            tasks = await self._call_single_reward_judger(judger, group_data_item)
+            all_tasks.extend(tasks)
+            judger_list.append(judger.judger_name)
+            task_len_list.append(task_len_list[-1] + len(tasks))
 
-            flat_tasks_with_names = [task for sample_tasks in tasks_per_sample for task in sample_tasks]
-            results = await asyncio.gather(*flat_tasks_with_names)
+        all_results = await asyncio.gather(*all_tasks)
 
-        import collections.abc
-
-        def flatten(results):
-            for item in results:
-                if isinstance(item, collections.abc.Iterable) and not isinstance(item, (str, bytes, dict)):
-                    yield from item
-                else:
-                    yield item
-
-        flat_results = list(flatten(results))
-        assert len(flat_results) == len(group_data_item) * len(active_judgers), (
-            f"Expected {len(group_data_item) * len(active_judgers)} results, but got {len(flat_results)}"
+        assert len(all_results) == len(group_data_item) * len(active_judgers), (
+            f"Expected {len(group_data_item) * len(active_judgers)} results, but got {len(all_results)}"
         )
-        # 将不同Judger的RLJudgerResponseItem进行组装
+
+        active_judger_results = {}
+        for i in range(active_judgers_len):
+            active_judger_results[judger_list[i]] = all_results[task_len_list[i] : task_len_list[i + 1]]
+
+        # 为每个样本创建一个 RLJudgerResponseItem，不同judger的结果放在同一个item中
         uid_list = [item.uid.observation_id for item in group_data_item]
         judger_response_items_dict = {uid: RLJudgerResponseItem(uid=uid) for uid in uid_list}
-        for result in flat_results:
-            return_uid = result.uid
-            judger_response_items_dict[return_uid].reward.update(result.reward)
-            judger_response_items_dict[return_uid].extra_info.update(result.extra_info)
+        for judger_name, results in active_judger_results.items():
+            for result in results:
+                for data in result:
+                    return_uid = data.uid
+                    judger_response_items_dict[return_uid].reward.update(data.reward)
+                    judger_response_items_dict[return_uid].reward.update({judger_name: data.reward})
+                    judger_response_items_dict[return_uid].extra_info.update(data.extra_info)
         return list(judger_response_items_dict.values())
 
     async def run(
@@ -166,27 +185,25 @@ class JudgerController:
             group_data_item = [group_data_item]
 
         if self.enable_weighted_judgers:
-            # todo: 支持多个judger返回多个value的加权/不加权的逻辑
-            pass
-            # data_source = group_data_item[0].data.data_source
-            # # 如果要使用多个judger并且进行加权打分，则必须在数据集中指定data_source的分数
-            # assert data_source , "No data source found for the given datasets"
-            # judger_names = [judger.judger_name for judger in self.reward_judger]
-            # active_reward_judger = [func for func in self.reward_judger if func.judger_name in data_source]
-            # assert active_reward_judger, (
-            #     f"No active reward judger in {judger_names} found for the given data source {data_source}."
-            # )
-            # judger_response_item = await self._call_custom_reward_judger(active_reward_judger, group_data_item)
-            # judger_return_item = [f"weight_{name}" for name, _ in judger_response_item[0].reward.items()]
-            # for item in judger_response_item:
-            #     final_reward = 0
-            #     for name, weight in data_source.items():
-            #         if name in item.reward:
-            #             final_reward += item.reward[name] * weight
-            #     item.reward["weighted_reward"] = final_reward
+            data_source = group_data_item[0].data.data_source
+            # 如果要使用多个judger并且进行加权打分，则必须在数据集中指定data_source的分数
+            assert data_source, "No data source found for the given datasets when multiple judgers are provided."
+            judger_names = [judger.judger_name for judger in self.reward_judger]
+            active_reward_judger = [func for func in self.reward_judger if func.judger_name in data_source]
+            assert active_reward_judger, (
+                f"No active reward judger in {judger_names} found for the given data source {data_source}."
+            )
+            judger_response_item = await self._call_custom_reward_judger(active_reward_judger, group_data_item)
+
+            # NOTE: 只计算score的加权和
+            for item in judger_response_item:
+                final_reward = 0
+                for name, weight in data_source.items():
+                    if name in item.reward:
+                        final_reward += item.reward[name]["score"] * weight
+                item.reward["weighted_score"] = final_reward
         else:
             judger_response_item = await self._call_custom_reward_judger(self.reward_judger, group_data_item)
-
         if input_type_is_list is False:
             return judger_response_item[0]
         return judger_response_item

--- a/xtuner/v1/ray/rollout/sglang.py
+++ b/xtuner/v1/ray/rollout/sglang.py
@@ -151,6 +151,8 @@ class SGLangWorker(RolloutWorker):
         # note: 非共卡模式下无需设置,共卡模式下需要offload必须设置，否则显存释放不了
         sglang_server_args.enable_memory_saver = True
         sglang_server_args.max_running_requests = int(os.environ.get("XTUNER_MAX_CONCURRENCY", 2000))
+        if "interns1" in self.model_name.lower():
+            sglang_server_args.grammar_backend = "none"
 
         if sglang_server_args.nnodes > 1:
             sglang_server_args.node_rank = self.rank // self.config.gpus_per_node


### PR DESCRIPTION
1. 修复当judger返回为dict时存在多个judger的处理逻辑
2. 移除sft时对ray的依赖
3. 修复rollout ut中，当推理后端为sglang，修改启动方式为multiprocessing
4. 修复sglang启动interns1时，grammer_backend配置为“none”