### PR TITLE
[Fix] extra ops is called in _fsdp_state of pytorch2.8

### DIFF
--- a/xtuner/v1/data_proto/sequence_context.py
+++ b/xtuner/v1/data_proto/sequence_context.py
@@ -49,7 +49,7 @@ class SequenceContext:
     num_img_tokens: list[int] | None
 
     # moe routed_experts
-    rollout_routed_experts: torch.LongTensor | None = None
+    rollout_routed_experts: torch.LongTensor | None
 
     def __init__(
         self,


### PR DESCRIPTION
This PR fix extra ops in `SequenceContext.__init__` being called in `_fsdp_state _pre_forward` of pytorch 2.8.
Extra ops is introduced in https://github.com/pytorch/pytorch/blob/v2.8.0/torch/distributed/fsdp/_fully_shard/_fsdp_state.py#L249, and further in https://github.com/pytorch/pytorch/blob/v2.8.0/torch/distributed/utils.py#L227, `dataclasses.replace(x)` would call `x.__init__` in the case of `x` is a dataclass object.

Note: this is a workaround for  SequenceContext, force it not being a dataclass. We should find a way to clean up dataclass object's `__init__` method if it's passed into FSDPModule forward method as a param.