### PR TITLE
[Feature] Add judger abort support for pause/resume in RL dataflow

### DIFF
--- a/xtuner/v1/ray/dataflow/flow.py
+++ b/xtuner/v1/ray/dataflow/flow.py
@@ -103,13 +103,6 @@ class DataFlowConfig(BaseModel):
         ),
     ] = None
     worker_log_dir: Annotated[Path, Parameter(help="Directory to save worker logs.")] = Path.cwd() / "work_dir"
-    abort_judger_names: Annotated[
-        list[str] | None,
-        Parameter(
-            help="If provided, only abort the specified judger groups by name when pausing. "
-            "If None, no judger groups are aborted on pause."
-        ),
-    ] = None
 
     def model_post_init(self, __context: Any) -> None:
         self.worker_log_dir.mkdir(parents=True, exist_ok=True)
@@ -163,7 +156,6 @@ class RawDataFlow:
         self._raw_reward_count = 0
         self.tb_metrics: Dict[str, Any] = {}
         self.target_batch_size = self.config.global_batch_size
-        self.abort_judger_names: list[str] | None = self.config.abort_judger_names
         rollout_info = ray.get(self.env_controller.get_rollout_info.remote())  # type: ignore[attr-defined]
         self.worker_url_list = list(rollout_info["server_url_dict"].values())
         self.logger.info(f"DataFlow connected to active rollout workers url: {self.worker_url_list}")
@@ -217,7 +209,7 @@ class RawDataFlow:
         ray.get(self.env_controller.restart.remote())  # type: ignore[attr-defined]
         # Restart judger abort state for next round
         try:
-            ray.get(self.env_controller.restart_judger.remote(judger_names=self.abort_judger_names))  # type: ignore[attr-defined]
+            ray.get(self.env_controller.restart_judger.remote())  # type: ignore[attr-defined]
         except Exception as e:
             self.logger.error(f"Failed to restart judger (next round may be affected): {e}")
         self.sample_params = sample_params if sample_params else self.config.sample_params
@@ -399,7 +391,7 @@ class RawDataFlow:
 
         if len(waiting_tasks) > 0:
             self.logger.info(f"Start pausing env controller for remaining worker tasks {len(waiting_tasks)}.")
-            await self.pause(abort_judger_names=self.abort_judger_names)
+            await self.pause()
             cleanup_start_time = time.perf_counter()
             while len(waiting_tasks) > 0:
                 elapsed_time = time.perf_counter() - cleanup_start_time
@@ -417,7 +409,7 @@ class RawDataFlow:
                 # When a waiting request starts running, it still needs another pause request to be marked as aborted.
                 _, pending_tasks = await asyncio.wait(waiting_tasks, timeout=0.1, return_when=asyncio.FIRST_COMPLETED)
                 if len(pending_tasks) > 0:
