### PR TITLE
[Feat] support NativeJudger as Ray actor with cpu resources

### DIFF
--- a/tests/ray/test_evaluator.py
+++ b/tests/ray/test_evaluator.py
@@ -65,7 +65,7 @@ class TestEvaluator(unittest.TestCase):
             "test_env",
             self.pg,
             self.rollout_cfg,
-            self.pg,
+            None,
             self.judger_cfg
         )
         self.sample_params = SampleParams(

--- a/xtuner/v1/ray/environment/base_env.py
+++ b/xtuner/v1/ray/environment/base_env.py
@@ -36,7 +36,7 @@ class BaseEnvironment(ABC):
         rollout_controller=None,
         judger_controller=None,
     ):
-        judger_pg = judger_pg if judger_pg else rollout_pg
+        # judger_pg = judger_pg if judger_pg else rollout_pg
         self.environment = environment
         if rollout_controller:
             self.rollout_controller = rollout_controller

--- a/xtuner/v1/ray/judger/controller.py
+++ b/xtuner/v1/ray/judger/controller.py
@@ -100,9 +100,13 @@ class JudgerController:
             ray.get([defaule_placement_group.ready()], timeout=PG_READY_TIMEOUT)
             self.pg = defaule_placement_group
         else:
+            assert len(pg.bundle_specs) >= sum(
+                config.num_ray_actors for config in self.judger_config.reward_judger_configs
+            ), "The provided placement group does not have enough bundles for all judger actors."
             self.pg = pg
         self.reward_judger: List[List[ray.actor.ActorHandle]] = []
         self.judger_instance_count = 0
+
         for idx, config in enumerate(self.judger_config.reward_judger_configs):
             # start_bundle_idx用于指定从placement group的哪个bundle开始分配资源
             judger = config.build_actor(pg=self.pg, start_bundle_idx=self.judger_instance_count)

--- a/xtuner/v1/ray/judger/controller.py
+++ b/xtuner/v1/ray/judger/controller.py
@@ -1,16 +1,18 @@
 import asyncio
+import random
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import ray
 from cyclopts import Parameter
 from pydantic import BaseModel, ConfigDict
+from ray.util.placement_group import PlacementGroup, placement_group
 from typing_extensions import Annotated
 
 from xtuner.v1.data_proto.rl_data import RLDataFlowItem, RLJudgerResponseItem
-from xtuner.v1.utils import get_logger
 
-from .native import NativeJudger
+
+PG_READY_TIMEOUT = 30
 
 
 class JudgerConfig(BaseModel):
@@ -79,7 +81,7 @@ class JudgerConfig(BaseModel):
 class JudgerController:
     """Controller for judging model outputs and calculating rewards."""
 
-    def __init__(self, judger_config: JudgerConfig, placement_group=None):
+    def __init__(self, judger_config: JudgerConfig, pg: Optional[PlacementGroup] = None):
         """Initialize the JudgerController.
 
         Args:
@@ -90,16 +92,30 @@ class JudgerController:
         self.judger_config = judger_config
         # note: placement_group is used to control the placement of Ray tasks.
         # It will be implemented when gpu judger is needed
-        self.placement_group = placement_group
-        self.reward_judger = []
-        for config in self.judger_config.reward_judger_configs:
-            self.reward_judger.append(config.build())
+        if pg is None:
+            assert len(self.judger_config.reward_judger_configs) == 1, (
+                "If no placement group is provided, there should be only one judger config."
+            )
+            defaule_placement_group = placement_group(bundles=[{"CPU": 1, "memory": 1024**3}], strategy="PACK")
+            ray.get([defaule_placement_group.ready()], timeout=PG_READY_TIMEOUT)
+            self.pg = defaule_placement_group
+        else:
+            self.pg = pg
+        self.reward_judger: List[List[ray.actor.ActorHandle]] = []
+        self.judger_instance_count = 0
+        for idx, config in enumerate(self.judger_config.reward_judger_configs):
+            # start_bundle_idx用于指定从placement group的哪个bundle开始分配资源
+            judger = config.build_actor(pg=self.pg, start_bundle_idx=self.judger_instance_count)
+            # 同一类judger可能会有多个实例（例如多个Ray actor）,同一类的judger作为一行
+            self.reward_judger.append(judger)
+            self.judger_instance_count += len(judger)
         self.enable_weighted_judgers = (
             False if len(self.reward_judger) == 1 else self.judger_config.enable_weighted_judgers
         )
-        self.logger = get_logger(log_dir=judger_config.worker_log_dir, tag="Judger")
 
-    async def _call_single_reward_judger(self, judger: NativeJudger, group_data_item: List[RLDataFlowItem]):
+    async def _call_single_reward_judger(
+        self, judger: List[ray.actor.ActorHandle], group_data_item: List[RLDataFlowItem]
+    ):
         """Call a single custom reward judger to calculate rewards.
 
         Args:
