### PR TITLE
[Enhance] Skip compilation for muon ops

### DIFF
--- a/tests/optim/test_muon_compile.py
+++ b/tests/optim/test_muon_compile.py
@@ -64,6 +64,13 @@ newton_schulz_triton:
 import pytest
 import torch
 
+
+# TODO:@nil0x9 The original unit test here does not work and is removed along with the removal
+# of compile decorators in muon ops (Tests fails when we try to compare compiled NS to vanilla 
+# counterpart). We remove the related tests here, but the problem still remains how compile 
+# affects the precision of muon ops. It would require investigation, which we defer till a compile
+# opition is introduced for optimizers -- then we might re-introduce the TC tests.
+
 # Skip all tests if CUDA is not available
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 
@@ -84,50 +91,50 @@ class TestNewtonSchulzCompile:
         shape = (num_experts * M, N)
         return torch.randn(shape, device=self.device, dtype=torch.float32)
 
-    def test_zeropower_via_newtonschulz5_compile(self):
-        """Test muon.zeropower_via_newtonschulz5 with/without compile.
-
-        Test cases based on Qwen3 MoE architecture (hidden_size=2048, num_experts=128):
-        - Non-MoE: (6144, 2048) and (2048, 6144) for shared experts
-        - MoE w1/w3: (128 * 768, 2048) per expert (768, 2048)
-        - MoE w2: (2048, 128 * 768) per expert (2048, 768)
-        """
-        from xtuner.v1.optim.muon import zeropower_via_newtonschulz5
-
-        # Scaled-down test cases based on Qwen3 MoE config
-        test_cases = [
-            # Non-MoE cases (shared expert-like)
-            (1, 1536, 512, "shared_expert_w1"),  # (1536, 512) scaled from (6144, 2048)
-            (1, 512, 1536, "shared_expert_w2"),  # (512, 1536) scaled from (2048, 6144)
-            # MoE cases - w1/w3 like (M < N)
-            (8, 192, 512, "moe_w1_small"),  # per expert: (192, 512) scaled from (768, 2048)
-            (16, 192, 512, "moe_w1_medium"),  # 16 experts
-            # MoE cases - w2 like (M > N)
-            (8, 512, 192, "moe_w2_small"),  # per expert: (512, 192) scaled from (2048, 768)
-            (16, 512, 192, "moe_w2_medium"),  # 16 experts
-            # Square cases
-            (1, 512, 512, "square_regular"),
-            (4, 256, 256, "square_moe"),
-        ]
-
-        for num_experts, M, N, name in test_cases:
-            G = self._create_test_matrix(num_experts, M, N)
-
-            # Without compile
-            result_no_compile = zeropower_via_newtonschulz5(
-                G, epsilon=self.epsilon, num_experts=num_experts
-            )
-
-            # With compile
-            compiled_fn = torch.compile(zeropower_via_newtonschulz5, fullgraph=True)
-            result_compile = compiled_fn(G, epsilon=self.epsilon, num_experts=num_experts)
-
-            # Compare results
-            max_diff = (result_no_compile - result_compile).abs().max().item()
-            assert max_diff < self.tolerance, (
-                f"{name} (num_experts={num_experts}, M={M}, N={N}): "
-                f"max_diff={max_diff} >= {self.tolerance}"
-            )
+    # def test_zeropower_via_newtonschulz5_compile(self):
+    #     """Test muon.zeropower_via_newtonschulz5 with/without compile.
+    #
+    #     Test cases based on Qwen3 MoE architecture (hidden_size=2048, num_experts=128):
+    #     - Non-MoE: (6144, 2048) and (2048, 6144) for shared experts
+    #     - MoE w1/w3: (128 * 768, 2048) per expert (768, 2048)
+    #     - MoE w2: (2048, 128 * 768) per expert (2048, 768)
+    #     """
+    #     from xtuner.v1.optim.muon import zeropower_via_newtonschulz5
+    #
+    #     # Scaled-down test cases based on Qwen3 MoE config
+    #     test_cases = [
+    #         # Non-MoE cases (shared expert-like)
+    #         (1, 1536, 512, "shared_expert_w1"),  # (1536, 512) scaled from (6144, 2048)
+    #         (1, 512, 1536, "shared_expert_w2"),  # (512, 1536) scaled from (2048, 6144)
+    #         # MoE cases - w1/w3 like (M < N)
+    #         (8, 192, 512, "moe_w1_small"),  # per expert: (192, 512) scaled from (768, 2048)
+    #         (16, 192, 512, "moe_w1_medium"),  # 16 experts
+    #         # MoE cases - w2 like (M > N)
+    #         (8, 512, 192, "moe_w2_small"),  # per expert: (512, 192) scaled from (2048, 768)
+    #         (16, 512, 192, "moe_w2_medium"),  # 16 experts
+    #         # Square cases
+    #         (1, 512, 512, "square_regular"),
+    #         (4, 256, 256, "square_moe"),
+    #     ]
+    #
+    #     for num_experts, M, N, name in test_cases:
+    #         G = self._create_test_matrix(num_experts, M, N)
+    #
+    #         # Without compile
+    #         result_no_compile = zeropower_via_newtonschulz5(
+    #             G, epsilon=self.epsilon, num_experts=num_experts
+    #         )
+    #
+    #         # With compile
+    #         compiled_fn = torch.compile(zeropower_via_newtonschulz5, fullgraph=True)
+    #         result_compile = compiled_fn(G, epsilon=self.epsilon, num_experts=num_experts)
+    #
+    #         # Compare results
+    #         max_diff = (result_no_compile - result_compile).abs().max().item()
+    #         assert max_diff < self.tolerance, (
+    #             f"{name} (num_experts={num_experts}, M={M}, N={N}): "
+    #             f"max_diff={max_diff} >= {self.tolerance}"
+    #         )
 
     def test_newton_schulz_triton(self):
         """Test newton_schulz_triton (Triton kernel, no torch.compile).
@@ -167,39 +174,39 @@ class TestNewtonSchulzCompile:
             assert not torch.isinf(result).any(), f"{name}: output contains Inf"
             assert result.abs().max() > 0, f"{name}: output is all zeros"
 
-    def test_transpose_case_compile(self):
-        """Test matrices where rows > cols (transpose case) with compile.
-
-        Based on Qwen3 MoE w2 shape: (hidden_size, num_experts * moe_intermediate_size)
-        """
-        from xtuner.v1.optim.muon import zeropower_via_newtonschulz5
-
-        test_cases = [
-            # Non-MoE transpose case
-            (1, 512, 128, "transpose_shared_expert"),  # Scaled from (2048, 512)
-            # MoE transpose cases - w2 like
-            (8, 512, 192, "transpose_moe_w2_small"),  # 8 experts, each (512, 192)
-            (16, 512, 192, "transpose_moe_w2_medium"),  # 16 experts
-        ]
-
-        for num_experts, M, N, name in test_cases:
-            G = self._create_test_matrix(num_experts, M, N)
-
-            # Without compile
-            result_no_compile = zeropower_via_newtonschulz5(
-                G, epsilon=self.epsilon, num_experts=num_experts
-            )
-
-            # With compile
-            compiled_fn = torch.compile(zeropower_via_newtonschulz5, fullgraph=True)
-            result_compile = compiled_fn(G, epsilon=self.epsilon, num_experts=num_experts)
-
-            # Compare results
-            max_diff = (result_no_compile - result_compile).abs().max().item()
-            assert max_diff < self.tolerance, (
-                f"zeropower_via_newtonschulz5 {name} (num_experts={num_experts}): "
-                f"max_diff={max_diff} >= {self.tolerance}"
-            )
+    # def test_transpose_case_compile(self):
+    #     """Test matrices where rows > cols (transpose case) with compile.
+    #
+    #     Based on Qwen3 MoE w2 shape: (hidden_size, num_experts * moe_intermediate_size)
+    #     """
+    #     from xtuner.v1.optim.muon import zeropower_via_newtonschulz5
+    #
+    #     test_cases = [
+    #         # Non-MoE transpose case
+    #         (1, 512, 128, "transpose_shared_expert"),  # Scaled from (2048, 512)
+    #         # MoE transpose cases - w2 like
+    #         (8, 512, 192, "transpose_moe_w2_small"),  # 8 experts, each (512, 192)
+    #         (16, 512, 192, "transpose_moe_w2_medium"),  # 16 experts
+    #     ]
+    #
+    #     for num_experts, M, N, name in test_cases:
+    #         G = self._create_test_matrix(num_experts, M, N)
+    #
+    #         # Without compile
+    #         result_no_compile = zeropower_via_newtonschulz5(
+    #             G, epsilon=self.epsilon, num_experts=num_experts
+    #         )
+    #
+    #         # With compile
+    #         compiled_fn = torch.compile(zeropower_via_newtonschulz5, fullgraph=True)
+    #         result_compile = compiled_fn(G, epsilon=self.epsilon, num_experts=num_experts)
+    #
+    #         # Compare results
+    #         max_diff = (result_no_compile - result_compile).abs().max().item()
+    #         assert max_diff < self.tolerance, (
+    #             f"zeropower_via_newtonschulz5 {name} (num_experts={num_experts}): "
+    #             f"max_diff={max_diff} >= {self.tolerance}"
+    #         )
 
     def test_two_functions_consistency(self):
         """Test that both functions produce similar results.

--- a/xtuner/v1/optim/muon.py
+++ b/xtuner/v1/optim/muon.py
@@ -177,7 +177,6 @@ class AsyncRuntime:
             previous_tasks = running_tasks
 
 
-@torch.compile(fullgraph=True)
 def adamw_update(
     X: Tensor,  # Model weights (modified in place)
     G: Tensor,  # Gradient
@@ -224,7 +223,6 @@ def adamw_update(
     X.addcdiv_(M, denom, value=-adj_lr)
 
 
-@torch.compile(fullgraph=True)
 def adamw_update_foreach(  # type: ignore
     X: List[Tensor],  # Model weights (modified in place)
     G: List[Tensor],  # Gradient
@@ -452,7 +450,6 @@ class Muon(Optimizer):
             if not group_params:
                 continue
 
-            # Wrap hyperparameters in tensors for torch.compile
             lr = torch.tensor(group["lr"])
             mu = torch.tensor(group["mu"])
             weight_decay = torch.tensor(group["weight_decay"])
@@ -537,7 +534,6 @@ class Muon(Optimizer):
             momentums = [s["momentum"] for s in states]
             variances = [s["variance"] for s in states]
 
-            # Wrap hyperparameters in tensors for torch.compile
             lr = torch.tensor(group["lr"])
             beta1 = torch.tensor(group["beta1"])
             beta2 = torch.tensor(group["beta2"])
@@ -867,7 +863,6 @@ def adamw_update_foreach_async(
     yield
 
 
-@torch.compile(fullgraph=True)
 def muon_update_pre_orthogonalize(
     G: List[Tensor],
     M: List[Tensor],
@@ -875,11 +870,7 @@ def muon_update_pre_orthogonalize(
     nesterov: bool,
 ) -> List[Tensor]:
     """Update momentum with gradient and compute the input to
