### PR TITLE
feat: support import outside loss fn

### DIFF
--- a/xtuner/v1/rl/loss_fn.py
+++ b/xtuner/v1/rl/loss_fn.py
@@ -34,11 +34,10 @@ def get_policy_loss_fn(name):
             try:
                 import importlib
 
-                parsed_packages = loss_name.split(".")
-                package_name = ".".join(parsed_packages[:-1])
-                module_name = parsed_packages[-1]
-                module = importlib.import_module(package_name, module_name)
-                return module
+                package_name, module_name = loss_name.rsplit(".", 1)
+                print(f"Importing loss function from {package_name}.{module_name}")
+                module = importlib.import_module(package_name)
+                return getattr(module, module_name)
             except ImportError as e:
                 raise ImportError(f"Failed to import loss function: {loss_name}, error: {e}")
         raise ValueError(


### PR DESCRIPTION
## usage

define your loss in a project `your_projects.modules.pg_loss.pg_loss_fn`

then set in config:

```python
loss_cfg = GRPOLossConfig(
    policy_loss_cfg=dict(
        cliprange_high=0.28,
        cliprange_low=0.2,
        loss_type="your_projects.modules.pg_loss.pg_loss_fn",
        clip_ratio_c=10.0,
        log_prob_diff_min=-20.0,
        log_prob_diff_max=20.0,
    ),
    ignore_idx=-100,
    use_kl_loss=False,
    kl_loss_coef=0.0,
    kl_loss_type="low_var_kl",
    mode="chunk",
    chunk_size=512,
)
```