### PR TITLE
[Enhance] Add `ray_method` decorator to decorate remote method

### DIFF
--- a/xtuner/v1/ray/dataflow/__init__.py
+++ b/xtuner/v1/ray/dataflow/__init__.py
@@ -1,2 +1,2 @@
-from .flow import DataFlow, DataFlowConfig
+from .flow import DataFlow, DataFlowConfig, DataFlowProxy
 from .replay_buffer import ReplayBuffer, ReplayBufferConfig

--- a/xtuner/v1/ray/environment/__init__.py
+++ b/xtuner/v1/ray/environment/__init__.py
@@ -1,2 +1,2 @@
 from .base_env import BaseEnvironment
-from .single_turn_env import SingleTurnEnvironment
+from .single_turn_env import SingleTurnEnvironment, SingleTurnEnvironmentProxy

--- a/xtuner/v1/ray/environment/base_env.py
+++ b/xtuner/v1/ray/environment/base_env.py
@@ -5,6 +5,7 @@ from typing import Any, List
 import ray
 
 from xtuner.v1.data_proto.rl_data import RLDataFlowItem
+from xtuner.v1.utils import ray_method
 
 
 class BaseEnvironment(ABC):
@@ -99,6 +100,7 @@ class BaseEnvironment(ABC):
         return judger_controller
 
     @abstractmethod
+    @ray_method
     async def generate(
         self, data: List[RLDataFlowItem], sample_params: Any, extra_params: Any
     ) -> List[RLDataFlowItem]:
@@ -116,6 +118,7 @@ class BaseEnvironment(ABC):
         pass
 
     @abstractmethod
+    @ray_method
     async def run(self, data: List[RLDataFlowItem], sample_params: Any, extra_params: Any) -> List[RLDataFlowItem]:
         """Executes a full cycle of generation and interpretation, such as
         generating a response and then evaluating it with a judger. This method
@@ -149,6 +152,7 @@ class BaseEnvironment(ABC):
             return ray.get(getattr(self.rollout_controller, method_name).remote())
         return getattr(self.rollout_controller, method_name).remote()
 
+    @ray_method
     def pause(self, block=True) -> None:
         """Pauses the rollout workers.
 
@@ -157,6 +161,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("pause", block)
 
+    @ray_method
     def shutdown(self, block=True) -> None:
         """Shuts down the rollout workers.
 
@@ -165,6 +170,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("shutdown", block)
 
+    @ray_method
     def restart(self, block=True) -> None:
         """Restarts the rollout workers.
 
@@ -173,6 +179,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("restart", block)
 
+    @ray_method
     def get_rollout_info(self, block=True) -> dict[str, Any]:
         """Gets information about the rollout workers.
 
@@ -181,6 +188,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("get_rollout_info", block)
 
+    @ray_method
     def onload_weights(self, block=True) -> None:
         """Loads weights onto the rollout workers.
 
@@ -189,6 +197,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("onload_weights", block)
 
+    @ray_method
     def onload_kvcache(self, block=True) -> str:
         """Loads the KV cache onto the rollout workers.
 
@@ -197,6 +206,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("onload_kvcache", block)
 
+    @ray_method
     def offload(self, block=True) -> str:
         """Offloads weights and the KV cache from the rollout workers.
 
@@ -205,6 +215,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("offload", block)
 
+    @ray_method
     def update_active_workers(self, block=True) -> None:
         """Checks the status of active rollout workers.
 
@@ -213,6 +224,7 @@ class BaseEnvironment(ABC):
         """
         return self._call_rollout_func("update_active_workers", block)
 