-    orthogonalization.
-
-    Inputs and outputs should be lists of regular Tensor, not DTensor. This is a separate function for compatibility
-    with torch.compile().
-    """
+    orthogonalization."""
     dtype = M[0].dtype
     G = [g.to(dtype=dtype) for g in G]
 
@@ -899,7 +890,6 @@ def muon_update_pre_orthogonalize(
     return U
 
 
-@torch.compile(fullgraph=True)
 def muon_update_post_orthogonalize(
     X: List[Tensor],
     U: List[Tensor],
@@ -907,11 +897,7 @@ def muon_update_post_orthogonalize(
     adjusted_lr: Tensor,
     weight_decay: Tensor,
 ):
-    """Apply weight decay and weight update after orthogonalization.
-
-    Inputs and outputs should be lists of regular Tensor, not DTensor. This is a separate function for compatibility
-    with torch.compile().
-    """
+    """Apply weight decay and weight update after orthogonalization."""
     # Apply weight decay
     torch._foreach_mul_(X, 1 - base_lr * weight_decay)
 
@@ -959,7 +945,6 @@ def adjust_lr_spectral_norm(lr, param_shape, num_experts=1):
     return adjusted_lr
 
 
-@torch.compile(fullgraph=True)
 def zeropower_via_newtonschulz5(G: Tensor, epsilon: float = 1e-7, num_experts: int = 1):
     """Newton-Schulz iteration to approximate the orthogonalization of X.
 


### PR DESCRIPTION
This PR removes all `torch.compile` decorators in `muon.py` because: in end-to-end experiment runs no real training throughput improvement was observed and, even worse, recompiles was triggered at the beginning of training runs, leading to tgs loss and even failures caused by recompile cache limit.