### PR TITLE
[Feat] Allow getting the video frame list via video_extra_dict without os.listdir

### DIFF
--- a/xtuner/v1/datasets/mllm_tokenize_fn/intern_s1_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/mllm_tokenize_fn/intern_s1_vl_tokenize_fn.py
@@ -375,7 +375,7 @@ class InternS1VLTokenizeFunction(BaseMLLMTokenizeFunction[InternS1DataItem]):
                 {"data_item": data_item, "video_path": video_path}, self.min_num_frames, self.max_num_frames
             )
             video_path = os.path.join(media_root, video_path)
-            if len(self._video_extra_info_list)>0:
+            if len(self._video_extra_info_list) > 0:
                 video_extra_dict = self._video_extra_info_list[index]
             else:
                 video_extra_dict = None

--- a/xtuner/v1/datasets/mllm_tokenize_fn/intern_s1_vl_utils.py
+++ b/xtuner/v1/datasets/mllm_tokenize_fn/intern_s1_vl_utils.py
@@ -4,7 +4,6 @@ import os
 import random
 import re
 import time
-from pathlib import Path
 from typing import Literal
 
 import cv2
@@ -93,9 +92,9 @@ def read_frames_folder(
     video_extra_dict=None,
 ):
     oss_read_time = 0
-    if video_extra_dict is not None and 'processed_video_length' in video_extra_dict:
-        processed_video_length = video_extra_dict['processed_video_length']
-        image_list = [f"{i:08d}.jpg" for i in range(1,processed_video_length+1,1)]
+    if video_extra_dict is not None and "processed_video_length" in video_extra_dict:
+        processed_video_length = video_extra_dict["processed_video_length"]
+        image_list = [f"{i:08d}.jpg" for i in range(1, processed_video_length + 1, 1)]
         image_list = [os.path.join(video_path, img) for img in image_list]
     else:
         if "s3://" in video_path:

--- a/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_tokenize_fn.py
@@ -715,20 +715,22 @@ class Qwen3VLTokenizeFunction(BaseMLLMTokenizeFunction):
                 timestamps = timestamps_list[i]
 
             video_path = os.path.join(media_root, video_path)
-            if len(self._video_extra_info_list)>0:
+            if len(self._video_extra_info_list) > 0:
                 video_extra_dict = self._video_extra_info_list[i]
             else:
                 video_extra_dict = None
 
             if self.oss_loader is not None:
                 image_list, frame_indices, timestamps = self.oss_loader(
-                    video_path, image_type="video", frames_indices=frames_indices, timestamps=timestamps,
-                    video_extra_dict=video_extra_dict
+                    video_path,
+                    image_type="video",
+                    frames_indices=frames_indices,
+                    timestamps=timestamps,
+                    video_extra_dict=video_extra_dict,
                 )
             else:
                 image_list, frame_indices, timestamps = read_qwen3_vl_video(
-                    video_path, frames_indices=frames_indices, timestamps=timestamps,
-                    video_extra_dict=video_extra_dict
+                    video_path, frames_indices=frames_indices, timestamps=timestamps, video_extra_dict=video_extra_dict
                 )
 
             assert len(image_list) % self.video_processor.merge_size == 0, "num_frames must be divisible by merge_size"

--- a/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_utils.py
+++ b/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_utils.py
@@ -3,7 +3,6 @@ import io
 import os
 import re
 import time
-from pathlib import Path
 from typing import Literal
 
 import numpy as np
@@ -76,11 +75,17 @@ def calc_frame_index_for_folder(image_list, frames_indices, timestamps, video_pa
     return frames_indices
 
 
-def read_frames_folder(video_path, frames_indices, timestamps=None, client=None,video_extra_dict=None,):
+def read_frames_folder(
+    video_path,
+    frames_indices,
+    timestamps=None,
+    client=None,
+    video_extra_dict=None,
+):
     oss_read_time = 0
-    if video_extra_dict is not None and 'processed_video_length' in video_extra_dict:
-        processed_video_length = video_extra_dict['processed_video_length']
-        image_list = [f"{i:08d}.jpg" for i in range(1,processed_video_length+1,1)]
+    if video_extra_dict is not None and "processed_video_length" in video_extra_dict:
+        processed_video_length = video_extra_dict["processed_video_length"]
+        image_list = [f"{i:08d}.jpg" for i in range(1, processed_video_length + 1, 1)]
         image_list = [os.path.join(video_path, img) for img in image_list]
     else:
         if "s3://" in video_path:
@@ -167,7 +172,10 @@ def read_qwen3_vl_video(
     video_get_batch_time = 0
     if path.endswith("/"):
         frames, oss_read_time, vlen, frame_indices, timestamps = read_frames_folder(
-            path, frames_indices, timestamps, client=client,
+            path,
+            frames_indices,
+            timestamps,
+            client=client,
             video_extra_dict=video_extra_dict,
         )
     elif path.endswith(".gif"):
@@ -213,7 +221,7 @@ class Qwen3VLOSSLoader:
         self.debug = debug
         self.oss_time_log_thr = oss_time_log_thr
 
-    def __call__(self, path, image_type="image", frames_indices=None, timestamps=None,video_extra_dict=None):
+    def __call__(self, path, image_type="image", frames_indices=None, timestamps=None, video_extra_dict=None):
         if image_type == "image":
             start_time = time.time()
             img_value_str = self.client.get(path)


### PR DESCRIPTION
#### Motivation
Loading frames from a pre-processed video folder currently requires `os.listdir` + `sort_frames`. When the folder is large this imposes unnecessary overhead.

#### Changes
- commit 1: Add an optional video_extra_dict argument. If provided, directory listing is skipped and the frame list is built
using `processed_video_length` only. 
[IMPORTANT] By this way, preprocessed video frames must be stored as zero-padded 8-digit .jpg files (for example 00000001.jpg, 00000002.jpg, ...).

- commit 2: Replace `Path(path).is_dir` with a simple suffix check, because Path does not support S3-style folder URIs