### PR TITLE
[Fix] remove excessive warning triggered by configs initialization on non-cuda devices

### DIFF
--- a/xtuner/v1/model/compose/intern_s1/intern_s1_config.py
+++ b/xtuner/v1/model/compose/intern_s1/intern_s1_config.py
@@ -9,7 +9,7 @@ from xtuner.v1.float8 import Float8Config
 from xtuner.v1.model.dense.qwen3 import Qwen3Dense8BConfig
 from xtuner.v1.model.moe.moe import MoEConfig, TransformerConfig
 from xtuner.v1.model.moe.qwen3 import Qwen3MoE235BA22Config
-from xtuner.v1.utils import get_logger
+from xtuner.v1.utils import get_logger, get_device
 
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ class InternS1VisionConfig(BaseModel):
     attn_impl: Literal["flash_attention", "flex_attention", "eager_attention"] = "flash_attention"
 
     def model_post_init(self, _):
-        if not is_installed("flash-attn") and self.attn_impl == "flash_attention":
+        if not is_installed("flash-attn") and self.attn_impl == "flash_attention" and get_device() == "cuda":
             logger.warning("flash-attn is not installed, using `flex_attention` instead.")
             self.attn_impl = "flex_attention"
         return self

--- a/xtuner/v1/model/compose/internvl/internvl_config.py
+++ b/xtuner/v1/model/compose/internvl/internvl_config.py
@@ -7,7 +7,7 @@ from xtuner.v1.float8 import Float8Config
 from xtuner.v1.model.dense.qwen3 import Qwen3Dense0P6BConfig, Qwen3Dense8BConfig
 from xtuner.v1.model.moe.moe import TransformerConfig
 from xtuner.v1.model.moe.qwen3 import Qwen3MoE30BA3Config
-from xtuner.v1.utils import get_logger
+from xtuner.v1.utils import get_logger, get_device
 
 
 if TYPE_CHECKING:
@@ -48,7 +48,7 @@ class InternVLVisionConfig(BaseModel):
     attn_impl: Literal["flash_attention", "flex_attention", "eager_attention"] = "flash_attention"
 
     def model_post_init(self, _):
-        if not is_installed("flash-attn") and self.attn_impl == "flash_attention":
+        if not is_installed("flash-attn") and self.attn_impl == "flash_attention" and get_device() == "cuda":
             logger.warning("flash-attn is not installed, using `flex_attention` instead.")
             self.attn_impl = "flex_attention"
         return self

--- a/xtuner/v1/model/compose/qwen3_vl/qwen3_vl_config.py
+++ b/xtuner/v1/model/compose/qwen3_vl/qwen3_vl_config.py
@@ -10,7 +10,7 @@ from xtuner.v1.model.base import TransformerConfig
 from xtuner.v1.model.dense.qwen3vl_text import Qwen3VLTextDense4BConfig, Qwen3VLTextDense8BConfig
 from xtuner.v1.model.moe.qwen3vl_text import Qwen3VLTextMoE30BA3Config, Qwen3VLTextMoE235BA22Config
 from xtuner.v1.module.rope import RopeScalingConfig
-from xtuner.v1.utils import get_logger
+from xtuner.v1.utils import get_logger, get_device
 
 
 logger = get_logger()
@@ -38,7 +38,7 @@ class Qwen3VLVisionConfig(BaseModel):
     attn_impl: Literal["flash_attention", "flex_attention", "eager_attention"] = "flash_attention"
 
     def model_post_init(self, _):
-        if not is_installed("flash-attn") and self.attn_impl == "flash_attention":
+        if not is_installed("flash-attn") and self.attn_impl == "flash_attention" and get_device() == "cuda":
             logger.warning("flash-attn is not installed, using `flex_attention` instead.")
             self.attn_impl = "flex_attention"
         return self


### PR DESCRIPTION
currently running the code on non-cuda devices (e.g., ascend npus) will trigger the following warning, when in reality npu fused attention is used.

```txt
[XTuner][2025-10-25 18:11:49][WARNING] flash-attn is not installed, using `flex_attention` instead.
[XTuner][2025-10-25 18:11:49][WARNING] flash-attn is not installed, using `flex_attention` instead.
[XTuner][2025-10-25 18:11:49][WARNING] flash-attn is not installed, using `flex_attention` instead.
[XTuner][2025-10-25 18:11:49][WARNING] flash-attn is not installed, using `flex_attention` instead.
[XTuner][2025-10-25 18:11:50][WARNING] flash-attn is not installed, using `flex_attention` instead.
```

this warning is triggered by config initialization triggered by importing methods from `xtuner.v1.model` (see [here](https://github.com/InternLM/xtuner/blob/b39581ac813c6148c27c36da7de0569bf41ed1d9/xtuner/v1/model/__init__.py#L24))