### PR TITLE
[Fix] Fix issue_comment trigger in claude-review workflow

### DIFF
--- a/.github/workflows/claude-general.yml
+++ b/.github/workflows/claude-general.yml
@@ -167,6 +167,9 @@ jobs:
               ```
 
               otherwise, push directly to the origin repository.
+
+              If you update the branch, you **MUST** provide the URL of the new commit.
+
           claude_args: |
               --max-turns 30
               --model claude-opus-4-6


### PR DESCRIPTION
## Root Cause

The `claude-review` workflow used `github.event.pull_request.number` and `github.event.pull_request.head.sha` which are not available when triggered via `issue_comment`. This caused the PR number and head SHA to be empty in comment commands and code links.

## Fix

- Use `github.event.pull_request.number || github.event.issue.number` so the PR number resolves correctly for both trigger types.
- Resolve head SHA dynamically via `gh pr view` instead of relying on the event context.
- Add a requirement to provide the new commit URL when pushing branch updates.

## Test Plan

- Verified the workflow YAML is valid.
- Confirmed `issue.number` is populated for `issue_comment` events on PRs.
