### PR TITLE
[Build] add dependencies for Qwen3.5 in Dockerfile

### DIFF
--- a/.github/workflows/docker-inner.yml
+++ b/.github/workflows/docker-inner.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       image_tag:
         required: true
-        description: 'Set docker image tag. Default is "latest", you can also set "auto" to genterate a formated tag, or input a manual tag'
+        description: 'Set docker image tag. Default is "latest", you can also set "auto" to generate a formated tag, or input a manual tag'
         type: string
         default: auto
       torch_version:
@@ -13,6 +13,11 @@ on:
         description: 'Set docker torch version. Default is "2.8.0"'
         type: string
         default: '2.8.0'
+      build_only:
+        required: false
+        description: 'Whether only build the image, not triggle pushing.'
+        type: boolean
+        default: false
   schedule:
     - cron:  '00 14 * * 0-4'
 
@@ -46,6 +51,7 @@ jobs:
           bash ${{ github.workspace }}/image_build.sh
           echo "Built image with tag: ${DOCKER_TAG}"
       - name: Push to cluster
+        if: ${{ !inputs.build_only }}
         run: |
           echo "$DOCKER_TAG"
           docker login registry.h.pjlab.org.cn -p ${{ secrets.CLUSTER_DOCKERHUB_TOKEN }} -u ${{ secrets.CLUSTER_DOCKERHUB_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ARG CODESPACE=/root/codespace
 ARG FLASH_ATTN3_DIR=/tmp/flash-attn3
 ARG ADAPTIVE_GEMM_DIR=/tmp/adaptive_gemm
 ARG GROUPED_GEMM_DIR=/tmp/grouped_gemm
+ARG CAUSAL_CONV1D_DIR=/tmp/causal_conv1d
 ARG DEEP_EP_DIR=/tmp/deep_ep
 ARG DEEP_GEMM_DIR=/tmp/deep_gemm
 ARG NVSHMEM_PREFIX=/usr/local/nvshmem
@@ -100,6 +101,23 @@ RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 WORKDIR ${CODESPACE}/GroupedGEMM
 
 RUN pip wheel -w ${GROUPED_GEMM_DIR} -v --no-deps .
+
+# compile causal_conv1d
+FROM setup_env AS causal_conv1d
+
+ARG CODESPACE
+ARG CAUSAL_CONV1D_DIR
+ARG CAUSAL_CONV1D_URL
+
+RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
+    git clone $(echo ${CAUSAL_CONV1D_URL} | cut -d '@' -f 1) && \
+    cd ${CODESPACE}/causal-conv1d && \
+    git checkout $(echo ${CAUSAL_CONV1D_URL} | cut -d '@' -f 2) && \
+    git submodule update --init --recursive --force
+
+WORKDIR ${CODESPACE}/causal-conv1d
+
+RUN CAUSAL_CONV1D_FORCE_BUILD=TRUE pip wheel -w ${CAUSAL_CONV1D_DIR} -v --no-deps .
 
 # pypi install nvshmem and compile deepep
 FROM setup_env AS deep_ep
@@ -167,6 +185,7 @@ ARG ADAPTIVE_GEMM_DIR
 ARG GROUPED_GEMM_DIR
 ARG DEEP_EP_DIR
 ARG DEEP_GEMM_DIR
+ARG CAUSAL_CONV1D_DIR
 
 COPY --from=flash_attn ${FLASH_ATTN3_DIR} ${FLASH_ATTN3_DIR}
 COPY --from=flash_attn ${FLASH_ATTN_DIR} ${FLASH_ATTN_DIR}
@@ -175,6 +194,7 @@ COPY --from=grouped_gemm ${GROUPED_GEMM_DIR} ${GROUPED_GEMM_DIR}
 COPY --from=deep_ep ${DEEP_EP_DIR} ${DEEP_EP_DIR}
 COPY --from=deep_ep ${NVSHMEM_PREFIX} ${NVSHMEM_PREFIX}
 COPY --from=deep_gemm ${DEEP_GEMM_DIR} ${DEEP_GEMM_DIR}
+COPY --from=causal_conv1d ${CAUSAL_CONV1D_DIR} ${CAUSAL_CONV1D_DIR}
 
 RUN unzip ${FLASH_ATTN_DIR}/*.whl -d ${PYTHON_SITE_PACKAGE_PATH}
 RUN unzip ${FLASH_ATTN3_DIR}/*.whl -d ${PYTHON_SITE_PACKAGE_PATH}
@@ -182,6 +202,7 @@ RUN unzip ${ADAPTIVE_GEMM_DIR}/*.whl -d ${PYTHON_SITE_PACKAGE_PATH}
 RUN unzip ${GROUPED_GEMM_DIR}/*.whl -d ${PYTHON_SITE_PACKAGE_PATH}
 RUN unzip ${DEEP_EP_DIR}/*.whl -d ${PYTHON_SITE_PACKAGE_PATH}
 RUN unzip ${DEEP_GEMM_DIR}/*.whl -d ${PYTHON_SITE_PACKAGE_PATH}
+RUN unzip ${CAUSAL_CONV1D_DIR} -d ${PYTHON_SITE_PACKAGE_PATH}
 
 # install sglang and its runtime requirements
 ARG SGLANG_VERSION

--- a/image_build.sh
+++ b/image_build.sh
@@ -8,6 +8,7 @@ export ADAPTIVE_GEMM_URL=https://github.com/InternLM/AdaptiveGEMM@374e68fb9ea716
 export GROUPED_GEMM_URL=https://github.com/InternLM/GroupedGEMM@aa5ffb21cb626d6cd61d99fc42958127b0b99be7
 export DEEP_EP_URL=https://github.com/deepseek-ai/DeepEP@9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee # v1.2.1
 export DEEP_GEMM_URL=https://github.com/deepseek-ai/DeepGEMM@c9f8b34dcdacc20aa746b786f983492c51072870 # v2.1.1.post3
+export CAUSAL_CONV1D_URL=https://github.com/Dao-AILab/causal-conv1d@da6dbaa9fd5a919967f14d3fd031da1288ad5025 # v1.6.0
 
 export TORCH_VERSION=${TORCH_VERSION:-"2.8.0"}
 export LMDEPLOY_VERSION="0.11.0"
@@ -27,6 +28,7 @@ docker build . \
   --build-arg ADAPTIVE_GEMM_URL=$ADAPTIVE_GEMM_URL \
   --build-arg FLASH_ATTN_URL=$FLASH_ATTN_URL \
   --build-arg GROUPED_GEMM_URL=$GROUPED_GEMM_URL \
+  --build-arg CAUSAL_CONV1D_URL=$CAUSAL_CONV1D_URL \
   --build-arg DEEP_EP_URL=$DEEP_EP_URL \
   --build-arg DEEP_GEMM_URL=$DEEP_GEMM_URL \
   --build-arg XTUNER_URL=$XTUNER_URL \
@@ -41,6 +43,7 @@ docker build . \
   --label "ADAPTIVE_GEMM_URL=${ADAPTIVE_GEMM_URL/@/\/tree\/}" \
   --label "FLASH_ATTN_URL=${FLASH_ATTN_URL/@/\/tree\/}" \
   --label "GROUPED_GEMM_URL=${GROUPED_GEMM_URL/@/\/tree\/}" \
+  --label "CAUSAL_CONV1D_URL=${CAUSAL_CONV1D_URL/@/\/tree\/}" \
   --label "DEEP_EP_URL=${DEEP_EP_URL/@/\/tree\/}" \
   --label "DEEP_GEMM_URL=${DEEP_GEMM_URL/@/\/tree\/}" \
   --label "LMDEPLOY_VERSION=$LMDEPLOY_VERSION" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ all = [
   "liger-kernel",
   "parametrize",
   "mathruler",
-  "pylatexenc"
+  "pylatexenc",
+  "flash-linear-attention",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Motivation
Add denpendencies for Qwen3.5 in Dockerfile, mainly: `causal-conv1d` and `flash-linear-attention`,
they are kernel libraries for Qwen3.5. And `causal-conv1d` is built from source for now.

## Change
1. add `causal-conv1d` and `flash-linear-attention` deps in Dockerfile and pyproject.toml
2. add `build_only` option in `publish-docker-inner` cd