+    @ray_method
     def get_rollout_stats(self, block=True) -> dict[str, Any]:
         """Gets statistics from the rollout workers.
 

--- a/xtuner/v1/ray/evaluator.py
+++ b/xtuner/v1/ray/evaluator.py
@@ -1,10 +1,11 @@
 import asyncio
 from pathlib import Path
-from typing import Callable, List, Optional, Sized, Union
+from typing import Callable, List, Optional, Sized, TypeVar, Union
 
 import ray
 from cyclopts import Parameter
 from pydantic import BaseModel, ConfigDict
+from ray.actor import ActorProxy
 from tqdm.auto import tqdm
 from typing_extensions import Annotated
 
@@ -15,6 +16,11 @@ from xtuner.v1.datasets.config import DataloaderConfig, DatasetConfigList
 from xtuner.v1.ray.environment import BaseEnvironment
 from xtuner.v1.ray.utils import create_task
 from xtuner.v1.utils import get_logger
+from xtuner.v1.utils.type_helper import ray_method
+
+
+T = TypeVar("T")
+Ret = TypeVar("Ret")
 
 
 class EvaluatorConfig(BaseModel):
@@ -106,8 +112,7 @@ class EvaluatorConfig(BaseModel):
     worker_log_dir: Annotated[Path, Parameter(help="Directory to save worker logs.")] = Path.cwd() / "work_dir"
 
 
-@ray.remote
-class Evaluator:
+class RawEvaluator:
     """A Ray actor for evaluating a model's performance on a given dataset.
 
     The Evaluator generates responses using an environment controller or rollout controller, then it use default or
@@ -241,6 +246,7 @@ class Evaluator:
 
         self.logger.info(ray.get(self.env_controller.get_rollout_stats.remote()))  # type: ignore[attr-defined]
 
