### PR TITLE
[Fix] add default eos_id to DeepSeekV3Config to avoid pydantic val err

### DIFF
--- a/xtuner/v1/model/moe/deepseek_v3.py
+++ b/xtuner/v1/model/moe/deepseek_v3.py
@@ -53,6 +53,7 @@ class DeepSeekV3Config(MoEConfig):
     vocab_size: int = 129280
     max_position_embeddings: int = 163840
     pad_token_id: int = 1  # eos_id
+    eos_token_id: int = 1
     num_hidden_layers: int = 61
     first_k_dense_replace: int = 3
     max_window_layers: int = 61
@@ -110,6 +111,7 @@ class DeepSeekV3Config(MoEConfig):
             vocab_size=cfg.vocab_size,
             max_position_embeddings=cfg.max_position_embeddings,
             pad_token_id=cfg.eos_token_id,
+            eos_token_id=cfg.eos_token_id,
             num_hidden_layers=cfg.num_hidden_layers,
             first_k_dense_replace=cfg.first_k_dense_replace,
             max_window_layers=cfg.num_hidden_layers,


### PR DESCRIPTION
This PR fixes the following issue:

Currently the default value for eos id in `DeepSeekV3Config` is missing, causing pydantic validation error when building `DeepSeekV3Config` thru either init func or `from_hf`

```bash
----> 1 DeepSeekV3Config()

File /usr/local/lib/python3.12/dist-packages/pydantic/main.py:214, in BaseModel.__init__(self, **data)
    212 # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
    213 __tracebackhide__ = True
--> 214 validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
    215 if self is not validated_self:
    216     warnings.warn(
    217         'A custom validator is returning a value other than `self`.\n'
    218         "Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.\n"
    219         'See the `model_validator` docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.',
    220         stacklevel=2,
    221     )

ValidationError: 1 validation error for Base model config for xtuner
eos_token_id
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
```