@@ -112,18 +128,20 @@ class JudgerController:
                 calculated rewards for each sample.
         """
         tasks = []
+        judger_input_data = (
+            [group_data_item] if self.judger_config.enable_batch_reward else [[item] for item in group_data_item]
+        )
+
         if self.judger_config.enable_batch_reward:
-            task = judger.judge(group_data_item)
-            tasks.append(task)
+            # Randomly pick a judger instance for batch evaluation to balance the load.
+            tasks.append(random.choice(judger).judge.remote(group_data_item))
         else:
-            for data_item in group_data_item:
-                task = judger.judge([data_item])
-                tasks.append(task)
+            tasks.extend([judger[idx % len(judger)].judge.remote(item) for idx, item in enumerate(judger_input_data)])
         return tasks
 
     async def _call_custom_reward_judger(
         self,
-        active_judgers: List[NativeJudger],
+        active_judgers: List[List[ray.actor.ActorHandle]],
         group_data_item: List[RLDataFlowItem],
     ) -> List[RLJudgerResponseItem]:
         """Call custom reward judgers to calculate rewards.
@@ -145,7 +163,7 @@ class JudgerController:
         for judger in active_judgers:
             tasks = await self._call_single_reward_judger(judger, group_data_item)
             all_tasks.extend(tasks)
-            judger_list.append(judger.judger_name)
+            judger_list.append(ray.get(judger[0].get_judger_name.remote()))
             task_len_list.append(task_len_list[-1] + len(tasks))
 
         all_results = await asyncio.gather(*all_tasks)
@@ -191,8 +209,13 @@ class JudgerController:
             data_source = group_data_item[0].data.data_source
             # 如果要使用多个judger并且进行加权打分，则必须在数据集中指定data_source的分数
             assert data_source, "No data source found for the given datasets when multiple judgers are provided."
-            judger_names = [judger.judger_name for judger in self.reward_judger]
-            active_reward_judger = [func for func in self.reward_judger if func.judger_name in data_source]
+            judger_names = []
+            active_reward_judger = []
+            for judger in self.reward_judger:
+                judger_name = ray.get(judger[0].get_judger_name.remote())
+                judger_names.append(judger_name)
+                if judger_name in data_source:
+                    active_reward_judger.append(judger)
             assert active_reward_judger, (
                 f"No active reward judger in {judger_names} found for the given data source {data_source}."
             )

--- a/xtuner/v1/ray/judger/geo3k.py
+++ b/xtuner/v1/ray/judger/geo3k.py
@@ -1,6 +1,5 @@
 import re
-
-from pydantic import BaseModel, ConfigDict
+from typing import Callable
 
 
 try:
@@ -9,7 +8,7 @@ except Exception:
     extract_boxed_content = None
     grade_answer = None
 
-from .native import NativeJudger
+from .native import NativeJudgerConfig
 
 
 def format_reward(predict_str: str) -> float:
@@ -36,17 +35,9 @@ def compute_reward(response, label, extra_info) -> dict:
     return {"score": score, "acc": acc}
 
 
-class GEO3KJudgerConfig(BaseModel):
+class GEO3KJudgerConfig(NativeJudgerConfig):
     """Configuration for the GEO3K judger."""
 
     judger_name: str = "hiyouga/geometry3k"
     extra_info: dict = {"format_score": 0.1, "use_boxed": True}
-    model_config = ConfigDict(extra="forbid")
-
-    def build(self):
-        """Build a NativeJudger instance from the configuration.
-
-        Returns:
-            NativeJudger: An instance of the NativeJudger configured for GEO3K.
-        """
-        return NativeJudger(judger_name=self.judger_name, reward_func=compute_reward, extra_info=self.extra_info)
+    reward_func: Callable = compute_reward

--- a/xtuner/v1/ray/judger/gsm8k.py
+++ b/xtuner/v1/ray/judger/gsm8k.py
@@ -1,8 +1,7 @@
 import re
+from typing import Callable
 
-from pydantic import BaseModel, ConfigDict
-
-from .native import NativeJudger
+from .native import NativeJudgerConfig
 
 
 _SOLUTION_CLIP_CHARS = 300
@@ -78,17 +77,9 @@ def compute_reward(response, label, extra_info):
             return {"score": extra_info["format_score"]}
 
 
-class GSM8KJudgerConfig(BaseModel):
+class GSM8KJudgerConfig(NativeJudgerConfig):
     """Configuration for the GSM8K judger."""
 
     judger_name: str = "openai/gsm8k"
-    model_config = ConfigDict(extra="forbid")
     extra_info: dict = {"score": 1, "format_score": 0}
