### PR TITLE
[Fix] npu resources scripts and torch_compile_cfg

### DIFF
--- a/examples/v1/scripts/run_rl.sh
+++ b/examples/v1/scripts/run_rl.sh
@@ -11,6 +11,17 @@ INFER_BACKEND=$2
 MODEL_PATH=$3
 DATA_PATH=$4
 EVAL_DATA_PATH=${5:-""}
+ACCELERATOR=${6:-"gpu"} # "gpu" or "npu"
+ACCELERATOR=$(echo "$ACCELERATOR" | tr '[:lower:]' '[:upper:]')
+if [ $ACCELERATOR != "GPU" ] && [ $ACCELERATOR != "NPU" ]; then
+  echo "Error: ACCELERATOR must be either 'gpu' or 'npu'!"
+  exit 1
+fi
+if [ "$ACCELERATOR" = "NPU" ]; then
+  ACCELERATOR_PER_NODE=${7:-16}
+else
+  ACCELERATOR_PER_NODE=${7:-8}
+fi
 
 export PYTHONPATH=$(pwd):$PYTHONPATH
 
@@ -61,12 +72,19 @@ if [ ! -d "$WORK_DIR" ]; then
   mkdir -p "$WORK_DIR"
 fi
 export LMDEPLOY_LOG_FILE="${WORK_DIR}/lmdeploy_log_${current_time}.txt"
-export XTUNER_RL_MEM_DIR="${WORK_DIR}/mem_${current_time}"
+if [ "$ACCELERATOR" = "GPU" ]; then
+    # TODO: support NPU RL Memory Monitor
+    export XTUNER_RL_MEM_DIR="${WORK_DIR}/mem_${current_time}"
+fi
 
 # 2. Launch Ray cluster
 # 根据 NODE_COUNT 分配 num_cpus, 防止内存OOM
 node_count=${NODE_COUNT:-1}
-total_cpus=$((node_count * 128))
+if [ "$ACCELERATOR" = "GPU" ]; then
+  total_cpus=$((node_count * 128))
+elif [ "$ACCELERATOR" = "NPU" ]; then
+  total_cpus=$((node_count * 256))
+fi
 
 if [ "$RAY_RANK" -eq 0 ]; then
   rm -rf /tmp/ray_log
@@ -96,12 +114,12 @@ else
 fi
 
 while true; do
-  result=$(ray status | grep GPU | cut -d ' ' -f2 | cut -d '/' -f2)
-  expected_gpu_count=$((node_count * 8))
-  if [ "$result" = "$expected_gpu_count.0" ]; then
+  result=$(ray status | grep ${ACCELERATOR} | cut -d ' ' -f2 | cut -d '/' -f2)
+  expected_accelerator_count=$((node_count * ${ACCELERATOR_PER_NODE}))
+  if [ "$result" = "$expected_accelerator_count.0" ]; then
     break
   else
-    echo "Waiting for GPU count to be $expected_gpu_count, current: $result"
+    echo "Waiting for ${ACCELERATOR} count to be $expected_accelerator_count, current: $result"
     sleep 2
   fi
 done

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -1401,6 +1401,13 @@ class BaseModel(nn.Module):
             self._disable_compile_cfg(self.config)
             return {}
 
+        # torch.compile is not supported on NPU
+        if DEVICE == "npu":
+            if custom_cfg is not False:
+                logger.warning("torch.compile is not supported on NPU, disabling torch.compile.")
+            self._disable_compile_cfg(self.config)
+            return {}
+
         if custom_cfg is True or custom_cfg is None:
             compile_cfg = self.default_compile_cfg
         else:


### PR DESCRIPTION
## Motivation
Some feature are not currently compatitable with npu device. This would lead to errors in RL training.

## Key Changes
1. Add `ACCELERATOR` and `ACCELERATOR_PER_NODE` parameter in `examples/v1/scripts/run_rl.sh` and `examples/v1/scripts/run_rl_submit.sh` to compatiable with npu device.
2. Make `xtuner.v1.model.base.BaseModel._resolve_compile_cfg` return empty dict when using npu device, this imples we shouldn't use torch.compile on npu device for now.