### PR TITLE
Optimize the implementation of Sampler and ProduceStrategy

### DIFF
--- a/tests/ray/test_agent_loop.py
+++ b/tests/ray/test_agent_loop.py
@@ -7,12 +7,13 @@ import torch
 from transformers import AutoTokenizer
 from xtuner.v1.ray.config.worker import RolloutConfig
 from xtuner.v1.ray.base import AcceleratorResourcesConfig, AutoAcceleratorWorkers
-from xtuner.v1.rl.base.agent_loop import AgentLoopConfig, SingleTurnAgentLoop
+from xtuner.v1.rl.base.agent_loop import SingleTurnAgentLoopConfig
 from xtuner.v1.rl.base.agent_loop_manager import AgentLoopManagerConfig
 from xtuner.v1.data_proto import RolloutState, Status, SampleParams 
 from xtuner.v1.ray.rollout import RolloutController
 from xtuner.v1.ray.judger.gsm8k import GSM8KJudgerConfig
-from xtuner.v1.rl.base.producer import SyncProduceStrategy, SamplerConfig, ProducerConfig
+from xtuner.v1.rl.base.producer import SyncProduceStrategyConfig
+from xtuner.v1.rl.base.sampler import SamplerConfig
 from xtuner.v1.rl.base.replay_buffer import ReplayBuffer
 from xtuner.v1.datasets.config import DataloaderConfig, DatasetConfig
 from xtuner.v1.datasets.rl_tokenize_fn import RLTextTokenizeFnConfig
@@ -79,8 +80,7 @@ class TestAgentLoop(unittest.IsolatedAsyncioTestCase):
             worker_log_dir=self.worker_log_dir,
         )
         judger_config = GSM8KJudgerConfig(judger_name="openai/gsm8k")  
-        agent_loop_cfg = AgentLoopConfig(
-            type=SingleTurnAgentLoop,
+        agent_loop_cfg = SingleTurnAgentLoopConfig(
             hf_checkpoint=self.model_path,
             sample_params=SampleParams(max_tokens=self.max_response_length, temperature=0.0)
         )
@@ -119,8 +119,7 @@ class TestAgentLoop(unittest.IsolatedAsyncioTestCase):
             worker_log_dir=self.worker_log_dir,
         )
         judger_config = GSM8KJudgerConfig(judger_name="openai/gsm8k")  
-        agent_loop_cfg = AgentLoopConfig(
-            type=SingleTurnAgentLoop,
+        agent_loop_cfg = SingleTurnAgentLoopConfig(
             hf_checkpoint=self.model_path,
             sample_params=SampleParams(max_tokens=self.max_response_length, temperature=0.0)
         )
@@ -140,7 +139,7 @@ class TestAgentLoop(unittest.IsolatedAsyncioTestCase):
             ),
             prompt_repeat_k=2,
         )
-        producer_cfg = ProducerConfig()
+        producer_cfg = SyncProduceStrategyConfig()
         agent_loop_manager_cfg = AgentLoopManagerConfig(task_name="test_gsm8k")
         # 2. 创建 rollout_controller, judger
         pg = AutoAcceleratorWorkers.build_placement_group(self.resources_cfg)

--- a/xtuner/v1/rl/base/agent_loop_manager.py
+++ b/xtuner/v1/rl/base/agent_loop_manager.py
@@ -7,6 +7,27 @@ from xtuner.v1.rl.base.replay_buffer import ReplayBuffer
 from .agent_loop import AgentLoop
 
 