-                    await self.pause(abort_judger_names=self.abort_judger_names)
+                    await self.pause()
                     await asyncio.sleep(1)
                     self.logger.debug(
                         f"Waiting for {len(pending_tasks)} remaining worker tasks to complete after pausing env controller."
@@ -438,13 +430,12 @@ class RawDataFlow:
             self.tb_metrics[f"task_time/{k}"] = v
 
     @ray_method
-    async def pause(self, timeout: float = 60.0, abort_judger_names: list[str] | None = None):
-        """Asynchronously sends abort requests to all rollout workers.
+    async def pause(self, timeout: float = 60.0):
+        """Asynchronously sends abort requests to all rollout workers and
+        judgers.
 
         Args:
             timeout: HTTP request timeout in seconds.
-            abort_judger_names: If provided, only abort the specified judger
-                groups by name. If ``None``, abort all judger groups.
         """
         if not self.worker_url_list:
             self.logger.info("No active rollout workers to pause.")
@@ -465,13 +456,12 @@ class RawDataFlow:
         else:
             self.logger.info(f"All {succeeded_count} abort requests sent successfully.")
 
-        # Abort judger actors (only when specific names are provided)
-        if abort_judger_names is not None:
-            try:
-                await self.env_controller.abort_judger.remote(judger_names=abort_judger_names)  # type: ignore[attr-defined]
-                self.logger.info(f"Judger abort signal sent successfully (targets: {abort_judger_names}).")
-            except Exception as e:
-                self.logger.warning(f"Failed to send judger abort signal: {e}")
+        # Abort judger actors whose config has abort_on_pause=True
+        try:
+            await self.env_controller.abort_judger.remote()  # type: ignore[attr-defined]
+            self.logger.info("Judger abort signal sent successfully.")
+        except Exception as e:
+            self.logger.warning(f"Failed to send judger abort signal: {e}")
 
     @ray_method
     async def run(
@@ -480,7 +470,6 @@ class RawDataFlow:
         sample_params: Optional[SampleParams] = None,
         extra_params: Optional[Dict] = None,
         staleness_threshold: Optional[float] = None,
-        abort_judger_names: list[str] | None = None,
     ) -> DataFlowResult:
         """Starts the data generation process.
 
@@ -495,13 +484,10 @@ class RawDataFlow:
             extra_params (Optional[Dict]): Additional parameters for rollout.
                 Overrides the existing extra_params in DataFlowConfig if provided.
             staleness_threshold (Optional[float]): Override for staleness threshold.
-            abort_judger_names (list[str] | None): If provided, overrides the
-                config-level ``abort_judger_names`` for this run.
+
         Returns:
             DataFlowResult: The collected training samples and metadata.
         """
-        if abort_judger_names is not None:
-            self.abort_judger_names = abort_judger_names
         self._reset_internal_states(
             global_batch_size=num,
             sample_params=sample_params,

--- a/xtuner/v1/ray/dataflow/flow.py
+++ b/xtuner/v1/ray/dataflow/flow.py
@@ -103,6 +103,13 @@ class DataFlowConfig(BaseModel):
         ),
     ] = None
     worker_log_dir: Annotated[Path, Parameter(help="Directory to save worker logs.")] = Path.cwd() / "work_dir"
+    abort_judger_names: Annotated[
+        list[str] | None,
+        Parameter(
+            help="If provided, only abort the specified judger groups by name when pausing. "
+            "If None, no judger groups are aborted on pause."
+        ),
+    ] = None
 
     def model_post_init(self, __context: Any) -> None:
         self.worker_log_dir.mkdir(parents=True, exist_ok=True)
@@ -156,6 +163,7 @@ class RawDataFlow:
         self._raw_reward_count = 0
         self.tb_metrics: Dict[str, Any] = {}
         self.target_batch_size = self.config.global_batch_size
+        self.abort_judger_names: list[str] | None = self.config.abort_judger_names
         rollout_info = ray.get(self.env_controller.get_rollout_info.remote())  # type: ignore[attr-defined]
         self.worker_url_list = list(rollout_info["server_url_dict"].values())
         self.logger.info(f"DataFlow connected to active rollout workers url: {self.worker_url_list}")
@@ -207,6 +215,11 @@ class RawDataFlow:
 
         self.sample_from_expired_storage, self.finished_samples_count = self.replay_buffer.get_prerun_state()
         ray.get(self.env_controller.restart.remote())  # type: ignore[attr-defined]
+        # Restart judger abort state for next round
+        try:
+            ray.get(self.env_controller.restart_judger.remote(judger_names=self.abort_judger_names))  # type: ignore[attr-defined]
+        except Exception as e:
+            self.logger.error(f"Failed to restart judger (next round may be affected): {e}")
         self.sample_params = sample_params if sample_params else self.config.sample_params
         self.extra_params = extra_params if extra_params else self.config.extra_params
         logger_msg = (
@@ -386,7 +399,7 @@ class RawDataFlow:
 
         if len(waiting_tasks) > 0:
             self.logger.info(f"Start pausing env controller for remaining worker tasks {len(waiting_tasks)}.")
-            await self.pause()
+            await self.pause(abort_judger_names=self.abort_judger_names)
             cleanup_start_time = time.perf_counter()
             while len(waiting_tasks) > 0:
                 elapsed_time = time.perf_counter() - cleanup_start_time
@@ -404,7 +417,7 @@ class RawDataFlow:
                 # When a waiting request starts running, it still needs another pause request to be marked as aborted.
                 _, pending_tasks = await asyncio.wait(waiting_tasks, timeout=0.1, return_when=asyncio.FIRST_COMPLETED)
                 if len(pending_tasks) > 0:
-                    await self.pause()
+                    await self.pause(abort_judger_names=self.abort_judger_names)
                     await asyncio.sleep(1)
                     self.logger.debug(
                         f"Waiting for {len(pending_tasks)} remaining worker tasks to complete after pausing env controller."
@@ -425,8 +438,14 @@ class RawDataFlow:
             self.tb_metrics[f"task_time/{k}"] = v
 
     @ray_method
-    async def pause(self, timeout: float = 60.0):
-        """Asynchronously sends abort requests to all rollout workers."""
+    async def pause(self, timeout: float = 60.0, abort_judger_names: list[str] | None = None):
+        """Asynchronously sends abort requests to all rollout workers.
+
+        Args:
+            timeout: HTTP request timeout in seconds.
+            abort_judger_names: If provided, only abort the specified judger
+                groups by name. If ``None``, abort all judger groups.
+        """
         if not self.worker_url_list:
             self.logger.info("No active rollout workers to pause.")
             return
@@ -446,6 +465,14 @@ class RawDataFlow:
         else:
             self.logger.info(f"All {succeeded_count} abort requests sent successfully.")
 
+        # Abort judger actors (only when specific names are provided)
+        if abort_judger_names is not None:
+            try:
+                await self.env_controller.abort_judger.remote(judger_names=abort_judger_names)  # type: ignore[attr-defined]
+                self.logger.info(f"Judger abort signal sent successfully (targets: {abort_judger_names}).")
+            except Exception as e:
+                self.logger.warning(f"Failed to send judger abort signal: {e}")
+
     @ray_method
     async def run(
         self,
@@ -453,6 +480,7 @@ class RawDataFlow:
         sample_params: Optional[SampleParams] = None,
         extra_params: Optional[Dict] = None,
         staleness_threshold: Optional[float] = None,
+        abort_judger_names: list[str] | None = None,
     ) -> DataFlowResult:
         """Starts the data generation process.
 
@@ -466,12 +494,14 @@ class RawDataFlow:
                 Overrides the existing sample_params in DataFlowConfig if provided.
             extra_params (Optional[Dict]): Additional parameters for rollout.
                 Overrides the existing extra_params in DataFlowConfig if provided.
-            enable_partial_rollout (Optional[bool]): Whether to enable partial rollout mode.
-                This is primarily intended for unit testing, allowing the dataflow to pause
-                and resume partway through a rollout for checkpointing and recovery tests.Returns:
+            staleness_threshold (Optional[float]): Override for staleness threshold.
+            abort_judger_names (list[str] | None): If provided, overrides the
+                config-level ``abort_judger_names`` for this run.
         Returns:
-            List[RLDataFlowItem]: A list of collected training samples.
+            DataFlowResult: The collected training samples and metadata.
         """
+        if abort_judger_names is not None:
+            self.abort_judger_names = abort_judger_names
         self._reset_internal_states(
             global_batch_size=num,
             sample_params=sample_params,

--- a/xtuner/v1/ray/environment/base_env.py
+++ b/xtuner/v1/ray/environment/base_env.py
@@ -234,23 +234,14 @@ class BaseEnvironment(ABC):
         return self._call_rollout_func("get_rollout_stats", block)
 
     @ray_method
-    async def abort_judger(self, judger_names: list[str] | None = None):
-        """Abort in-flight judger requests.
-
-        Args:
-            judger_names: If provided, only abort the specified judger groups.
-                If ``None``, abort all judger groups.
-        """
+    async def abort_judger(self):
+        """Abort in-flight judger requests for judgers with
+        ``abort_on_pause=True``."""
         if self.judger_controller:
-            await self.judger_controller.abort.remote(judger_names=judger_names)
+            await self.judger_controller.abort.remote()
 
     @ray_method
-    async def restart_judger(self, judger_names: list[str] | None = None):
-        """Clear judger abort state.
-
-        Args:
-            judger_names: If provided, only restart the specified judger groups.
-                If ``None``, restart all judger groups.
-        """
+    async def restart_judger(self):
+        """Clear abort state on judgers with ``abort_on_pause=True``."""
         if self.judger_controller:
-            await self.judger_controller.restart_judger.remote(judger_names=judger_names)
+            await self.judger_controller.restart_judger.remote()

--- a/xtuner/v1/ray/environment/base_env.py
+++ b/xtuner/v1/ray/environment/base_env.py
@@ -232,3 +232,25 @@ class BaseEnvironment(ABC):
             block (bool): Whether to block until the operation completes.
         """
         return self._call_rollout_func("get_rollout_stats", block)
+
+    @ray_method
+    async def abort_judger(self, judger_names: list[str] | None = None):
+        """Abort in-flight judger requests.
+
+        Args:
+            judger_names: If provided, only abort the specified judger groups.
+                If ``None``, abort all judger groups.
+        """
+        if self.judger_controller:
+            await self.judger_controller.abort.remote(judger_names=judger_names)
+
+    @ray_method
+    async def restart_judger(self, judger_names: list[str] | None = None):
+        """Clear judger abort state.
+
+        Args:
+            judger_names: If provided, only restart the specified judger groups.
+                If ``None``, restart all judger groups.
+        """
+        if self.judger_controller:
+            await self.judger_controller.restart_judger.remote(judger_names=judger_names)

--- a/xtuner/v1/ray/environment/single_turn_env.py
+++ b/xtuner/v1/ray/environment/single_turn_env.py
@@ -11,6 +11,7 @@ from xtuner.v1.data_proto.rl_data import (
     RLDataFlowItem,
     RLJudgerResponseItem,
     RLRolloutResponseItem,
+    RolloutState,
     is_valid_for_training,
     update_dataflow_item,
     update_rollout_item,
@@ -173,6 +174,11 @@ class RawSingleTurnEnvironment(BaseEnvironment):
                     for _ in group_data_items
                 ]
             group_data_items = update_dataflow_item(group_data_items, "env.judger", judger_responses)
+            # Mark items whose judger was aborted so they are treated as ABORTED
+            # rather than COMPLETED in downstream state determination.
+            for item, judger_resp in zip(group_data_items, judger_responses):
+                if isinstance(judger_resp.extra_info, dict) and judger_resp.extra_info.get("state") == "aborted":
+                    item.env.rollout.state = RolloutState.ABORTED
         return group_data_items
 
 

--- a/xtuner/v1/ray/judger/controller.py
+++ b/xtuner/v1/ray/judger/controller.py
@@ -138,6 +138,9 @@ class JudgerController:
             self.reward_judger.append(judger)
             self.reward_judger_names.append(config.judger_name)
             self.judger_instance_count += len(judger)
+        self._abort_on_pause_mask: list[bool] = [
+            cfg.abort_on_pause for cfg in self.judger_config.reward_judger_configs
+        ]
         self.enable_weighted_judgers = (
             False if len(self.reward_judger) == 1 else self.judger_config.enable_weighted_judgers
         )
@@ -269,36 +272,24 @@ class JudgerController:
             return judger_response_item[0]
         return judger_response_item
 
-    async def abort(self, judger_names: list[str] | None = None):
-        """Abort running judger requests.
-
-        Args:
-            judger_names: If provided, only abort judger groups whose name is
-                in this list. If ``None``, no judger groups are aborted.
-        """
-        if judger_names is None:
-            return
+    async def abort(self):
+        """Abort running judger requests whose config has
+        ``abort_on_pause=True``."""
         tasks = []
         for idx, judger_group in enumerate(self.reward_judger):
-            if self.reward_judger_names[idx] not in judger_names:
+            if not self._abort_on_pause_mask[idx]:
                 continue
             for actor in judger_group:
                 tasks.append(actor.abort.remote())
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
-    async def restart_judger(self, judger_names: list[str] | None = None):
-        """Clear abort state on judger actors.
-
-        Args:
-            judger_names: If provided, only restart judger groups whose name is
-                in this list. If ``None``, no judger groups are restarted.
-        """
-        if judger_names is None:
-            return
+    async def restart_judger(self):
+        """Clear abort state on judger actors whose config has
+        ``abort_on_pause=True``."""
         tasks = []
         for idx, judger_group in enumerate(self.reward_judger):
-            if self.reward_judger_names[idx] not in judger_names:
+            if not self._abort_on_pause_mask[idx]:
                 continue
             for actor in judger_group:
                 tasks.append(actor.restart.remote())

--- a/xtuner/v1/ray/judger/controller.py
+++ b/xtuner/v1/ray/judger/controller.py
@@ -268,3 +268,39 @@ class JudgerController:
         if input_type_is_list is False:
             return judger_response_item[0]
         return judger_response_item
+
+    async def abort(self, judger_names: list[str] | None = None):
+        """Abort running judger requests.
+
+        Args:
+            judger_names: If provided, only abort judger groups whose name is
+                in this list. If ``None``, no judger groups are aborted.
+        """
+        if judger_names is None:
+            return
+        tasks = []
+        for idx, judger_group in enumerate(self.reward_judger):
+            if self.reward_judger_names[idx] not in judger_names:
+                continue
+            for actor in judger_group:
+                tasks.append(actor.abort.remote())
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def restart_judger(self, judger_names: list[str] | None = None):
+        """Clear abort state on judger actors.
+
+        Args:
+            judger_names: If provided, only restart judger groups whose name is
+                in this list. If ``None``, no judger groups are restarted.
+        """
+        if judger_names is None:
+            return
+        tasks = []
+        for idx, judger_group in enumerate(self.reward_judger):
+            if self.reward_judger_names[idx] not in judger_names:
+                continue
+            for actor in judger_group:
+                tasks.append(actor.restart.remote())
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/xtuner/v1/ray/judger/native.py
+++ b/xtuner/v1/ray/judger/native.py
@@ -43,6 +43,7 @@ class NativeJudgerConfig(BaseModel):
     postprocess_func: Optional[Callable] = Field(default=None, exclude=True)
     request_timeout: float = 30.0
     extra_info: dict = Field(default={}, exclude=True)
+    abort_on_pause: bool = False
 
     def build_actor(self, pg: PlacementGroup, start_bundle_idx: int) -> List[ray.actor.ActorClass]:
         """Create and launch Ray actor instances for the GSM8K judger.

--- a/xtuner/v1/ray/judger/native.py
+++ b/xtuner/v1/ray/judger/native.py
@@ -264,3 +264,11 @@ class NativeJudger:
             str: The name of the judger.
         """
         return self.judger_name
+
+    async def abort(self):
+        """No-op abort for judgers that don't support cancellation."""
+        pass
+
+    def restart(self):
+        """No-op restart for judgers that don't support cancellation."""
+        pass


### PR DESCRIPTION
  ## Summary

  - Add `abort_judger_names` config to `DataFlowConfig` to specify which judger groups to abort
  on pause
  - On pause: send abort signal to targeted judger actors via `JudgerController.abort()`
  - On round reset: clear abort state via `JudgerController.restart_judger()`
  - Mark aborted judger items as `RolloutState.ABORTED` in single-turn env
  - `NativeJudger` provides no-op stubs; actual abort logic lives in custom judger
  implementations
  - `None` consistently means "abort no judgers" across all layers

  ## Changes

  | File | Change |
  |------|--------|
  | `xtuner/v1/ray/dataflow/flow.py` | `abort_judger_names` config, abort on pause, restart on reset |
  | `xtuner/v1/ray/environment/base_env.py` | `abort_judger()` and `restart_judger()` proxy methods |
  | `xtuner/v1/ray/environment/single_turn_env.py` | Mark aborted judger items as `RolloutState.ABORTED` |
  | `xtuner/v1/ray/judger/controller.py` | `abort()` and `restart_judger()` on JudgerController |
  | `xtuner/v1/ray/judger/native.py` | No-op `abort()`/`restart()` interface stubs |