### PR TITLE
[Fix] restrict opencv headless version due to its packing issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "transformers==4.57.0",
   "cyclopts",
   "transformers_stream_generator",
-  "opencv-python-headless",
+  "opencv-python-headless<=4.12.0.88",
   "pydantic",
   "tensorboard",
   "xxhash",


### PR DESCRIPTION
## Motivation
This is due to opencv packing bug that requires extra library `libxcb` in headless release, see https://github.com/opencv/opencv-python/pull/1189 for more details.

## Key Change
Restrict `opencv-python-headless<=4.12.0.88` in `pyproject.toml`.