### PR TITLE
[Fix] fix fully_shard offload_policy type inconsistency

### DIFF
--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -10,6 +10,7 @@ from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     FSDPModule,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from typing_extensions import override
@@ -112,7 +113,7 @@ class BaseComposeModel(BaseModel):
             mesh=self.fsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         if isinstance(self.vision_tower.blocks[0], FSDPModule):

--- a/xtuner/v1/model/compose/intern_s1/modeling_intern_s1.py
+++ b/xtuner/v1/model/compose/intern_s1/modeling_intern_s1.py
@@ -20,6 +20,7 @@ from xtuner.v1.loss import CELossContext
 from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from ..base import BaseComposeModel, to_hf_key_list_wrapper
@@ -94,7 +95,7 @@ class InternS1ForConditionalGeneration(BaseComposeModel):
             mesh=self.fsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         self.language_model.embed_tokens.set_modules_to_forward_prefetch(   # type: ignore

--- a/xtuner/v1/model/compose/intern_s1/modeling_projector.py
+++ b/xtuner/v1/model/compose/intern_s1/modeling_projector.py
@@ -14,6 +14,7 @@ from xtuner.v1.utils.compile import maybe_compile
 from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from .modeling_vision import init_world_mesh
@@ -77,7 +78,7 @@ class InternS1MultiModalProjector(BaseModel):
             mesh=self.fsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=True,
-            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else OffloadPolicy(),
         )
         return self
 

--- a/xtuner/v1/model/compose/intern_s1/modeling_vision.py
+++ b/xtuner/v1/model/compose/intern_s1/modeling_vision.py
@@ -26,6 +26,7 @@ from xtuner.v1.utils.compile import maybe_compile
 from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from xtuner.v1.ops.attn_imp import attn_impl_mapping, AttnOpOutputs
@@ -403,7 +404,7 @@ class InternS1VisionModel(BaseModel):
                 reshard_after_forward=True,
                 offload_policy=CPUOffloadPolicy()
                 if fsdp_config.cpu_offload
-                else None,
+                else OffloadPolicy(),
             )
 
         for layer_cur, layer_next in zip(self.encoder.layer[:-1], self.encoder.layer[1:]):
@@ -414,6 +415,6 @@ class InternS1VisionModel(BaseModel):
             mesh=self.fsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=True,
-            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else OffloadPolicy(),
         )
         return self

--- a/xtuner/v1/model/compose/qwen3_vl/modeling_projector.py
+++ b/xtuner/v1/model/compose/qwen3_vl/modeling_projector.py
@@ -10,6 +10,7 @@ from xtuner.v1.utils.compile import maybe_compile
 from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from .modeling_vision import init_world_mesh
@@ -113,7 +114,7 @@ class Qwen3VLProjector(BaseModel):
             mesh=self.fsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=True,
-            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else OffloadPolicy(),
         )
         return self
 

--- a/xtuner/v1/model/compose/qwen3_vl/modeling_vision.py
+++ b/xtuner/v1/model/compose/qwen3_vl/modeling_vision.py
@@ -14,6 +14,7 @@ from xtuner.v1.config import FSDPConfig
 from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from transformers.models.llama.modeling_llama import repeat_kv
@@ -356,7 +357,7 @@ class Qwen3VLVisionModel(BaseModel):
                 reshard_after_forward=True,
                 offload_policy=CPUOffloadPolicy()
                 if fsdp_config.cpu_offload
-                else None,
+                else OffloadPolicy(),
             )
 
         for layer_cur, layer_next in zip(self.blocks[:-1],  self.blocks[1:]):
@@ -367,7 +368,7 @@ class Qwen3VLVisionModel(BaseModel):
             mesh=self.fsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=True,
-            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if fsdp_config.cpu_offload else OffloadPolicy(),
         )
         return self
 

--- a/xtuner/v1/model/dense/dense.py
+++ b/xtuner/v1/model/dense/dense.py
@@ -11,6 +11,7 @@ from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from torch.distributed.tensor import DTensor
@@ -228,7 +229,7 @@ class Dense(BaseModel):
                 mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
                 mp_policy=mp_policy,
                 reshard_after_forward=self.fsdp_config.reshard_after_forward,
-                offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+                offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
             )
 
         for layer_cur, layer_next in zip(
@@ -242,7 +243,7 @@ class Dense(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         fully_shard(
@@ -250,7 +251,7 @@ class Dense(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         fully_shard(
@@ -258,7 +259,7 @@ class Dense(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         fully_shard(
@@ -266,7 +267,7 @@ class Dense(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
         self.set_modules_to_forward_prefetch([self.embed_tokens, self.layers["0"]])  # type: ignore
 

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -18,6 +18,7 @@ from torch.distributed.distributed_c10d import ReduceOp
 from torch.distributed.fsdp import (
     CPUOffloadPolicy,
     MixedPrecisionPolicy,
+    OffloadPolicy,
     fully_shard,
 )
 from torch.distributed.tensor import DTensor, Replicate, distribute_tensor
@@ -738,7 +739,7 @@ class MoE(BaseModel):
                 mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
                 mp_policy=mp_policy,
                 reshard_after_forward=reshard_after_forward,
-                offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+                offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
             )
 
         for layer_cur, layer_next in zip(
@@ -752,7 +753,7 @@ class MoE(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         fully_shard(
@@ -760,7 +761,7 @@ class MoE(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         fully_shard(
@@ -768,7 +769,7 @@ class MoE(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
 
         fully_shard(
@@ -776,7 +777,7 @@ class MoE(BaseModel):
             mesh=self.fsdp_mesh if self.hsdp_mesh is None else self.hsdp_mesh,
             mp_policy=mp_policy,
             reshard_after_forward=self.fsdp_config.reshard_after_forward,
-            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
+            offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else OffloadPolicy(),
         )
         self.set_modules_to_forward_prefetch([self.embed_tokens, self.layers["0"]])  # type: ignore
 


### PR DESCRIPTION
Fix offload_policy type inconsistency (use `OffloadPolicy()` instead of `None`) in `fully_shard`

`OffloadPolicy` is a dummy dataclass in `torch.distributed.fsdp` which fits perfectly into the signature of `fully_shard` (the following shows a snippet from torch 2.7.0, other versions likewise):

```python
@overload
def fully_shard(
    module: nn.Module,
    *,
    mesh: Optional[DeviceMesh] = ...,
    reshard_after_forward: Union[bool, int] = ...,
    shard_placement_fn: Optional[Callable[[nn.Parameter], Optional[Shard]]] = ...,
    mp_policy: MixedPrecisionPolicy = ...,
    offload_policy: OffloadPolicy = ...,    <------ it's not Optional so you shouldn't use None for this arg!!!
    ignored_params: Optional[set[nn.Parameter]] = ...,
) -> FSDPModule: ...
```

if you use `None` for `offload_policy`, it would work perfectly in runtime, for torch uses `isinstance(offload_policy, CPUOffloadPolicy)` to determine whether or not to turn on  cpu offload (and `isinstance(None, CPUOffloadPolicy` always evaluates to `False`). The problem for using `None` is that it introduces arg-type mismatch for static checkers and makes your life miserable:

<img width="2160" height="1204" alt="image" src="https://github.com/user-attachments/assets/d0d3e654-9235-4e87-bea2-dc92e13dd9d7" />

Using `OffloadPolicy` instead resolves this issue.