+    @ray_method
     async def run(self, return_samples=False):
         """Run the full evaluation process.
 
@@ -269,3 +275,7 @@ class Evaluator:
         if return_samples:
             return scores, self.eval_samples
         return scores
+
+
+Evaluator = ray.remote(RawEvaluator)
+EvaluatorProxy = ActorProxy[RawEvaluator]

--- a/xtuner/v1/rl/base/__init__.py
+++ b/xtuner/v1/rl/base/__init__.py
@@ -1,10 +1,13 @@
-from .controller import TrainingController
+from .controller import TrainingController, TrainingControllerProxy
 from .loss import BaseRLLossConfig, RLLossContextInputItem
-from .worker import TrainingWorker, WorkerConfig
+from .worker import TrainingWorker, TrainingWorkerClass, TrainingWorkerProxy, WorkerConfig
 
 
 __all__ = [
     "TrainingController",
+    "TrainingControllerProxy",
+    "TrainingWorkerClass",
+    "TrainingWorkerProxy",
     "TrainingWorker",
     "WorkerConfig",
     "BaseRLLossConfig",

--- a/xtuner/v1/rl/base/controller.py
+++ b/xtuner/v1/rl/base/controller.py
@@ -3,9 +3,11 @@ from typing import Literal, TypedDict
 
 import ray
 import torch
+from ray.actor import ActorProxy
 
 from xtuner.v1.data_proto.sequence_context import SequenceContext
 from xtuner.v1.engine.vision_compose_train_engine import VisionComposeConfigProtocol
+from xtuner.v1.utils import ray_method
 
 from .worker import TrainingWorker
 
@@ -17,8 +19,7 @@ class ColateItem(TypedDict):
     rollout_logprobs: torch.Tensor | None
 
 
-@ray.remote
-class TrainingController:
+class RawTrainingController:
     def __init__(self, workers: list[TrainingWorker]) -> None:
         self.workers = workers
 
@@ -162,6 +163,7 @@ class TrainingController:
         # 排序后这条 pack 会被放在最前面，导致 rank0 的第一个 step 消耗的有效 token 数往往少于其他 rank，是正常现象。
         return sorted(packed_data_batches, key=lambda x: x["seq_ctx"].max_length_q, reverse=True)
 
+    @ray_method
     def fit(self, data_batches: list[ColateItem], pack_max_length: int, rollout_idx: int):
         has_rollout_routed_experts = False
         language_cfg = None
@@ -255,6 +257,7 @@ class TrainingController:
             )
         ray.get(handles)
 
+    @ray_method
     def offload(self, target: Literal["model", "optimizer", "all"] = "all"):
         if target == "model":
             ray.get([worker.offload_model.remote() for worker in self.workers])  # type: ignore
@@ -265,6 +268,7 @@ class TrainingController:
             ray.get([worker.offload_optimizer.remote() for worker in self.workers])  # type: ignore
         return
 
+    @ray_method
     def onload(self, target: Literal["model", "optimizer", "all"] = "all"):
         """Onload the model or optimizer of the training workers."""
         if target == "model":
@@ -276,16 +280,27 @@ class TrainingController:
             ray.get([worker.onload_optimizer.remote() for worker in self.workers])  # type: ignore
         return
 
+    @ray_method
     def update_rollout_info(self, info_dict):
         ray.get([worker.update_rollout_info.remote(**info_dict) for worker in self.workers])  # type: ignore[attr-defined]
 
+    @ray_method
     def update_weights(self):
         """Update the weights of the training workers."""
         handles = [worker.update_weights.remote() for worker in self.workers]
         ray.get(handles)
         return
 
+    @ray_method
     def save_hf(self, hf_dir: str, save_dtype: torch.dtype = torch.bfloat16):
         handles = [worker.save_hf.remote(hf_dir, save_dtype) for worker in self.workers]  # type: ignore
         ray.get(handles)
         return
+
+    @ray_method
+    def ready(self) -> bool:
+        return True
+
+
+TrainingController = ray.remote(RawTrainingController)
+TrainingControllerProxy = ActorProxy[RawTrainingController]

--- a/xtuner/v1/utils/__init__.py
+++ b/xtuner/v1/utils/__init__.py
@@ -11,7 +11,7 @@ from .misc import XTUNER_DETERMINISTIC, SharedMemory, get_padding_length, is_hf_
 from .pad import pad_to_max_length, pad_to_multiple_of
 from .profile import profile_time_and_memory, timer, timer_logger
 from .state import ForwardState
-from .type_helper import copy_method_signature, copy_signature
+from .type_helper import copy_method_signature, copy_signature, ray_method
 from .update_weights_utils import monkey_unpatch_torch_reductions
 
 
@@ -45,4 +45,5 @@ __all__ = [
     "default_init_weights",
     "IGNORE_INDEX",
     "monkey_unpatch_torch_reductions",
+    "ray_method",
 ]

--- a/xtuner/v1/utils/type_helper.py
+++ b/xtuner/v1/utils/type_helper.py
@@ -1,6 +1,10 @@
-from typing import Callable, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, ParamSpec, TypeVar, overload
 
 from typing_extensions import Concatenate
+
+
+if TYPE_CHECKING:
+    from ray import ObjectRef
 
 
 P = ParamSpec("P")
@@ -20,3 +24,23 @@ def copy_method_signature(f: Callable[Concatenate[C, P], T]):
         return func
 
     return identity
+
+
+class RemoteMethod(Generic[P, T]):
+    def remote(self, *args: P.args, **kwargs: P.kwargs) -> "ObjectRef[T]": ...
+
+    def bind(self, *args: P.args, **kwargs: P.kwargs) -> Any: ...
+
+
+@overload
+def ray_method(f: Callable[Concatenate[C, P], Awaitable[T]]) -> RemoteMethod[P, T]: ...
+
+
+@overload
+def ray_method(f: Callable[Concatenate[C, P], T]) -> RemoteMethod[P, T]: ...
+
+
+def ray_method(f):
+    import ray
+
+    return ray.method(f)  # type: ignore[ret-type]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #1350
* __->__ #1349
* #1348

The decorator `ray.method` has drawback like this:
https://github.com/ray-project/ray/issues/59303

Therefore implement `ray_method` to replace `ray.method`

1. Using `ray_method` to decorate `DataFlow`
2. Using `ray_method` to decorate enviroment
3. Using `ray_method` to decorate evaluator
4. Using `ray_method` to decorate trainer and worker