### PR TITLE
[Fix] fix vision model type error on npu_device

### DIFF
--- a/xtuner/v1/ops/others.py
+++ b/xtuner/v1/ops/others.py
@@ -9,7 +9,7 @@ def native_dropout(input: Tensor, p: float, training: bool, inplace: bool) -> Te
 def npu_dropout(input: Tensor, p: float, training: bool, inplace: bool) -> Tensor:
     import torch_npu
 
-    return torch_npu._npu_dropout(input, p)
+    return torch_npu._npu_dropout(input, p)[0]  # _npu_dropout returns a tuple
 
 
 def get_dropout():


### PR DESCRIPTION
Currently if you run a vision model using xtuner on npu_device, the following error will be thrown:

```
 TypeError: layer_norm(): argument 'input' (position 1) must be Tensor, not tuple 
```

This is bc the codebase patches Vision Embedding with npu dropout API, which actually returns a tuple `(output, mask)`
 instead of a tensor as in standard PyTorch API does. This PR fixes this issue.  
