### PR TITLE
[ReplayBuffer] add ReplayBuffer with various StorageBackend

### DIFF
--- a/tests/ray/test_replay_buffer.py
+++ b/tests/ray/test_replay_buffer.py
@@ -1,20 +1,21 @@
 import unittest
 import asyncio
-from xtuner.v1.rl.base.replay_buffer import ReplayBuffer, StorageIndices, FIFOStorageBackend, StalenessStorageBackend
+from xtuner.v1.rl.base.replay_buffer import ReplayBuffer, StorageIndices, FIFOBackend, StalenessBackend
 from xtuner.v1.data_proto.rl_data import RolloutState, Status
 
 class MockState:
     def __init__(self, id, staleness=0):
         self.id = id
         self.seq_staleness = staleness
+        self.status = Status.COMPLETED
 
 class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
     async def test_fifo_backend(self):
-        backend = FIFOStorageBackend()
+        backend = FIFOBackend()
         buffer = ReplayBuffer(storage_backend=backend)
         states = [MockState(i) for i in range(1, 4)]
         
-        await buffer.put(states, "task1", Status.COMPLETED)
+        await buffer.put(states, "task1")
         res = await buffer.get(2, "task1", Status.COMPLETED)
         
         self.assertEqual(len(res), 2)
@@ -22,14 +23,14 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(res[1].id, 2)
 
     async def test_staleness_priority(self):
-        backend = StalenessStorageBackend(min_staleness=0, max_staleness=5)
+        backend = StalenessBackend(min_staleness=0, max_staleness=5)
         buffer = ReplayBuffer(storage_backend=backend)
         
         s1 = MockState(id="low", staleness=1)
         s5 = MockState(id="high", staleness=5)
         
-        await buffer.put([s1], "task1", Status.COMPLETED)
-        await buffer.put([s5], "task1", Status.COMPLETED)
+        await buffer.put([s1], "task1")
+        await buffer.put([s5], "task1")
         
         res = await buffer.get(2, "task1", Status.COMPLETED)
         self.assertEqual(res[0].id, "high")
@@ -37,8 +38,8 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
 
     async def test_multi_task(self):
         buffer = ReplayBuffer()
-        await buffer.put([MockState(100)], "task_a", Status.COMPLETED)
-        await buffer.put([MockState(200)], "task_b", Status.COMPLETED)
+        await buffer.put([MockState(100)], "task_a")
+        await buffer.put([MockState(200)], "task_b")
         
         res_a = await buffer.get(10, "task_a", Status.COMPLETED)
         res_b = await buffer.get(10, "task_b", Status.COMPLETED)


### PR DESCRIPTION
## ReplayBuffer 设计说明

### StorageIndices
数据索引类，给不同的后端支持统一的索引的方法
```python
@dataclass
class StorageIndices:
    # 为不同存储后段提供统一的索引接口，目前只会用到task_name和group_status，其他的字段后续再扩展
    task_name: str | None = None
    group_status: Status | None = None
    tags: dict = field(default_factory=dict)  # 如果非等于的条件则使用 scores_gt > 0.8
```

### Storage
抽象的存储后端，支持不同类型的存储系统，例如python原生list, pandas, SQL 等；目前只能用到 `NaiveStorage`，但是提供了`PandasStorageBackend`，`SQLStorageBackend`的伪代码作为参考；
```python
class Storage(ABC):
    @abstractmethod
    async def put(self, items: list[RolloutState], storage_indices: StorageIndices): ...
    @abstractmethod
    async def get(self, count: int, storage_indices: StorageIndices) -> list[RolloutState]: ...
    @abstractmethod
    async def __len__(self): ...
```

在此基础上，通过`FIFOBackend`, `StalenessBackend` 定义数据怎么放 + 数据怎么取；例如：`FIFOBackend` 定义数据为先入先出，`StalenessBackend` 定义数据按照新鲜度，新鲜度越旧（数值越大）的数据先出队

### ReplayBufffer
```python
class ReplayBuffer:
    def __init__(self, storage_backend: Storage = None):
        self._storage = FIFOBackend()  if storage_backend is None else storage_backend
        self._lock = asyncio.Lock()
    async def put(self, items: list[RolloutState], task_name: str, **kwargs):..
    async def get(self, batch_size: int, task_name: str, group_status: Status) -> list[RolloutState]:...
```