### PR TITLE
[Fix] convert_geo3k typo

### DIFF
--- a/xtuner/v1/utils/convert_geometry3k.py
+++ b/xtuner/v1/utils/convert_geometry3k.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     # add a row to each data item that represents a unique id
     def make_map_fn(split):
         def process_fn(example, idx):
-            problem = example.pop("problem").repalce("<image>", "<IMG_CONTEXT>")
+            problem = example.pop("problem").replace("<image>", "<IMG_CONTEXT>")
             prompt = problem + " " + instruction_following
             answer = example.pop("answer")
             images = example.pop("images")


### PR DESCRIPTION
## Key Change
Fix typo `repalce` into `replace` in `xtuner/v1/utils/convert_geometry3k.py`.