### PR TITLE
Add secret mount for nvidia-nccl HTTPS proxy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,7 +204,8 @@ RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 WORKDIR ${CODESPACE}
 
 # nccl update for torch 2.6.0
-RUN if [ "x${TORCH_VERSION}" = "x2.6.0" ]; then \
+RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
+    if [ "x${TORCH_VERSION}" = "x2.6.0" ]; then \
         pip install nvidia-nccl-cu12==2.25.1 --no-cache-dir; \
     fi
 


### PR DESCRIPTION
When using pytorch 2.6.0, the default nccl version needs to be updated. We add a https_proxy in Dockerfile to speed up install when it's built in special environment.