### PR TITLE
money patch hf modules cache at first of main

### DIFF
--- a/xtuner/v1/train/cli/sft.py
+++ b/xtuner/v1/train/cli/sft.py
@@ -8,6 +8,7 @@ from cyclopts.group import Group
 from xtuner.v1.train.arguments import TrainingArguments
 from xtuner.v1.train.trainer import Trainer
 from xtuner.v1.utils import Config
+from xtuner.v1.utils.misc import monkey_patch_hf_modules_cache
 
 
 app = App(
@@ -23,6 +24,8 @@ def main(
         TrainingArguments | None, Parameter(group=Group("Training Arguments", sort_key=1), name="*")
     ] = None,
 ):
+    monkey_patch_hf_modules_cache()
+
     if arguments is not None:
         if config is not None:
             raise ValueError("Cannot specify both `config` and `arguments`.")

--- a/xtuner/v1/train/trainer.py
+++ b/xtuner/v1/train/trainer.py
@@ -58,7 +58,6 @@ from xtuner.v1.utils.internal_metrics import (
     InternalMetricsRecorder,
     flatten_internal_metrics_for_logs,
 )
-from xtuner.v1.utils.misc import monkey_patch_hf_modules_cache
 
 from .toy_tokenizer import UTF8ByteTokenizer
 
@@ -1736,7 +1735,6 @@ class Trainer:
     def _setup_env(self):
         if os.getenv("XTUNER_GC_ENABLE", "0") == "0":
             gc.disable()
-        monkey_patch_hf_modules_cache()
         os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
         log_str = "\n============XTuner Training Environment============\n"


### PR DESCRIPTION
If user use hf remote code in `config.py` (for example, use `get_model_config_from_hf`) , we cannot patch it in `Trainer.__init__`.
So we must patch at first of main to handle such cases.