-
-    def build(self):
-        """Build a NativeJudger instance from the configuration.
-
-        Returns:
-            NativeJudger: An instance of the NativeJudger configured for GSM8K.
-        """
-        return NativeJudger(judger_name=self.judger_name, reward_func=compute_reward, extra_info=self.extra_info)
+    reward_func: Callable = compute_reward

--- a/xtuner/v1/ray/judger/native.py
+++ b/xtuner/v1/ray/judger/native.py
@@ -2,9 +2,63 @@ import inspect
 from typing import Any, Callable, List, Optional
 
 import httpx
+import ray
+from pydantic import BaseModel
+from ray.util.placement_group import PlacementGroup
 
 from xtuner.v1.data_proto.rl_data import RLDataFlowItem, RLJudgerResponseItem
 from xtuner.v1.utils import get_logger
+
+
+class NativeJudgerConfig(BaseModel):
+    """Base configuration class for judgers."""
+
+    model_config = {"arbitrary_types_allowed": True}
+    judger_name: str
+    num_ray_actors: int = 1
+    reward_func: Optional[Callable] = None
+    remote_url: Optional[str] = None
+    preprocess_func: Optional[Callable] = None
+    postprocess_func: Optional[Callable] = None
+    request_timeout: float = 30.0
+    extra_info: dict = {}
+
+    def build_actor(self, pg: PlacementGroup, start_bundle_idx: int) -> List[ray.actor.ActorClass]:
+        """Create and launch Ray actor instances for the GSM8K judger.
+
+        This method instantiates multiple NativeJudger Ray actors according to `num_ray_actors`,
+        assigning each to a specific bundle in the provided placement group for resource isolation.
+        Each actor is initialized with the judger's configuration and reward function.
+
+        Args:
+            pg: The Ray PlacementGroup used to allocate resources for the actors.
+            start_bundle_idx: The starting bundle index in the placement group for actor placement.
+
+        Returns:
+            List[ActorClass]: A list of Ray actor handles representing the launched judger workers.
+        """
+        workers_list = []
+        pg_options = {"num_cpus": pg.bundle_specs[0].get("CPU", 1)}
+        for idx in range(self.num_ray_actors):
+            worker = (
+                ray.remote(NativeJudger)
+                .options(
+                    placement_group=pg,
+                    placement_group_bundle_index=(start_bundle_idx + idx),
+                    **pg_options,
+                )
+                .remote(
+                    judger_name=self.judger_name,
+                    reward_func=self.reward_func,
+                    remote_url=self.remote_url,
+                    preprocess_func=self.preprocess_func,
+                    postprocess_func=self.postprocess_func,
+                    request_timeout=self.request_timeout,
+                    extra_info=self.extra_info,
+                )
+            )
+            workers_list.append(worker)
+        return workers_list
 
 
 class NativeJudger:
@@ -67,7 +121,6 @@ class NativeJudger:
         elif self.remote_url:
             self.http_client = httpx.AsyncClient(timeout=request_timeout)
             self.execute_func = self._remote_executor
-        self.logger = get_logger(__name__)
 
     def _default_preprocess(self, data_item: List[RLDataFlowItem], extra_info: dict) -> Any:
         """Default preprocessing function.
@@ -155,7 +208,7 @@ class NativeJudger:
             # transform json to RLJudgerResponseItem
             return self.postprocess_func(json_result)
         except httpx.RequestError as exc:
-            self.logger.error(f"An error occurred while requesting {exc.request.url}: {exc}")
+            get_logger().error(f"An error occurred while requesting {exc.request.url}: {exc}")
             return []
 
     async def judge(self, data_item: List[RLDataFlowItem]) -> List[RLJudgerResponseItem]:
@@ -175,3 +228,11 @@ class NativeJudger:
         if self.execute_func is None:
             raise RuntimeError("Judger is not properly initialized.")
         return await self.execute_func(data_item)
+
+    def get_judger_name(self) -> str:
+        """Get the name of the judger.
+
+        Returns:
+            str: The name of the judger.
+        """
+        return self.judger_name

--- a/xtuner/v1/ray/judger/native.py
+++ b/xtuner/v1/ray/judger/native.py
@@ -38,13 +38,14 @@ class NativeJudgerConfig(BaseModel):
             List[ActorClass]: A list of Ray actor handles representing the launched judger workers.
         """
         workers_list = []
-        pg_options = {"num_cpus": pg.bundle_specs[0].get("CPU", 1)}
         for idx in range(self.num_ray_actors):
