### PR TITLE
[Build] fix deep_geem injection by freezing sgl-kernel version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,7 @@ RUN unzip ${DEEP_GEMM_DIR}/*.whl -d ${PYTHON_SITE_PACKAGE_PATH}
 ARG SGLANG_VERSION
 
 RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
-   pip install sglang==${SGLANG_VERSION} sgl_kernel pybase64 orjson uvloop setproctitle msgspec \
+   pip install sglang==${SGLANG_VERSION} sgl-kernel==0.3.14.post1 pybase64 orjson uvloop setproctitle msgspec \
    compressed_tensors python-multipart torch_memory_saver \
    grpcio-tools==1.75.1 hf_transfer interegular llguidance==0.7.11 \
    xgrammar==0.1.24 blobfile==3.0.0 flashinfer_python==0.4.0 --no-cache-dir --no-deps
@@ -199,7 +199,7 @@ ARG LMDEPLOY_URL
 RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
     pip install fastapi fire openai outlines \
         partial_json_parser ray[default] shortuuid uvicorn \
-        'pydantic>2' openai_harmony --no-cache-dir dlblas && \
+        'pydantic>2' openai_harmony dlblas --no-cache-dir  && \
     if [ -n "${LMDEPLOY_VERSION}" ]; then \
         pip install lmdeploy==${LMDEPLOY_VERSION} --no-deps --no-cache-dir; \
     else \


### PR DESCRIPTION
## Motivation
Current docker image would fail ci_test due to `DeepGemm` import failure:
```
>>> import deep_gemm
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.12/dist-packages/deep_gemm/__init__.py", line 16, in <module>
    from . import deep_gemm_cpp  # noqa: F401  # Registers ops into torch.ops without touching CUDA
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: /usr/local/lib/python3.12/dist-packages/deep_gemm/deep_gemm_cpp.abi3.so: undefined symbol: _ZNK3c106SymInt22maybe_as_int_slow_pathEv
>>>
```
The latest version of `sgl-kernel` would hack the components of package `deep_gemm` with a prebuilt dynamic library, this is not compatitable with our no-deps installation of `sglang`.

## Key changes
1. fix `sgl-kernel==0.3.14.post1` in Dockerfile
2. Reorder dlblas position in pip installation of Dockerfile