### PR TITLE
[Fix] Fix inconsistent device in RoPE for npu device

### DIFF
--- a/xtuner/v1/data_proto/sequence_context.py
+++ b/xtuner/v1/data_proto/sequence_context.py
@@ -104,7 +104,7 @@ class SequenceContext:
 
         if position_ids is None:
             _position_ids = [torch.arange(k - q, k) for q, k in zip(seq_lens_q, seq_lens_k)]
-            position_ids = torch.cat(_position_ids).unsqueeze(0).to(self.cu_seq_lens_k.device)  # type: ignore[assignment]
+            position_ids = torch.cat(_position_ids).unsqueeze(0).to(self.device)  # type: ignore[assignment]
 
             if self.sequence_parallel_mesh is not None:
                 position_ids = split_for_sequence_parallel(position_ids, dim=1, sp_mesh=self.sequence_parallel_mesh)  # type: ignore

--- a/xtuner/v1/module/rope/rope.py
+++ b/xtuner/v1/module/rope/rope.py
@@ -94,7 +94,7 @@ class RotaryEmbedding(nn.Module):
         device_type = x.device.type
         device_type = device_type if isinstance(device_type, str) and device_type != "mps" else "cpu"
         with torch.autocast(device_type=device_type, enabled=False):
-            freqs = (inv_freq_expanded.float().to(x.device) @ position_ids_expanded.float()).transpose(
+            freqs = (inv_freq_expanded.float().to(x.device) @ position_ids_expanded.float().to(x.device)).transpose(
                 1, 2
             )  # [B, S, H/2]
             emb = torch.cat((freqs, freqs), dim=-1)  # [B, S, H]


### PR DESCRIPTION
# Issue
## Error
In Ascend NPU devices, running the CI script `ci/scripts/test_sft_trainer_235B.py` alone would trigger a device assertion error in `rope.py`

```bash
 freqs = (inv_freq_expanded.float().to(x.device) @ position_ids_expanded.float()).transpose(
[rank0]:              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[rank0]: RuntimeError: Expected all tensors to be on the same device, but found at least two devices, npu:0 and cpu! 
```

## Reproduction
This error would occur when: 1. run on npu devices, and 2. SP_SIZE is set greater than 1. 

# Cause
For npu devices,  `cu_seq_lens_k` is trasnfered to cpu to fit into torch npu API,
```python
# xtuner/v1/data_proto/sequence_context.py L337
if device == "npu" or isinstance(device, torch.device) and device.type == "npu":
    self.cu_seq_lens_q = self.cu_seq_lens_q.cpu()  # type: ignore
    self.cu_seq_lens_k = self.cu_seq_lens_k.cpu()  # type: ignore
```
and then position_ids is transfered to device of `cu_seq_lens_k` (which is now cpu):

```python
# xtuner/v1/data_proto/sequence_context.py L107
position_ids = torch.cat(_position_ids).unsqueeze(0).to(self.cu_seq_lens_k.device)  # type: ignore[assignment]
```

which would now cause the matmul in RoPE to thow an error.

# Fix
This PR fixes this issue with:
1. an additional `to(x.device)` in RoPE fwd. 
2. change `self.cu_seq_lens_k.device` to `self.device` in `xtuner/v1/data_proto/sequence_context.py L107`.