+class AgentLoopManagerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    task_name: str
+
+    def build(
+        self,
+        agent_loop: AgentLoop,
+        produce_strategy: ProduceStrategy,
+        sampler: Sampler,
+        replay_buffer: ReplayBuffer,
+    ) -> "AgentLoopManager":
+        return AgentLoopManager(
+            agent_loop=agent_loop,
+            produce_strategy=produce_strategy,
+            sampler=sampler,
+            replay_buffer=replay_buffer,
+            task_name=self.task_name,
+        )
+
+
 class AgentLoopManager:
     def __init__(
         self,
@@ -37,24 +58,3 @@ class AgentLoopManager:
     # async def disaggregate_get_batch(self, task_name: str, batch_size: int):
     #     # 从不同的 replay_buffer 中采样，然后训练
     #     return self._replay_buffer.get(batch_size, task_name, Status.COMPLETED)
-
-
-class AgentLoopManagerConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
-
-    task_name: str
-
-    def build(
-        self,
-        agent_loop: AgentLoop,
-        produce_strategy: ProduceStrategy,
-        sampler: Sampler,
-        replay_buffer: ReplayBuffer,
-    ) -> AgentLoopManager:
-        return AgentLoopManager(
-            agent_loop=agent_loop,
-            produce_strategy=produce_strategy,
-            sampler=sampler,
-            replay_buffer=replay_buffer,
-            task_name=self.task_name,
-        )

--- a/xtuner/v1/rl/base/sampler.py
+++ b/xtuner/v1/rl/base/sampler.py
@@ -1,0 +1,68 @@
+from typing import Iterator, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
+from xtuner.v1.data_proto.rl_data import RolloutState, Status
+from xtuner.v1.datasets.config import DataloaderConfig
+from xtuner.v1.datasets.dataloader import Dataloader
+
+from .replay_buffer import ReplayBuffer
+
+
+class SamplerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    dataloader_cfg: DataloaderConfig
+    prompt_repeat_k: int = 1
+
+    def build(
+        self, tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast | str, replay_buffer: ReplayBuffer
+    ) -> "Sampler":
+        if isinstance(tokenizer, str):
+            tokenizer_obj = AutoTokenizer.from_pretrained(tokenizer, trust_remote_code=True)
+        else:
+            tokenizer_obj = tokenizer
+        dataloader = self.dataloader_cfg.build(
+            tokenizer=tokenizer_obj, dp_mesh=None, global_batch_size=1, micro_batch_size=1, seed=1
+        )
+        return Sampler(dataloader=dataloader, prompt_repeat_k=self.prompt_repeat_k, replay_buffer=replay_buffer)
+
+
+class _DatasetSampler:
+    def __init__(self, dataloader: Dataloader, prompt_repeat_k: int):
+        self.dataloader = dataloader
+        self.dataloader_iter: Optional[Iterator] = None
+        self.cur_epoch = 0
+        self.prompt_repeat_k = prompt_repeat_k
+
+    def sample_from_dataloader(self) -> list[RolloutState]:
+        if self.dataloader_iter is None:
+            self.dataloader_iter = iter(self.dataloader)
+        assert self.dataloader_iter is not None
+        try:
+            data = next(self.dataloader_iter)[0]
+        except StopIteration:
+            self.cur_epoch += 1
+            self.dataloader.set_epoch(self.cur_epoch)
+            self.dataloader_iter = iter(self.dataloader)
+            data = next(self.dataloader_iter)[0]
+        group_data = [data] * self.prompt_repeat_k
+        return group_data
+
+
+class Sampler(_DatasetSampler):
+    def __init__(
+        self,
+        dataloader: Dataloader,
+        prompt_repeat_k: int,
+        replay_buffer: ReplayBuffer,
+    ):
+        super().__init__(dataloader, prompt_repeat_k)
+        self.replay_buffer = replay_buffer
+
+    async def sample(self, task_name: str) -> list[RolloutState]:
+        buffer_data = await self.replay_buffer.get(1, task_name=task_name, group_status=Status.ABORTED)
+        if len(buffer_data) == 0:
+            return self.sample_from_dataloader()
+        else:
+            return buffer_data[0]


### PR DESCRIPTION
- Sampler 重命名：

`Sampler` -> `_DatasetSampler`, `SamplerWithReplayBuffer` -> `Sampler`，并且ProduceStrategy默认使用Sampler

- AsyncProduceStrategy 重命名：`AsyncProduceStrategy` -> `OverProduceStrategy`

- ProduceStrategy 增加两个入参：`is_valid_sample_fn`, `should_continue_fn`

1. `is_valid_sample_fn` 用于定义判断样本是否有效，过滤的规则写在这里进行传入，默认为 `all(sample.status == Status.COMPLETED for sample in samples)`
2. `should_continue_fn` 传入是否继续生产的条件，默认为completed_samples_count < batch_size

通过增加这两个入参，并且去掉了tqdm进度条，去除`ProduceStrategy`中hardcode的部分，仅作为一个轻量的控制流，仅通过调用算法/业务相关函数/Module实现对应功能，进度条显示应该有更加优雅的实现方式