+            bundle_idx = start_bundle_idx + idx
+            pg_options = {"num_cpus": pg.bundle_specs[bundle_idx].get("CPU", 1)}
             worker = (
                 ray.remote(NativeJudger)
                 .options(
                     placement_group=pg,
-                    placement_group_bundle_index=(start_bundle_idx + idx),
+                    placement_group_bundle_index=bundle_idx,
                     **pg_options,
                 )
                 .remote(

--- a/xtuner/v1/ray/rollout/lmdeploy.py
+++ b/xtuner/v1/ray/rollout/lmdeploy.py
@@ -231,8 +231,8 @@ class LMDeployWorker(RolloutWorker):
         max_batch_size = self.config.rollout_max_batch_size_per_instance // dp_size
         distributed_executor_backend = lmdeploy_config_kwargs.get("distributed_executor_backend", "ray")
         lmdeploy_config_kwargs["log_level"] = lmdeploy_config_kwargs.pop("log_level", "WARNING")
-        lmdeploy_config_kwargs["uvicorn_log_level"] = lmdeploy_config_kwargs.pop("uvicorn_log_level", "CRITICAL")
-        lmdeploy_config_kwargs["tm_log_level"] = lmdeploy_config_kwargs.pop("tm_log_level", "CRITICAL")
+        lmdeploy_config_kwargs["uvicorn_log_level"] = lmdeploy_config_kwargs.pop("uvicorn_log_level", "ERROR")
+        lmdeploy_config_kwargs["tm_log_level"] = lmdeploy_config_kwargs.pop("tm_log_level", "ERROR")
 
         extra_engine_config = {}
         if backend == "pytorch" and self.config.enable_return_routed_experts:

--- a/xtuner/v1/ray/rollout/worker.py
+++ b/xtuner/v1/ray/rollout/worker.py
@@ -517,7 +517,7 @@ class RolloutWorker(SingleAcceleratorWorker):
                         finish_reason=finish_reason,
                         logprobs=last_logprobs,
                         extra_info=extra_info,
-                        state=RolloutState.COMPLETED if finish_reason == "abort" else RolloutState.COMPLETED,
+                        state=RolloutState.ABORTED if finish_reason == "abort" else RolloutState.COMPLETED,
                     )
                 return rollout_response
             except KeyError as e:

--- a/xtuner/v1/utils/rl_test_utils.py
+++ b/xtuner/v1/utils/rl_test_utils.py
@@ -2,7 +2,7 @@ import json
 import multiprocessing
 import os
 import time
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import httpx
 import requests
@@ -10,7 +10,7 @@ import uvicorn
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
-from xtuner.v1.ray.judger.native import NativeJudger
+from xtuner.v1.ray.judger.native import NativeJudgerConfig
 
 # try:
 from xtuner.v1.ray.rollout.lmdeploy import LMDeployWorker
@@ -167,16 +167,8 @@ def custom_postprocessor_for_gsm8k(result):
     return judger_response_item
 
 
-class GSM8KRemoteJudgerConfig(BaseModel):
+class GSM8KRemoteJudgerConfig(NativeJudgerConfig):
     judger_name: str
     remote_url: str
     extra_info: dict = {"score": 1, "format_score": 0}
-    model_config = ConfigDict(extra="forbid")
-
-    def build(self):
-        return NativeJudger(
-            judger_name=self.judger_name,
-            remote_url=self.remote_url,
-            postprocess_func=custom_postprocessor_for_gsm8k,
-            extra_info=self.extra_info,
-        )
+    postprocess_func: Callable = custom_postprocessor_for_gsm8k


### PR DESCRIPTION
**Key Changes:**
- Change NativeJudger and CustomJudger to Ray Actor with cpu resources for compute judger task and support construct multi judger instance. 
- Add NativeJudgerConfig for custom judger config and provide build_actor() method

**Example for creating judger as ray actor:**
````python
from xtuner.v1.ray.judger.controller import JudgerController, JudgerConfig
from xtuner.v1.ray.judger.gsm8k import GSM8KJudgerConfig
from xtuner.v1.ray.base import AutoCPUWorkers, CPUResourcesConfig

# 1. Configure the judger. Here we use GSM8KJudger with 16 parallel actors.
gsm8k_judger_config = GSM8KJudgerConfig(judger_name="openai/gsm8k", num_ray_actors=16)

# 2. Add judger configurations to the main JudgerConfig.
judger_cfg = JudgerConfig(
    reward_judger_configs=[gsm8k_judger_config],
)

# 3. Define CPU resources and create a placement group for the actors.
# This reserves 16 bundles, each with 1 CPU.
cpu_resources_config = CPUResourcesConfig.from_total(
    total_cpus=16,
    num_workers=16
)
pg = AutoCPUWorkers.build_placement_group(cpu_resources_config)

# 4. Create the JudgerController actor, placing its child actors in the placement group.
judger_controller = JudgerController.remote(judger_cfg, pg)
````