### PR TITLE
[Fix] Fix device mismatch for ascend npu when loss_cfg.loss_reduction != "token"

### DIFF
--- a/xtuner/v1/loss/ce_loss.py
+++ b/xtuner/v1/loss/ce_loss.py
@@ -137,7 +137,7 @@ class LMHeadLossContext(BaseLossContext):
                 loss_weight = torch.ones_like(shifted_labels, dtype=torch.float32)
             else:
                 assert cu_seq_lens_list is not None, "cu_seq_lens_list must be provided for sample or square reduction"
-                cu_seq_lens = cu_seq_lens_list[i]
+                cu_seq_lens = cu_seq_lens_list[i].to(shifted_labels.device)
                 boundaries = cu_seq_lens[1:]
                 num_tokens = cu_seq_lens[1:] - cu_seq_lens[:-1]
 


### PR DESCRIPTION
Currently when one passes `loss_cfg.loss_reduction` other than "token" on a ascend/npu device, a Runtime Error (device mismatch) is expected in this line:

https://github.com/InternLM/xtuner/blob/d339718800ef8c554a85e051d773e244b495b9e7/xtuner/v1/loss/ce_loss.py#L191

The root cause of this error is that, in ascend npu device, `cu_seq_lens` tensors are required to be on `cpu`. In func `build_batches_loss_kwargs`, the devuce of`loss_weight` is inherited from `num_grad_tokens -> boundaries -> cu_seq_lens` -- and hence the problem.