### PR TITLE
[Fix] force max_seqlen q and k into cpu tensors, and fix max_seqlen bc bugs in vl model

### DIFF
--- a/xtuner/v1/model/compose/intern_s1/modeling_vision.py
+++ b/xtuner/v1/model/compose/intern_s1/modeling_vision.py
@@ -86,6 +86,7 @@ class InternS1VisionAttention(nn.Module):
             hidden_states: torch.Tensor
     ):
         batch_size, seq_len, _ = hidden_states.size()
+        seq_len_tensor = torch.tensor(seq_len, device="cpu")
 
         query_states = self.q_proj(hidden_states)
         key_states = self.k_proj(hidden_states)
@@ -107,8 +108,8 @@ class InternS1VisionAttention(nn.Module):
             value_states[None].transpose(1, 2),
             cu_seqlens_q=cu_seq_lens,
             cu_seqlens_k=cu_seq_lens,
-            max_seqlen_q=seq_len,
-            max_seqlen_k=seq_len,
+            max_seqlen_q=seq_len_tensor,
+            max_seqlen_k=seq_len_tensor,
             dropout_p=0.0 if not self.training else self.attention_dropout,
             softmax_scale=self.scale,
             causal=False,

--- a/xtuner/v1/model/compose/qwen3_vl/modeling_vision.py
+++ b/xtuner/v1/model/compose/qwen3_vl/modeling_vision.py
@@ -438,7 +438,7 @@ class Qwen3VLVisionModel(BaseModel):
             dtype=torch.int32,
         )
         cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
-        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
+        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
 
         deepstack_feature_lists = []
         for layer_num, blk in enumerate(self.blocks):


### PR DESCRIPTION
1. force max_length_q and max_length_k in SequenceContext into cpu tensors
2. fix max_length_q and max_length_k type bc (from int change to torch.Tensor) bugs in VL Models