### PR TITLE
chore: update CI image to pt29_20260304_35b0bb8

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -14,7 +14,7 @@ on:
 env:
   WORKSPACE_PREFIX: $(echo $GITHUB_WORKSPACE |cut -d '/' -f 1-5)
   WORKSPACE_PREFIX_SHORT: $(echo $GITHUB_WORKSPACE |cut -d '/' -f 1-3)
-  IMAGE: registry.h.pjlab.org.cn/ailab-llmrazor/xtuner:pt28_20251216_d769950
+  IMAGE: registry.h.pjlab.org.cn/ailab-llmrazor/xtuner_tmp:pt29_20260304_35b0bb8
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
更新 CI 镜像为 pt29 版本: `registry.h.pjlab.org.cn/ailab-llmrazor/xtuner_tmp:pt29_20260304_35b0bb8`