### PR TITLE
[Refactor] Refactor load spec save planning

### DIFF
--- a/docs/design/load_spec_refactor.md
+++ b/docs/design/load_spec_refactor.md
@@ -1,0 +1,403 @@
+# LoadSpec 设计
+
+> 面向 `xtuner/v1/utils/load_spec.py` 与 `xtuner/v1/model/base.py` 的加载/保存路径。
+> TP 设计（`dense_tp.md`）依赖本文档描述的抽象。
+
+## TL;DR
+
+LoadSpec 描述 xtuner 运行时 tensor 与 HF safetensors 之间的**纯布局映射**。对一个
+param，它回答两件事：
+
+1. 这个 param 由哪些 HF key 组成？怎么拼？ — `global_hf_keys` + `fused_dim`
+2. 本 rank 持有全量 tensor 的哪一块？ — `shards`（按外到内顺序施加）
+
+加载/保存执行路径不直接读 LoadSpec，而是调用 `plan_hf_load()` /
+`plan_hf_save(...)` 拿到一份**不可变的 plan**，按 plan 驱动 IO 与通信。
+
+**核心约束**：LoadSpec 只承担"同 dtype 下的形状/索引映射"。fp8 的量化反量化、
+padding 的 zero-fill 等 dtype 语义都住在 `base.py` 的 load/save 路径里，
+LoadSpec 不感知。
+
+---
+
+## 1. 设计理念
+
+### 1.1 单一抽象，两条正交轴
+
+原先三类映射（SAME / FUSED / SHARD）统一成一个 schema 上的两个正交维度：
+
+| 问题 | 表达 |
+| --- | --- |
+| 这个 param 对应几个 HF key？怎么拼？ | `len(global_hf_keys)`；多 key 时 `fused_dim` 指定拼接维 |
+| 本 rank 持有哪一块？ | `shards`（可为空；按施加顺序排列） |
+
+消费方用派生属性 `is_fused` / `is_sharded` 查询，**不需要**任何枚举分支。
+
+### 1.2 多维切分按顺序叠加
+
+`shards` 是列表，原生支持 TP × FSDP、EP × FSDP 等多轴组合。每条
+`ShardDescriptor.start/end` 的含义是"在**前面所有** descriptor 切完之后的
+子 tensor 上的偏移"。这条规则完全对齐 DTensor `placements` 从 `mesh_dim=0` 到
+`mesh_dim=N-1` 逐步施加的语义 —— 你可以把 `shards[i]` 理解成 `placements[i]`
+在"此刻本 rank 实际持有"这个问题上的等价形式。
+
+### 1.3 Plan 是冻结快照
+
+`plan_hf_load()` / `plan_hf_save(...)` 返回的是 Pydantic dataclass：
+
+- 一次性从当前 LoadSpec 状态计算出执行所需的全部信息；
+- 不持有对 LoadSpec 的引用；
+- 执行器（`_load_hf_param` / `unshard_tensors_for_hf_save` / `_split_hf_tensors_for_save`）
+  只读 plan，**不读** LoadSpec。
+
+这条边界保证"布局规划"和"IO/通信执行"解耦。未来要接入新的持久化格式（例如
+DCP），只需要替换 plan 的消费者，不牵涉 LoadSpec 内部结构。
+
+### 1.4 fp8 与 LoadSpec 解耦
+
+LoadSpec 是"同 dtype 下的布局描述"。fp8 涉及的两件事 —— 量化/反量化、运行时
+padding —— 归属如下：
+
+- **运行时 padding**：用 `LoadSpec.origin_shape` 表达 checkpoint-visible shape
+  （剥掉运行时 padding 之后）。今天这个字段的唯一来源是 fp8 tensor metadata；
+  它只记录 shape，不记录 dtype / wrapper 类型。
+- **量化/反量化**：只在 `base.py._to_float8` / 反量化分支里现场判断（通过
+  `is_float8_weight(tensor)`）。LoadSpec 不包含 `runtime_is_float8` 这类
+  dtype-specific 字段。
+
+### 1.5 Spec → Plan → Executor 的分层
+
+```
+┌────────────────────┐  plan_hf_load()    ┌──────────────┐
+│                    │ ──────────────────▶│ HFLoadPlan   │──▶ _load_hf_param
+│     LoadSpec       │                    └──────────────┘
+│  (pure layout)     │  plan_hf_save(...) ┌──────────────┐
+│                    │ ──────────────────▶│ HFSavePlan   │──▶ unshard_tensors_for_hf_save
+└────────────────────┘                    └──────────────┘                    │
+                                                                              ▼
+                                                                      _split_hf_tensors_for_save
+```
+
+"Spec 是源、Plan 是派生、Executor 只依赖 Plan"。这条线保持单向。
+
+---
+
+## 2. 数据模型
+
+### 2.1 `ShardDescriptor`
+
+```python
+class ShardDescriptor(BaseModel):
+    dim: int                           # 被切的维
+    start: int                         # 在"前面切完的 sub-tensor"上的起点
+    end: int                           # 在"前面切完的 sub-tensor"上的终点
+    group: dist.ProcessGroup           # 产生这次切分的通信组
+```
+
+`group` 是 load/save 双向通信域。load 时只需要知道本 rank 的范围；save 时需要沿
+`group` 做 all-gather 复原全量 tensor。
+
+### 2.2 `LoadSpec`
+
+```python
+class LoadSpec(BaseModel):
+    name: str                          # xtuner 侧 fully-qualified param name
+    global_hf_keys: list[str]          # 对应的 HF key 列表（按 fused_dim 拼接顺序）
+    global_shape: tuple[int, ...]      # 全量 tensor（fused 之后）的 runtime shape
+                                       # 可能包含运行时 padding（例如 fp8 的 FSDP 对齐 pad）
+    fused_dim: int | None = None       # 多 HF key 时的拼接维；单 key 时必须为 None
+    shards: list[ShardDescriptor] = [] # 从外到内的切分列表
+    origin_shape: tuple[int, ...] | None = None  # checkpoint-visible shape after runtime padding is trimmed
+                                       # None 表示"runtime shape 就是 checkpoint shape"
+```
+
+派生属性：
+
+```python
+is_fused            # len(global_hf_keys) > 1
+is_sharded          # bool(shards)
+unpadded_global_shape  # origin_shape or global_shape
+```
+
+**不变量**（`model_post_init` 强制）：
+
+- `is_fused` ⇔ `fused_dim is not None`；
+- 每条 shard 的 `start/end` 必须落在"前面切完之后的 sub-tensor"范围内；
+- 若 `origin_shape` 给定，它的秩与 `global_shape` 相同，且每维 `≤ global_shape`。
+
+### 2.3 `HFLoadPlan`
+
+`plan_hf_load()` 的产出：
+
+```python
+class HFLoadPlan(BaseModel):
+    name: str
+    hf_keys: list[str]                 # 本 rank 实际需要读的 HF key
+    fused_dim: int | None = None       # 多 key 时的拼接维
+    slices: list[LoadSlice] = []       # 读完拼接后，再做的 narrow 列表
+    zero_fill: bool = False            # 本 rank 完全落在运行时 padding 区，跳过 IO
+```
+
+`slices` 的 start/end 是**相对已加载 tensor 的坐标**，不是相对 `global_shape`。
+zero_fill=True 时 `hf_keys` 和 `slices` 都为空。
+
+### 2.4 `HFSavePlan`
+
+`plan_hf_save(...)` 的产出，承载两类信息：
+
+```python
+class HFSavePlan(BaseModel):
+    name: str
+    hf_keys: list[str]                  # 当前 save tensor 最终要写/同步的 HF keys
+    global_shape: tuple[int, ...]
+    unpadded_global_shape: tuple[int, ...]
+    fused_dim: int | None = None
+    distributed_save: bool = False
+    preserves_shards: bool = False      # True 表示 hf_keys 来自保留 shard 后的局部 tensor
+    unshard_steps: list[SaveShardStep] = []      # 所有 shard 的逆操作 + preserved 标记
+```
+
+`SaveShardStep` 记录一次 shard 在"施加前的 runtime shape / checkpoint-visible
+shape"两个快照 —— save 执行时倒序跑每一步、all-gather 还原、narrow 回
+checkpoint-visible shape。`preserved` 标记把某些 shard 排除在 all-gather 之外
+（见 §3.3）。`HFSavePlan.hf_keys` 始终是执行器要处理的 key 集合：普通 save 下
+它是完整 HF key list，preserved shard save 下它是当前局部 shard 覆盖的 key list。
+
+---
+
+## 3. 计划生成
+
+### 3.1 `plan_hf_load()`
+
+不接受参数 —— 本 rank 的所有信息已经在 LoadSpec 里。步骤：
+
+1. 计算本 rank 最终持有的区间 `final_intervals`（顺序应用 `shards`）；
+2. 用 `unpadded_global_shape` 裁剪掉运行时 padding 部分；若裁完为空，返回
+   `zero_fill=True`；
+3. 若 `is_fused`，按 `fused_dim` 上的区间算出需要的 HF key 下标范围（floor/ceil
+   支持 mid-key shard，例如 FSDP 在 EP-local 专家 tensor 内部再切）；
+4. 对每个 dim，如果"最终区间"比"加载后的 tensor 区间"窄，生成一条 `LoadSlice`。
+
+### 3.2 `plan_hf_save(distributed_save=, preserve_process_group=, gather_process_group=)`
+
+三个参数对应三种 save 策略，互斥使用：
+
+| 参数 | 用途 |
+| --- | --- |
+| `distributed_save=True` | HF save：非 fused tensor 只在 rank0 写；fused tensor 的 HF key 在 save rank 间分配 |
+| `preserve_process_group=ep_group` | RL 权重同步：保留 EP 在 `fused_dim` 上的 shard，每个 EP rank 只流自己的 expert key；其他 shard 照常 all-gather |
+| `gather_process_group=fsdp_group` | FSDP-only all-gather：只 gather 这个 group 的 shard，其他 shard 保留 |
+
+策略统一落到 `_preserved_shard_indices` 这一步上 —— 决定哪些 `LoadSpec.shards`
+需要保留。之后 `_save_shard_steps` 给每个 shard 生成带 `preserved` 标记的
+`SaveShardStep`。若有 preserved shard，`LoadSpec` 直接从这些 shard 推导
+`HFSavePlan.hf_keys`；save plan 只暴露最终要写/同步的 HF keys，以及
+`preserves_shards` 说明这些 keys 来自局部 tensor 还是完整 tensor。
+
+### 3.3 preserve vs gather 的正交性
+
+`preserve_process_group` 是"显式保留某个 group"的策略，`gather_process_group`
+是"显式 gather 某个 group（其余保留）"的策略。两者不能同时使用（assert 拦截）。
+在今天的代码里：
+
+- 普通 HF save：两者都不传，全部 all-gather；
+- RL 权重同步：传 `preserve_process_group=ep_group`；
+- `_fsdp_foreach_allgather`：传 `gather_process_group=fsdp_group`，只做 FSDP
+  层的 all-gather，不动 EP / TP。
+
+---
+
+## 4. 执行
+
+### 4.1 加载路径
+
+```python
+def _load_hf_param(self, param, load_spec, loader):
+    plan = load_spec.plan_hf_load()
+    if plan.zero_fill:
+        # 本 rank 只持有运行时 padding，写 0 返回
+        local_tensor.zero_()
+        return []
+    # 按 plan.hf_keys 逐个读（fp8 走 dequant 分支，这里 base.py 现场处理）
+    loaded_tensors = self._load_hf_keys(plan, loader, ...)
+    # 拼接 + narrow 全部交给 safetensors_to_params
+    self.safetensors_to_params(loaded_tensors, local_tensor, plan)
+```
+
+`safetensors_to_params` 的签名是 `(safetensors, local_tensor, plan)`。三个 MoE
+子类（`gpt_oss`、`qwen3_5_text`、`qwen3vl_text`）按 `plan.name` 做 reshape /
+transpose 等模型特有变换后，调通用的 `_apply_load_slices` + `_copy_loaded_tensor_to_local`。
+
+### 4.2 保存路径
+
+所有 save 场景（HF save、RL 权重同步、FSDP-only gather）共用一条管道：
+
+```python
+save_items = [HFSaveItem(tensor, load_spec.plan_hf_save(...)) for ...]
+full_tensors = unshard_tensors_for_hf_save(save_items)
+for full_tensor, item in zip(full_tensors, save_items):
+    names, tensors = self._split_hf_tensors_for_save(full_tensor, item.save_plan)
+```
+
+`unshard_tensors_for_hf_save` 自带**依赖感知的批量 foreach all-gather**：
+
+- 同一个 tensor 的多个 step 必须串行（例如 "先还原 FSDP，再还原 EP"）；
+- 不同 tensor 的 step 如果 `(group, dtype)` 兼容，可以 foreach 批到同一次 NCCL 调用。
+
+每一轮由 `_build_ready_save_unshard_groups` 从每个 pending 队列取头部 step，按
+group + dtype 分桶；`_foreach_all_gather_save_shards` 跑一次批量 gather；下一轮
+再消费队列的下一层。MoE EP+FSDP 的 save 就是这样两轮跑完的。
+
+### 4.3 `HFSaveItem`
+
+```python
+class HFSaveItem(NamedTuple):
+    tensor: torch.Tensor
+    save_plan: HFSavePlan
+```
+
+这是**跨 LoadSpec 和 BaseModel 边界**的 bundle：一边是 runtime tensor（模型侧
+概念，带 fp8 wrapper / DTensor wrapper），一边是纯布局的 `HFSavePlan`。它的
+归属地是 `base.py` ——`load_spec.py` 保持"不认识模型侧概念"。
+`unshard_tensors_for_hf_save` 的签名使用两个平行列表（`list[torch.Tensor]` +
+`list[HFSavePlan]`）而不是 `list[HFSaveItem]`，避免 `load_spec.py` 反向依赖
+`base.py`。
+
+---
+
+## 5. 调用时机
+
+`_init_load_spec` 被定位为"从当前 DTensor 布局反推 HF 映射的纯函数"。
+调用约定：**谁改 param 布局谁负责重算，后者覆盖前者**。
+
+| 时机 | 调用方 | spec 代表 |
+| --- | --- | --- |
+| 子类 `__init__` 末尾 | 子类自己 | 构建完成时的布局（EP-only / Replicate / 其它 init-time 切分） |
+| `parallelize(tp_mesh)` 结束 | `BaseModel.parallelize` | TP + 已有切分 |
+| `fully_shard` 结束 | `BaseModel.fully_shard` | 叠加 FSDP（训练态） |
+| `Float8Handler.pad_for_fsdp` 回调 | 回调内 | fp8 pad 后的真实 shape |
+
+`from_hf` / `save_hf` 入口有 assert 兜底：
+
+```python
+assert "load_spec_mapping" in self.__dict__, (
+    f"{type(self).__name__}.__init__ must call self._init_load_spec() at the end."
+)
+```
+
+这条约定是硬契约；子类若跳过会在第一次 load/save 时被抓。
+
+---
+
+## 6. 示例
+
+### 6.1 Dense, tp=2, fsdp=4, `q_proj.weight`
+
+```python
+LoadSpec(
+    name="layers.0.self_attn.q_proj.weight",
+    global_hf_keys=["model.layers.0.self_attn.q_proj.weight"],
+    global_shape=(n*d, h),
+    fused_dim=None,
+    shards=[
+        ShardDescriptor(dim=0, start=tp_start,   end=tp_end,   group=tp_group),
+        ShardDescriptor(dim=0, start=fsdp_start, end=fsdp_end, group=fsdp_group),
+    ],
+)
+```
+
+`fsdp_start/end` 相对于"已经被 TP 切过的 sub-tensor"而言，不是相对
+`global_shape`。
+
+### 6.2 MoE, ep=8, fsdp=4, fused expert weight
+
+```python
+LoadSpec(
+    name="layers.0.experts.fused_w1w3.weight",
+    global_hf_keys=[f"model.layers.0.mlp.experts.{i}.gate_proj.weight" for i in range(64)]
+                 + [f"model.layers.0.mlp.experts.{i}.up_proj.weight"  for i in range(64)],
+    global_shape=(128 * I_padded, H),    # I_padded 含 fp8 FSDP 对齐 pad
+    fused_dim=0,
+    shards=[
+        ShardDescriptor(dim=0, start=ep_start,   end=ep_end,   group=ep_group),
+        ShardDescriptor(dim=0, start=fsdp_start, end=fsdp_end, group=fsdp_group),
+    ],
+    origin_shape=(128 * I, H),           # 剥掉 pad 后的 checkpoint shape
+)
+```
+
+RL 权重同步调用 `plan_hf_save(preserve_process_group=ep_group)` —— EP shard 被
+标记 preserved，保存管道只做 FSDP 还原，结果留在 EP-local 坐标系；再由
+`_request_ep_sequential_update` 按 EP rank 顺序广播。
+
+### 6.3 embed_tokens, 纯 FSDP
+
+```python
+LoadSpec(
+    name="embed_tokens.weight",
+    global_hf_keys=["model.embed_tokens.weight"],
+    global_shape=(V, H),
+    fused_dim=None,
+    shards=[ShardDescriptor(dim=0, start=fsdp_start, end=fsdp_end, group=fsdp_group)],
+)
+```
+
+---
+
+## 7. 为什么这样设计
+
+几个关键取舍的归档。
+
+### 7.1 为什么 `shards` 是列表而不是单轴四元组
+
+旧的 `(dim, shard_start, shard_end, group)` 只表达一刀。TP × FSDP 或 EP × FSDP
+是常见组合，旧 schema 只能靠"加载时临时推导第二刀"这种硬编码绕过（
+`FSDP_SHARD_DIM == 0` 就是这条路径的残留）。列表 + DTensor 施加顺序是最小的
+统一表达。
+
+### 7.2 为什么删 `LoadEnum`
+
+`SAME/FUSED/SHARD` 给定 `global_hf_keys` 和 `shards` 后是可派生的。保留它相当于
+同一份状态的两种表达，下游分支要同步维护。直接用 `is_fused` / `is_sharded` 两个
+独立 bool 可以正交表达所有组合（包括原本需要新造 `FUSED_SHARD` 的情况）。
+
+### 7.3 为什么 fp8 不进 LoadSpec
+
+LoadSpec 的定位是"同 dtype 下的映射"。fp8 涉及的反量化需要的是 tensor 的真实
+dtype / wrapper 类型，这些只有在 IO 路径里拿到 runtime tensor 才能判断。若把
+`runtime_is_float8` 放进 spec，一方面是状态重复（`is_float8_weight(tensor)` 已经
+是事实来源），另一方面污染 LoadSpec 的语义 —— 它不再是纯布局描述。
+
+`origin_shape` 是 checkpoint-visible shape。它今天只服务 fp8 runtime padding，
+但仍然只携带 shape 信息；fp8 的 dtype / wrapper 判断不进入 LoadSpec。
+
+### 7.4 为什么 `unshard_tensors_for_hf_save` 住在 `load_spec.py`
+
+尽管它做的是分布式 all-gather，但它**只依赖 HFSavePlan + 一个通信原语**。把它
+放在 `load_spec.py` 让"spec → plan → 执行"三层都在一个文件里闭环，调用方
+（base.py）只需要准备 `(tensor, plan)` 对，不需要理解 shard 调度。
+
+若将来 `unshard_tensors_for_hf_save` 进一步膨胀，可以拆到独立模块（例如
+`save_runner.py`），但当前规模尚不需要。
+
+### 7.5 为什么保存不用 `_fuse_contiguous_chunks_without_alloc`
+
+旧代码对 `dim == 0` 的单 tensor all-gather 用过一个零拷贝 view 合并优化。这条
+优化只在"一次 gather 一个 tensor"时成立 —— 当前批量 foreach 把多个 tensor 交错
+塞进同一个扁平缓冲区，per-tensor chunks 不再连续，这条路径失效。换掉 NCCL 调用
+次数（O(num_tensors) → O(rounds)）比 dim=0 多一次 cat alloc 更划算。如果某个
+特定场景发现这次 trade-off 不值，可以单独给那条路走非批量路径，但默认策略保持
+批量。
+
+---
+
+## 8. 测试
+
+核心测试都在 `tests/utils/test_load_spec.py`：
+
+- `TestLoadSpecSchema`：字段契约 + `shards` 顺序验证；
+- `TestHFLoadPlan`：`plan_hf_load` 在 fused / non-fused / fp8 padding 下的产出；
+- `TestHFSavePolicy`：`distributed_save` 的 HF key 分配规则。
+
+行为等价性由 `tests/model/test_qwen3_dense.py::test_save_hf` 和
+`tests/model/test_qwen3_moe.py::test_save_hf` 的 safetensors bit-equal 保证。

--- a/tests/utils/test_load_spec.py
+++ b/tests/utils/test_load_spec.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import Shard as DTensorShard
 from torch.distributed.tensor import distribute_tensor
+from torch.distributed.tensor.placement_types import _StridedShard
 
 from xtuner.v1.model.base import BaseModel, XTunerBaseModelConfig
 from xtuner.v1.utils import load_spec as load_spec_module
@@ -73,6 +74,28 @@ class TestLoadSpecSchema:
         assert spec.fused_dim is None
         assert [(shard.dim, shard.start, shard.end) for shard in spec.shards] == [(0, 0, 128)]
 
+    def test_dtensor_shards_follow_explicit_placement_order(self, single_rank_group: dist.ProcessGroup) -> None:
+        class FakeDeviceMesh:
+            shape = (2, 2)
+
+            def size(self, mesh_dim: int) -> int:
+                return self.shape[mesh_dim]
+
+            def get_local_rank(self, mesh_dim: int) -> int:
+                return (1, 0)[mesh_dim]
+
+            def get_group(self, mesh_dim: int) -> dist.ProcessGroup:
+                return single_rank_group
+
+        class FakeDTensor:
+            shape = (8,)
+            placements = (_StridedShard(0, split_factor=2), DTensorShard(0))
+            device_mesh = FakeDeviceMesh()
+
+        shards = load_spec_module._dtensor_shards(FakeDTensor())  # type: ignore[arg-type]
+
+        assert [(shard.dim, shard.start, shard.end) for shard in shards] == [(0, 0, 4), (0, 2, 4)]
+
     def test_fused_spec_requires_fused_dim(self) -> None:
         with pytest.raises(ValidationError, match="fused_dim"):
             LoadSpec(
@@ -113,6 +136,19 @@ class TestLoadSpecSchema:
                     ShardDescriptor(dim=0, start=65, end=80, group=single_rank_group),
                 ],
             )
+
+    def test_zero_size_dtensor_shards_are_valid(self, single_rank_group: dist.ProcessGroup) -> None:
+        spec = LoadSpec(
+            name="embeddings.cls_embedding",
+            global_hf_keys=["embeddings.cls_embedding"],
+            global_shape=(1, 1, 1024),
+            shards=[ShardDescriptor(dim=0, start=1, end=1, group=single_rank_group)],
+        )
+
+        plan = spec.plan_hf_load()
+
+        assert plan.zero_fill is True
+        assert plan.hf_keys == []
 
 
 class TestHFLoadPlan:
@@ -361,3 +397,27 @@ class TestHFSaveUnshardScheduler:
 
         assert [tuple(tensor.shape) for tensor in output] == [(8, 2), (4, 2)]
         assert [call["shapes"] for call in calls] == [[(4, 2), (4, 2)], [(8, 2)]]
+
+
+class TestBaseModelHFSave:
+    """BaseModel save should preserve state semantics outside LoadSpec."""
+
+    def test_non_dtensor_buffers_keep_runtime_dtype(self) -> None:
+        class BufferModel(BaseModel):
+            def __init__(self) -> None:
+                super().__init__(XTunerBaseModelConfig())
+                self.register_buffer("rotary_coef", torch.tensor([1.25], dtype=torch.float32), persistent=True)
+                self._init_load_spec()
+
+            def to_hf_key_list(self, key: str) -> list[str]:
+                return [key]
+
+        model = BufferModel()
+
+        [(names, tensors)] = list(
+            model._get_hf_param(model._load_spec_params(), dtype=torch.bfloat16, distributed_save=True)
+        )
+
+        assert names == ["rotary_coef"]
+        assert tensors[0].dtype == torch.float32
+        assert torch.equal(tensors[0], model.rotary_coef)

--- a/tests/utils/test_load_spec.py
+++ b/tests/utils/test_load_spec.py
@@ -1,0 +1,363 @@
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from pydantic import ValidationError
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Shard as DTensorShard
+from torch.distributed.tensor import distribute_tensor
+
+from xtuner.v1.model.base import BaseModel, XTunerBaseModelConfig
+from xtuner.v1.utils import load_spec as load_spec_module
+from xtuner.v1.utils.load_spec import LoadSpec, ShardDescriptor, unshard_tensors_for_hf_save
+
+
+@pytest.fixture(scope="module")
+def single_rank_group() -> dist.ProcessGroup:
+    # ShardDescriptor.group is typed as `dist.ProcessGroup`; Pydantic enforces
+    # the isinstance check even with `arbitrary_types_allowed=True`, so schema
+    # tests need a real (but minimal) process group. A single-rank gloo group
+    # is sufficient and avoids any CUDA / multi-process plumbing.
+    if not dist.is_initialized():
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29555")
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+    group = dist.group.WORLD
+    assert group is not None
+    return group
+
+
+class TestLoadSpecSchema:
+    """New-schema fields should describe layout without legacy dispatch state."""
+
+    def test_same_unsharded_spec(self) -> None:
+        spec = LoadSpec(
+            name="layers.0.mlp.gate.weight",
+            global_hf_keys=["model.layers.0.mlp.gate.weight"],
+            global_shape=(128, 64),
+        )
+
+        assert spec.is_fused is False
+        assert spec.is_sharded is False
+        assert spec.fused_dim is None
+        assert spec.shards == []
+        assert spec.origin_shape is None
+        assert spec.unpadded_global_shape == spec.global_shape
+
+    def test_from_tensor_derives_plain_tensor_layout(self) -> None:
+        spec = LoadSpec.from_tensor(
+            name="layers.0.experts.fused_w1w3.weight",
+            hf_keys=["k0", "k1"],
+            tensor=torch.empty(128, 64),
+            origin_shape=(120, 64),
+        )
+
+        assert spec.global_hf_keys == ["k0", "k1"]
+        assert spec.global_shape == (128, 64)
+        assert spec.fused_dim == 0
+        assert spec.shards == []
+        assert spec.origin_shape == (120, 64)
+
+    def test_from_tensor_derives_dtensor_shards(self, single_rank_group: dist.ProcessGroup) -> None:
+        assert single_rank_group is not None
+        mesh = DeviceMesh("cpu", [0])
+        tensor = distribute_tensor(torch.empty(128, 64), mesh, [DTensorShard(0)])
+
+        spec = LoadSpec.from_tensor(name="layers.0.mlp.gate.weight", hf_keys=["gate"], tensor=tensor)
+
+        assert spec.global_hf_keys == ["gate"]
+        assert spec.global_shape == (128, 64)
+        assert spec.fused_dim is None
+        assert [(shard.dim, shard.start, shard.end) for shard in spec.shards] == [(0, 0, 128)]
+
+    def test_fused_spec_requires_fused_dim(self) -> None:
+        with pytest.raises(ValidationError, match="fused_dim"):
+            LoadSpec(
+                name="layers.0.mlp.fused_w1w3.weight",
+                global_hf_keys=[
+                    "model.layers.0.mlp.experts.0.gate_proj.weight",
+                    "model.layers.0.mlp.experts.0.up_proj.weight",
+                ],
+                global_shape=(256, 64),
+            )
+
+    def test_multi_axis_shards_preserve_order(self, single_rank_group: dist.ProcessGroup) -> None:
+        ep = ShardDescriptor(dim=0, start=64, end=128, group=single_rank_group)
+        fsdp = ShardDescriptor(dim=0, start=16, end=32, group=single_rank_group)
+        spec = LoadSpec(
+            name="layers.0.experts.fused_w1w3.weight",
+            global_hf_keys=[
+                "model.layers.0.mlp.experts.0.gate_proj.weight",
+                "model.layers.0.mlp.experts.0.up_proj.weight",
+            ],
+            global_shape=(256, 64),
+            fused_dim=0,
+            shards=[ep, fsdp],
+        )
+
+        assert [(shard.start, shard.end) for shard in spec.shards] == [(64, 128), (16, 32)]
+        assert spec.is_fused is True
+        assert spec.is_sharded is True
+
+    def test_ordered_shard_bounds_are_validated(self, single_rank_group: dist.ProcessGroup) -> None:
+        with pytest.raises(ValidationError, match="Invalid shard descriptor"):
+            LoadSpec(
+                name="layers.0.experts.fused_w1w3.weight",
+                global_hf_keys=["model.layers.0.mlp.experts.0.gate_proj.weight"],
+                global_shape=(128, 64),
+                shards=[
+                    ShardDescriptor(dim=0, start=64, end=128, group=single_rank_group),
+                    ShardDescriptor(dim=0, start=65, end=80, group=single_rank_group),
+                ],
+            )
+
+
+class TestHFLoadPlan:
+    """LoadSpec should derive HF read plans from shards only."""
+
+    def test_fused_slice_selects_overlapping_hf_keys(self, single_rank_group: dist.ProcessGroup) -> None:
+        spec = LoadSpec(
+            name="layers.0.experts.fused_w1w3.weight",
+            global_hf_keys=["k0", "k1", "k2", "k3"],
+            global_shape=(400, 64),
+            fused_dim=0,
+            shards=[ShardDescriptor(dim=0, start=150, end=260, group=single_rank_group)],
+        )
+
+        plan = spec.plan_hf_load()
+
+        assert plan.hf_keys == ["k1", "k2"]
+        assert plan.fused_dim == 0
+        assert [(load_slice.dim, load_slice.start, load_slice.end) for load_slice in plan.slices] == [(0, 50, 160)]
+        assert not hasattr(plan, "loaded_shape")
+
+    def test_non_fused_slice_keeps_single_hf_key(self, single_rank_group: dist.ProcessGroup) -> None:
+        spec = LoadSpec(
+            name="layers.0.self_attn.q_proj.weight",
+            global_hf_keys=["q_proj"],
+            global_shape=(128, 256),
+            shards=[ShardDescriptor(dim=1, start=64, end=192, group=single_rank_group)],
+        )
+
+        plan = spec.plan_hf_load()
+
+        assert plan.hf_keys == ["q_proj"]
+        assert plan.fused_dim is None
+        assert [(load_slice.dim, load_slice.start, load_slice.end) for load_slice in plan.slices] == [(1, 64, 192)]
+
+    def test_origin_shape_clips_runtime_padding(self, single_rank_group: dist.ProcessGroup) -> None:
+        spec = LoadSpec(
+            name="layers.0.experts.fused_w1w3.weight",
+            global_hf_keys=["k0", "k1", "k2", "k3"],
+            global_shape=(480, 64),
+            fused_dim=0,
+            shards=[ShardDescriptor(dim=0, start=350, end=450, group=single_rank_group)],
+            origin_shape=(400, 64),
+        )
+
+        plan = spec.plan_hf_load()
+
+        assert plan.hf_keys == ["k3"]
+        assert [(load_slice.dim, load_slice.start, load_slice.end) for load_slice in plan.slices] == [(0, 50, 100)]
+        assert plan.zero_fill is False
+
+    def test_origin_shape_returns_zero_fill_for_pad_only_rank(self, single_rank_group: dist.ProcessGroup) -> None:
+        spec = LoadSpec(
+            name="layers.0.experts.fused_w1w3.weight",
+            global_hf_keys=["k0", "k1", "k2", "k3"],
+            global_shape=(480, 64),
+            fused_dim=0,
+            shards=[ShardDescriptor(dim=0, start=420, end=480, group=single_rank_group)],
+            origin_shape=(400, 64),
+        )
+
+        plan = spec.plan_hf_load()
+
+        assert plan.zero_fill is True
+        assert plan.hf_keys == []
+        assert plan.slices == []
+
+
+class TestHFSavePolicy:
+    """HF save should preserve the old distributed write policy from the new schema."""
+
+    def test_fused_keys_are_split_across_save_ranks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        model = BaseModel(XTunerBaseModelConfig())
+        model.config.hf_save_cfg.max_save_rank = 4
+        spec = LoadSpec(
+            name="layers.0.experts.fused_w1w3.weight",
+            global_hf_keys=[f"k{i}" for i in range(8)],
+            global_shape=(800, 64),
+            fused_dim=0,
+        )
+
+        monkeypatch.setattr(dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(dist, "get_world_size", lambda group=None: 8)
+
+        expected_ranges = {
+            0: (0, 2),
+            1: (2, 4),
+            2: (4, 6),
+            3: (6, 8),
+            4: (0, 0),
+        }
+        for rank, expected_range in expected_ranges.items():
+            monkeypatch.setattr(dist, "get_rank", lambda group=None, rank=rank: rank)
+            assert model._hf_save_key_range(spec.plan_hf_save(distributed_save=True)) == expected_range
+
+    def test_preserved_fused_shard_exposes_local_hf_keys(self, single_rank_group: dist.ProcessGroup) -> None:
+        spec = LoadSpec(
+            name="layers.0.experts.fused_w1w3.weight",
+            global_hf_keys=["k0", "k1", "k2", "k3"],
+            global_shape=(400, 64),
+            fused_dim=0,
+            shards=[ShardDescriptor(dim=0, start=100, end=200, group=single_rank_group)],
+        )
+
+        save_plan = spec.plan_hf_save(preserve_process_group=single_rank_group)
+
+        assert save_plan.preserves_shards is True
+        assert save_plan.hf_keys == ["k1"]
+
+    def test_preserved_fused_shard_must_align_with_hf_key_boundary(self, single_rank_group: dist.ProcessGroup) -> None:
+        spec = LoadSpec(
+            name="layers.0.experts.fused_w1w3.weight",
+            global_hf_keys=["k0", "k1", "k2", "k3"],
+            global_shape=(400, 64),
+            fused_dim=0,
+            shards=[ShardDescriptor(dim=0, start=50, end=150, group=single_rank_group)],
+        )
+
+        with pytest.raises(AssertionError, match="must align with HF key size"):
+            spec.plan_hf_save(preserve_process_group=single_rank_group)
+
+
+class TestHFSaveUnshardScheduler:
+    """Save unshard should batch independent work without violating per-tensor dependencies."""
+
+    @staticmethod
+    def _patch_foreach_all_gather(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+        calls: list[dict[str, object]] = []
+
+        def fake_foreach_all_gather(
+            tensor_list: list[torch.Tensor],
+            group: dist.ProcessGroup,
+        ) -> list[list[torch.Tensor]]:
+            calls.append(
+                {
+                    "group": group,
+                    "shapes": [tuple(tensor.shape) for tensor in tensor_list],
+                    "dtypes": [tensor.dtype for tensor in tensor_list],
+                }
+            )
+            return [[tensor] for tensor in tensor_list]
+
+        monkeypatch.setattr(load_spec_module, "foreach_all_gather", fake_foreach_all_gather)
+        return calls
+
+    def test_single_tensor_single_step(
+        self, monkeypatch: pytest.MonkeyPatch, single_rank_group: dist.ProcessGroup
+    ) -> None:
+        calls = self._patch_foreach_all_gather(monkeypatch)
+        spec = LoadSpec(
+            name="layers.0.mlp.gate.weight",
+            global_hf_keys=["gate"],
+            global_shape=(4, 2),
+            shards=[ShardDescriptor(dim=0, start=1, end=3, group=single_rank_group)],
+        )
+
+        output = unshard_tensors_for_hf_save(
+            [torch.ones(2, 2)],
+            [spec.plan_hf_save()],
+        )
+
+        assert [tuple(tensor.shape) for tensor in output] == [(4, 2)]
+        assert [call["shapes"] for call in calls] == [[(4, 2)]]
+
+    def test_same_group_same_dtype_tensors_are_batched(
+        self, monkeypatch: pytest.MonkeyPatch, single_rank_group: dist.ProcessGroup
+    ) -> None:
+        calls = self._patch_foreach_all_gather(monkeypatch)
+        specs = [
+            LoadSpec(
+                name="layers.0.mlp.gate.weight",
+                global_hf_keys=["gate"],
+                global_shape=(4, 2),
+                shards=[ShardDescriptor(dim=0, start=1, end=3, group=single_rank_group)],
+            ),
+            LoadSpec(
+                name="layers.0.mlp.up.weight",
+                global_hf_keys=["up"],
+                global_shape=(6, 2),
+                shards=[ShardDescriptor(dim=0, start=2, end=5, group=single_rank_group)],
+            ),
+        ]
+
+        output = unshard_tensors_for_hf_save(
+            [torch.ones(2, 2), torch.ones(3, 2)],
+            [spec.plan_hf_save() for spec in specs],
+        )
+
+        assert [tuple(tensor.shape) for tensor in output] == [(4, 2), (6, 2)]
+        assert [call["shapes"] for call in calls] == [[(4, 2), (6, 2)]]
+
+    def test_same_group_different_dtype_tensors_are_split(
+        self, monkeypatch: pytest.MonkeyPatch, single_rank_group: dist.ProcessGroup
+    ) -> None:
+        calls = self._patch_foreach_all_gather(monkeypatch)
+        specs = [
+            LoadSpec(
+                name="layers.0.mlp.gate.weight",
+                global_hf_keys=["gate"],
+                global_shape=(4, 2),
+                shards=[ShardDescriptor(dim=0, start=1, end=3, group=single_rank_group)],
+            ),
+            LoadSpec(
+                name="layers.0.mlp.up.weight",
+                global_hf_keys=["up"],
+                global_shape=(4, 2),
+                shards=[ShardDescriptor(dim=0, start=1, end=3, group=single_rank_group)],
+            ),
+        ]
+
+        output = unshard_tensors_for_hf_save(
+            [torch.ones(2, 2, dtype=torch.float32), torch.ones(2, 2, dtype=torch.float64)],
+            [spec.plan_hf_save() for spec in specs],
+        )
+
+        assert [tuple(tensor.shape) for tensor in output] == [(4, 2), (4, 2)]
+        assert [call["dtypes"] for call in calls] == [[torch.float32], [torch.float64]]
+
+    def test_multi_step_tensor_waits_for_previous_step(
+        self, monkeypatch: pytest.MonkeyPatch, single_rank_group: dist.ProcessGroup
+    ) -> None:
+        calls = self._patch_foreach_all_gather(monkeypatch)
+        specs = [
+            LoadSpec(
+                name="layers.0.experts.fused_w1w3.weight",
+                global_hf_keys=["k0", "k1"],
+                global_shape=(8, 2),
+                fused_dim=0,
+                shards=[
+                    ShardDescriptor(dim=0, start=0, end=4, group=single_rank_group),
+                    ShardDescriptor(dim=0, start=1, end=3, group=single_rank_group),
+                ],
+            ),
+            LoadSpec(
+                name="layers.0.mlp.gate.weight",
+                global_hf_keys=["gate"],
+                global_shape=(4, 2),
+                shards=[ShardDescriptor(dim=0, start=1, end=3, group=single_rank_group)],
+            ),
+        ]
+
+        output = unshard_tensors_for_hf_save(
+            [torch.ones(2, 2), torch.ones(2, 2)],
+            [spec.plan_hf_save() for spec in specs],
+        )
+
+        assert [tuple(tensor.shape) for tensor in output] == [(8, 2), (4, 2)]
+        assert [call["shapes"] for call in calls] == [[(4, 2), (4, 2)], [(8, 2)]]

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -1,6 +1,5 @@
 import importlib
 import json
-import math
 import pydoc
 import re
 from concurrent.futures import Future, ThreadPoolExecutor, wait
@@ -9,12 +8,11 @@ from importlib import import_module
 from itertools import chain
 from pathlib import Path
 from shutil import copy, copytree
-from typing import Annotated, Any, Generator, Iterable, Literal, Mapping, Sequence, cast
+from typing import Annotated, Any, Generator, Iterable, Literal, Mapping, NamedTuple, Sequence, cast
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-import torch.nn.functional as F
 from cyclopts import Parameter
 from more_itertools import consume
 from pydantic import BaseModel as PydanticBaseModel
@@ -27,10 +25,7 @@ from torch.distributed.fsdp import (
     MixedPrecisionPolicy,
     fully_shard,
 )
-from torch.distributed.tensor import DTensor, Placement, Replicate, Shard, distribute_tensor
-from torch.distributed.tensor._utils import (
-    compute_local_shape_and_global_offset as _compute_local_shape_and_global_offset,
-)
+from torch.distributed.tensor import DTensor, Replicate, distribute_tensor
 from torch.utils import _pytree
 from typing_extensions import NotRequired, Self, TypedDict, overload
 
@@ -46,10 +41,14 @@ from xtuner.v1.float8.fsdp_utils import (
 from xtuner.v1.loss import BaseLossConfig, BaseLossContext, CELossConfig
 from xtuner.v1.module.attention import GatedDeltaNetConfig, MHAConfig, MLAConfig
 from xtuner.v1.module.rope import RopeScalingConfig
-from xtuner.v1.ops.comm.foreach_allgather import foreach_all_gather
 from xtuner.v1.utils import get_device, get_logger, get_torch_device_module, profile_time_and_memory
 from xtuner.v1.utils.compile import MaybeCompile, is_compiled_function, maybe_compile
-from xtuner.v1.utils.load_spec import LoadEnum, LoadSpec
+from xtuner.v1.utils.load_spec import (
+    HFLoadPlan,
+    HFSavePlan,
+    LoadSpec,
+    unshard_tensors_for_hf_save,
+)
 from xtuner.v1.utils.loader import HFCheckpointLoader
 from xtuner.v1.utils.misc import FunctionEnum, FunctionType, get_function_full_qualname, get_function_type
 
@@ -60,12 +59,6 @@ logger = get_logger()
 
 DEVICE_MODULE = get_torch_device_module()
 DEVICE = get_device()
-
-
-def compute_local_shape_and_global_offset(*args, **kwargs):
-    "wrapper of _compute_local_shape_and_global_offset avoiding meta tensor error"
-    with torch.device(DEVICE):
-        return _compute_local_shape_and_global_offset(*args, **kwargs)
 
 
 class DataBatchInfo(TypedDict):
@@ -365,7 +358,27 @@ def _save_file(
     save_file(tensors, filename, metadata=metadata)
 
 
+class _HFSaveBucketItem(NamedTuple):
+    tensor: torch.Tensor
+    save_plan: HFSavePlan
+    runtime_is_float8: bool
+
+
 class BaseModel(nn.Module):
+    """Base class for all xtuner training models with HF checkpoint I/O
+    support.
+
+    Subclass ``__init__`` **must** call ``self._init_load_spec()`` at the end,
+    once every parameter and submodule has been constructed (including any
+    ``__init__``-time sharding such as MoE EP via ``distribute_tensor``). This
+    populates ``self.load_spec_mapping`` so that ``from_hf`` / ``save_hf`` and
+    the RL weight-sync path can translate between local params and HF
+    checkpoint keys. ``fully_shard`` and ``Float8Handler.pad_for_fsdp`` may
+    re-invoke ``_init_load_spec`` afterwards to keep the mapping in sync with
+    the current layout. See ``docs/design/load_spec_refactor.md`` §5.2 for the
+    full contract.
+    """
+
     load_spec_mapping: dict[str, LoadSpec] = {}
     fsdp_mesh: DeviceMesh | None = None
     hsdp_mesh: DeviceMesh | None = None
@@ -391,6 +404,10 @@ class BaseModel(nn.Module):
     ) -> tuple[
         Annotated[set[str], "loaded keys"], Annotated[set[str], "unloaded keys"], Annotated[set[str], "missing keys"]
     ]:
+        # Recompute from the complete HF key list and the current runtime layout.
+        # `__init__` still initializes the mapping for consumers that read it before checkpoint I/O.
+        self._init_load_spec()
+        self._assert_load_spec_initialized()
         self._hf_path = Path(hf_path)
 
         if isinstance(hf_path, Path):
@@ -448,6 +465,7 @@ class BaseModel(nn.Module):
             reshard_after_forward=fsdp_config.reshard_after_forward,
             offload_policy=CPUOffloadPolicy() if self.fsdp_config.cpu_offload else None,
         )
+        self._init_load_spec()
         return self
 
     def _fully_shard(
@@ -516,6 +534,9 @@ class BaseModel(nn.Module):
         )
 
     def save_hf(self, hf_dir: Path | str, save_dtype: torch.dtype = torch.bfloat16, safetensors_prefix: str = "model"):
+        # Save may be called without `fully_shard`; refresh from the current runtime layout.
+        self._init_load_spec()
+        self._assert_load_spec_initialized()
         with profile_time_and_memory(f"[Saving HF to [{safetensors_prefix}]{hf_dir} cost]"):
             self._save_hf(hf_dir=hf_dir, save_dtype=save_dtype, safetensors_prefix=safetensors_prefix)
 
@@ -523,34 +544,67 @@ class BaseModel(nn.Module):
         self,
         safetensors: list[torch.Tensor],
         local_tensor: torch.Tensor,
-        param_name: str,
-        start: int | None,
-        end: int | None,
-        dim: int | None,
-    ):
+        load_plan: HFLoadPlan,
+    ) -> None:
+        """Copy loaded HF tensors into a local parameter tensor.
+
+        Args:
+            safetensors (list[torch.Tensor]): HF tensors loaded for ``load_plan.hf_keys``, in key order.
+            local_tensor (torch.Tensor): Destination local parameter or buffer tensor.
+            load_plan (HFLoadPlan): Plan whose ``slices`` are relative to ``safetensors`` after concatenation.
+        """
+        loaded_tensor = self._cat_safetensors(safetensors, load_plan)
+        loaded_tensor = self._apply_load_slices(loaded_tensor, load_plan)
+        self._copy_loaded_tensor_to_local(loaded_tensor, local_tensor)
+
+    def _cat_safetensors(self, safetensors: list[torch.Tensor], load_plan: HFLoadPlan) -> torch.Tensor:
+        assert safetensors, f"Internal Error. No safetensors were loaded for {load_plan.name}"
         if len(safetensors) > 1:
+            dim = load_plan.fused_dim
             assert dim is not None, "Internal Error dim must not be None when len(safetensors) > 1"
-            loaded_tensor = torch.cat(safetensors, dim=dim)
-        else:
-            loaded_tensor = safetensors[0]
+            return torch.cat(safetensors, dim=dim)
+        return safetensors[0]
 
-        if start is not None and end is not None:
-            assert self.fsdp_config is not None, (
-                "Internal Error. fsdp_config must not be None when start and end is not None"
-            )
-            start = min(start, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            end = min(end, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            loaded_tensor_slice = loaded_tensor.index_select(
-                dim=self.FSDP_SHARD_DIM, index=torch.arange(start, end, dtype=torch.int64, device=loaded_tensor.device)
-            )
-            non_pad_len = end - start
-            local_tensor[:non_pad_len].copy_(loaded_tensor_slice)
+    def _apply_load_slices(self, loaded_tensor: torch.Tensor, load_plan: HFLoadPlan) -> torch.Tensor:
+        for load_slice in load_plan.slices:
+            start = min(load_slice.start, loaded_tensor.shape[load_slice.dim])
+            end = min(load_slice.end, loaded_tensor.shape[load_slice.dim])
+            assert start <= end, f"Invalid load slice [{start}, {end}) for {load_plan.name}"
+            loaded_tensor = loaded_tensor.narrow(load_slice.dim, start, end - start)
+        return loaded_tensor
 
-            if non_pad_len < local_tensor.shape[self.FSDP_SHARD_DIM]:
-                assert self.config.float8_cfg is not None
-                local_tensor[non_pad_len:].copy_(0.0)  # type: ignore  # padded part must be set to 0
-        else:
+    def _copy_loaded_tensor_to_local(self, loaded_tensor: torch.Tensor, local_tensor: torch.Tensor) -> None:
+        if loaded_tensor.shape == local_tensor.shape:
             local_tensor.copy_(loaded_tensor)
+            return
+
+        assert loaded_tensor.dim() == local_tensor.dim(), (
+            f"Loaded tensor shape {tuple(loaded_tensor.shape)} is incompatible with local tensor shape "
+            f"{tuple(local_tensor.shape)}"
+        )
+        # HF checkpoints never store FSDP padding. After applying the LoadPlan slices, only the FSDP shard dim may be
+        # shorter than the runtime local tensor; all other dims must match exactly.
+        non_pad_dim_matches = all(
+            loaded_tensor.shape[dim] == local_tensor.shape[dim]
+            for dim in range(local_tensor.dim())
+            if dim != self.FSDP_SHARD_DIM
+        )
+        assert non_pad_dim_matches, (
+            f"Loaded tensor shape {tuple(loaded_tensor.shape)} is incompatible with local tensor shape "
+            f"{tuple(local_tensor.shape)}; padding is only expected on dim {self.FSDP_SHARD_DIM}"
+        )
+        non_pad_len = loaded_tensor.shape[self.FSDP_SHARD_DIM]
+        assert non_pad_len <= local_tensor.shape[self.FSDP_SHARD_DIM], (
+            f"Loaded tensor shape {tuple(loaded_tensor.shape)} is larger than local tensor shape "
+            f"{tuple(local_tensor.shape)}"
+        )
+        local_tensor.narrow(self.FSDP_SHARD_DIM, 0, non_pad_len).copy_(loaded_tensor)
+
+        if non_pad_len < local_tensor.shape[self.FSDP_SHARD_DIM]:
+            assert self.config.float8_cfg is not None
+            pad_len = local_tensor.shape[self.FSDP_SHARD_DIM] - non_pad_len
+            # Torch casts the scalar to the destination dtype; for fp8 this writes the canonical zero value.
+            local_tensor.narrow(self.FSDP_SHARD_DIM, non_pad_len, pad_len).copy_(0.0)  # type: ignore
 
     def param_to_safetensor(
         self,
@@ -629,30 +683,6 @@ class BaseModel(nn.Module):
             return get_rope_embedding(config=config)
 
     def _init_load_spec(self) -> None:
-        # NOTE: (yehaochen) This is a workaround to distinguish between different parameter HF loading methods
-        # and model partitioning methods. Although PyTorch provides Shard, Replicate and other Placements, in
-        # MoE models, we need to handle both how to load HF weights and how to calculate gradients for partitioned
-        # parameters during the backward phase, so a more complex ParallelParamSpec is defined to describe these:
-        # Specifically:
-        # - For model loading and saving:
-        # From a computational efficiency perspective, we have to make the model parameter layout different from the
-        # HF model, resulting in a one-to-one or many-to-many mapping relationship, and we need a specification to
-        # describe this mapping.
-        # - For gradient computation:
-        # In MoE models, we need to divide the gradients of EP-partitioned parameters by ep_size (this is another
-        # complex issue not elaborated here), and although ep and ep both belong to Shard, their processing logic
-        # is different, so we need a specification to express the partitioning method in a more fine-grained way.
-
-        def get_shard_placement(placements: tuple[Placement, ...]) -> Shard | None:
-            ret = None
-            for p in placements:
-                if isinstance(p, Shard):
-                    if ret is None:
-                        ret = p
-                    else:
-                        raise RuntimeError("Multiple Shard placements found, please report this issue")
-            return ret
-
         if self.__class__.to_hf_key_list is BaseModel.to_hf_key_list:
             self.load_spec_mapping = {}
             return
@@ -686,82 +716,15 @@ class BaseModel(nn.Module):
                         repl = self.config.hf_key_mapping[max_matched_pattern]
                         hf_keys.append(re.sub(max_matched_pattern, repl, key))
 
-            if isinstance(param, DTensor) and (placement := get_shard_placement(param.placements)) is not None:
-                dim = placement.dim
-                _, _offset = compute_local_shape_and_global_offset(param.shape, param.device_mesh, param.placements)
-                start = _offset[dim]
-                end = _offset[dim] + param._local_tensor.shape[dim]
-                local_shape = param._local_tensor.shape
-                global_size = param.shape[dim]
-
-                if len(hf_keys) > 1:
-                    start_hf_key_idx = start / global_size * len(hf_keys)
-
-                    assert start_hf_key_idx.is_integer(), "Internal xtuner error, please report this issue"
-                    start_hf_key_idx = int(start_hf_key_idx)
-
-                    end_hf_key_idx = end / global_size * len(hf_keys)
-                    # TODO: (yehaochen) Support TP
-                    assert end_hf_key_idx.is_integer(), "Internal xtuner error, please report this issue"
-                    load_type = LoadEnum.FUSED
-                    end_hf_key_idx = int(end_hf_key_idx)
-                elif len(hf_keys) == 1:
-                    start_hf_key_idx = start / global_size
-                    end_hf_key_idx = end / global_size
-                    if start_hf_key_idx == 0 and end_hf_key_idx == 1:
-                        load_type = LoadEnum.SAME
-                    else:
-                        load_type = LoadEnum.SHARD
-                else:
-                    raise RuntimeError
-
-                # TP shard
-                if load_type is LoadEnum.SHARD:
-                    load_spec = LoadSpec(
-                        name=name,
-                        hf_keys=hf_keys,
-                        shape=local_shape,
-                        dim=dim,
-                        load_enum=LoadEnum.SHARD,
-                        shard_start=start,
-                        shard_end=end,
-                        group=param.device_mesh.get_group(),
-                    )
-                # Replicate
-                elif load_type == LoadEnum.SAME:
-                    load_spec = LoadSpec(
-                        name=name,
-                        hf_keys=hf_keys,
-                        shape=local_shape,
-                        dim=dim,
-                        load_enum=LoadEnum.SAME,
-                        group=param.device_mesh.get_group(),
-                    )
-                # EPSHard
-                else:
-                    load_spec = LoadSpec(
-                        name=name,
-                        hf_keys=hf_keys[start_hf_key_idx:end_hf_key_idx],
-                        shape=local_shape,
-                        dim=dim,
-                        load_enum=LoadEnum.FUSED,
-                        group=param.device_mesh.get_group(),
-                    )
-            else:
-                if len(hf_keys) == 1:
-                    load_spec = LoadSpec(
-                        name=name,
-                        hf_keys=hf_keys,
-                        shape=param.shape,
-                        load_enum=LoadEnum.SAME,
-                    )
-                else:
-                    load_spec = LoadSpec(
-                        name=name,
-                        hf_keys=hf_keys,
-                        shape=param.shape,
-                        load_enum=LoadEnum.FUSED,
-                    )
+            runtime_tensor = param._local_tensor if isinstance(param, DTensor) else param
+            runtime_is_float8 = is_float8_weight(runtime_tensor)
+            origin_shape = tuple(runtime_tensor._ori_shape) if runtime_is_float8 else None  # type: ignore[attr-defined]
+            load_spec = LoadSpec.from_tensor(
+                name=name,
+                hf_keys=hf_keys,
+                tensor=param,
+                origin_shape=origin_shape,
+            )
             load_spec_mapping[name] = load_spec
 
         if hf_key_mapping_missing:
@@ -770,16 +733,28 @@ class BaseModel(nn.Module):
 
         self.load_spec_mapping = load_spec_mapping
 
+    def _assert_load_spec_initialized(self) -> None:
+        # `load_spec_mapping` defaults to the class-level empty dict; `_init_load_spec`
+        # always assigns an instance attribute (possibly empty), so presence on
+        # `self.__dict__` is the reliable signal that the subclass contract was honored.
+        assert "load_spec_mapping" in self.__dict__, (
+            f"{type(self).__name__}.__init__ must call self._init_load_spec() at the end. "
+            "See docs/design/load_spec_refactor.md §5.2."
+        )
+
     def _to_float8(
         self,
         gathered_tensor_list: list[torch.Tensor],
         name_list: list[str],
-        ori_tensor_list: list[torch.Tensor],
+        runtime_is_float8_list: list[bool],
         dtype: torch.dtype,
     ) -> tuple[list[torch.Tensor], list[str]]:
+        assert len(gathered_tensor_list) == len(name_list) == len(runtime_is_float8_list), (
+            "Internal error: float8 conversion metadata length does not match tensor list"
+        )
         gathered_tensor_list_new, name_list_new = [], []
-        for gathered_tensor, name, ori_tensor in zip(gathered_tensor_list, name_list, ori_tensor_list):
-            if not is_float8_weight(ori_tensor):
+        for gathered_tensor, name, runtime_is_float8 in zip(gathered_tensor_list, name_list, runtime_is_float8_list):
+            if not runtime_is_float8:
                 gathered_tensor_list_new.append(gathered_tensor)
                 name_list_new.append(name)
                 continue
@@ -947,344 +922,195 @@ class BaseModel(nn.Module):
             return torch.float32
         return dtype
 
-    def _get_shard_hf_param(
-        self,
-        params: list[tuple[torch.Tensor, LoadSpec]],
-        dtype: torch.dtype,
-        device="cpu",
-        bucket_size=None,
-    ) -> Generator[tuple[list[str], list[torch.Tensor]], None, None]:
-        if not params:
-            return
-
-        ignored_params, params = self._split_ignored_params(params)
-        if ignored_params:
-            name_list: list[str] = [load_spec.hf_keys[0] for _, load_spec in ignored_params]
-            hf_params = [param._local_tensor if isinstance(param, DTensor) else param for param, _ in ignored_params]
-            yield name_list, hf_params
-
-        if not params:
-            return
-
-        if dtype != torch.bfloat16:
-            raise NotImplementedError
-
-        load_spec0 = params[0][1]
-        assert load_spec0.group is not None
-
-        def _get_hf_params(fsdp_tensor_list: list[tuple[torch.Tensor, LoadSpec]]) -> list[torch.Tensor]:
-            # Get fsdp unsharded params
-            _tensor_list, _spec_list = list(zip(*fsdp_tensor_list))
-            if self.fsdp_mesh is not None:
-                fsdp_unsharded_tensor_list = self._fsdp_foreach_allgather(_tensor_list, _spec_list)  # type: ignore
-            else:
-                fsdp_unsharded_tensor_list = _tensor_list  # type: ignore
-
-            # Get unsharded params
-            _unsharded_tensor_list = foreach_all_gather(fsdp_unsharded_tensor_list, load_spec0.group)
-            unsharded_tensor_list = [
-                torch.cat(list(tensors), dim=load_spec0.dim) for tensors in _unsharded_tensor_list
-            ]
-            name_list = [spec.hf_keys[0] for _, spec in fsdp_tensor_list]
-            unsharded_tensor_list = [
-                self.param_to_safetensor(safetensor, name)
-                for safetensor, name in zip(unsharded_tensor_list, name_list)
-            ]
-            unsharded_tensor_list = [t.to(device) for t in unsharded_tensor_list]
-            return unsharded_tensor_list
-
-        if bucket_size is None:
-            bucket_size = self.config.hf_save_cfg.bucket_size
-
-        safetensor_size = 0
-        tensor_list: list[tuple[torch.Tensor, LoadSpec]] = []
-        name_list = []
-
-        for param, load_spec in params:
-            local_tensor = param._local_tensor if isinstance(param, DTensor) else param
-            local_tensor = local_tensor.to(dtype=self._get_save_dtype(load_spec.hf_keys[0], torch.bfloat16))
-            tensor_size = self._get_tensor_size(param, dtype)
-            if safetensor_size + tensor_size > bucket_size and tensor_list:
-                hf_params = _get_hf_params(tensor_list)
-
-                yield name_list, hf_params
-                safetensor_size = tensor_size
-                name_list = load_spec.hf_keys.copy()
-                tensor_list = [(local_tensor, load_spec)]
-                continue
-            safetensor_size += tensor_size
-            tensor_list.append((local_tensor, load_spec))
-            name_list.append(load_spec.hf_keys[0])
-
-        if tensor_list:
-            hf_params = _get_hf_params(tensor_list)
-            yield name_list, hf_params
-
-    def _get_fused_hf_param(
-        self,
-        params: list[tuple[torch.Tensor, LoadSpec]],
-        dtype: torch.dtype,
-        device="cpu",
-        bucket_size=None,
-        update_weights_for_rl: bool = False,
-    ) -> Generator[tuple[list[str], list[torch.Tensor]], None, None]:
-        if not params:
-            return
-
-        ignored_params, params = self._split_ignored_params(params)
-        if ignored_params:
-            fp32_name_list: list[str] = [load_spec.hf_keys[0] for _, load_spec in ignored_params]
-            fp32_params = [param._local_tensor if isinstance(param, DTensor) else param for param, _ in ignored_params]
-            yield fp32_name_list, fp32_params
-
-        def _get_hf_params(
-            fsdp_tensor_list: list[tuple[torch.Tensor, LoadSpec]],
-            name_list: list[str],
-        ) -> tuple[list[torch.Tensor], list[str]]:
-            # Get fsdp unsharded params
-            spec_list: list[LoadSpec]
-            tensor_list: list[torch.Tensor]
-
-            tensor_list, spec_list = list(zip(*fsdp_tensor_list))  # type: ignore[assignment]
-            if self.fsdp_mesh is not None:
-                fsdp_unshard_tensor_list = self._fsdp_foreach_allgather(tensor_list, spec_list)  # type: ignore
-            else:
-                fsdp_unshard_tensor_list = tensor_list  # type: ignore
-
-            saved_fused_tensor_list: list[torch.Tensor] = []
-            hf_keys_list: list[list[str]] = []
-
-            for load_spec, fsdp_unshared_tensor in zip(spec_list, fsdp_unshard_tensor_list):
-                hf_keys = load_spec.hf_keys
-
-                if update_weights_for_rl:
-                    hf_keys_list.append(hf_keys)
-                    saved_fused_tensor_list.append(fsdp_unshared_tensor)
-                else:
-                    if load_spec.group is not None:
-                        all_hf_keys_list: list[None] | list[list[str]] = [None for _ in range(load_spec.group.size())]
-                        dist.all_gather_object(all_hf_keys_list, hf_keys, group=load_spec.group)
-                        all_hf_keys_list = cast(list[list[str]], all_hf_keys_list)
-                        all_hf_keys = list(chain(*all_hf_keys_list))
-                    else:
-                        all_hf_keys = hf_keys
-
-                    current_rank = dist.get_rank()
-
-                    expected_fused_save_ranks = self._get_ranks_to_save_fused_tensor(len(all_hf_keys))
-                    hardcode_fused_save_ranks = list(
-                        range(min((dist.get_world_size(), self.config.hf_save_cfg.max_save_rank)))
-                    )
-
-                    key_per_rank = len(all_hf_keys) / len(hardcode_fused_save_ranks)
-                    # assert key_per_rank.is_integer(), (
-                    #     f"XTuner Internal Error, size of all_hf_keys: {len(all_hf_keys)},  "
-                    #     f"size of `fused_save_ranks` {len(fused_save_ranks)}"
-                    # )
-                    if not key_per_rank.is_integer():
-                        key_per_rank = len(all_hf_keys) / len(expected_fused_save_ranks)
-
-                    start = int(current_rank * key_per_rank)
-                    end = int(start + key_per_rank)
-
-                    _hf_key_list = all_hf_keys[start:end]
-
-                    if not _hf_key_list:
-                        continue
-
-                    hf_keys_list.append(_hf_key_list)
-
-                    assert load_spec.dim is not None
-                    if load_spec.group is not None:
-                        assert load_spec.dim is not None
-                        _gathered_tensor_list = [
-                            torch.zeros_like(fsdp_unshared_tensor) for _ in range(load_spec.group.size())
-                        ]
-                        dist.all_gather(_gathered_tensor_list, fsdp_unshared_tensor, group=load_spec.group)
-                        _gathered_tensor = torch.cat(_gathered_tensor_list, dim=load_spec.dim)
-                    else:
-                        _gathered_tensor = fsdp_unshared_tensor
-                    hf_tensor_size = _gathered_tensor.shape[load_spec.dim] / len(all_hf_keys)
-                    _saved_fused_tensor = torch.index_select(
-                        _gathered_tensor,
-                        dim=load_spec.dim,
-                        index=torch.arange(
-                            int(start * hf_tensor_size),
-                            int(end * hf_tensor_size),
-                            dtype=torch.int64,
-                            device=_gathered_tensor.device,
-                        ),
-                    )
-                    saved_fused_tensor_list.append(_saved_fused_tensor)
-
-            # Split the fused tensor into hf tensors
-            hf_tensor_list: list[torch.Tensor] = []
-            # used in self._to_float8 to determine whether to convert a unshard hf_tensor to fp8
-            fsdp_shard_tensor_list: list[torch.Tensor] = []
-            # `origin_tensor_list` is only used to mark, which tensors are float8 weights for the
-            # `_to_float8` function
-            origin_tensor_list: list[torch.Tensor] = []
-
-            for saved_tensor, load_spec, hf_keys, origin_tensor in zip(
-                saved_fused_tensor_list, spec_list, hf_keys_list, tensor_list
-            ):
-                dim = cast(int, load_spec.dim)
-                hf_tensor_size = saved_tensor.shape[dim] / len(hf_keys)
-                assert hf_tensor_size.is_integer(), "Internal Error, hf_tensor_size is not integer"
-                hf_tensor_size = int(hf_tensor_size)
-                hf_tensor = saved_tensor.split([hf_tensor_size] * len(hf_keys), dim=dim)
-                hf_tensor_list.extend(hf_tensor)
-                fsdp_shard_tensor_list.extend([saved_tensor] * len(hf_tensor))
-                origin_tensor_list.extend([origin_tensor] * len(hf_tensor))
-
-            name_list = list(chain.from_iterable(hf_keys_list))
-            hf_tensor_list = [
-                self.param_to_safetensor(safetensor, name) for safetensor, name in zip(hf_tensor_list, name_list)
-            ]
-
-            if dtype == torch.float8_e4m3fn:
-                hf_tensor_list_new, name_list_new = self._to_float8(
-                    hf_tensor_list, name_list, origin_tensor_list, dtype
-                )
-                return hf_tensor_list_new, name_list_new
-
-            hf_tensor_list = [t.to(device=device) for t in hf_tensor_list]
-
-            return hf_tensor_list, name_list
-
-        if bucket_size is None:
-            bucket_size = self.config.hf_save_cfg.bucket_size
-        safetensor_size = 0
-        tensor_list: list[tuple[torch.Tensor, LoadSpec]] = []
-        name_list: list[str] = []
-
-        for param, load_spec in params:
-            local_tensor = param._local_tensor if isinstance(param, DTensor) else param
-            local_tensor = local_tensor.to(dtype=self._get_save_dtype(load_spec.hf_keys[0], torch.bfloat16))
-            tensor_size = self._get_tensor_size(param, dtype)
-            if safetensor_size + tensor_size > bucket_size and tensor_list:
-                hf_params, name_list = _get_hf_params(tensor_list, name_list)
-                yield name_list, hf_params
-                safetensor_size = tensor_size
-                name_list = load_spec.hf_keys.copy()
-                tensor_list = [(local_tensor, load_spec)]
-                continue
-            safetensor_size += tensor_size
-            tensor_list.append((local_tensor, load_spec))
-            name_list.extend(load_spec.hf_keys)
-
-        if tensor_list:
-            hf_params, name_list = _get_hf_params(tensor_list, name_list)
-            yield name_list, hf_params
-
-    def _get_same_hf_param(
+    def _get_hf_param(
         self,
         params: list[tuple[torch.Tensor, LoadSpec]],
         dtype: torch.dtype,
         device: torch.device | str = "cpu",
         bucket_size: int | None = None,
+        distributed_save: bool = False,
+        preserved_fused_shard_group: dist.ProcessGroup | None = None,
     ) -> Generator[tuple[list[str], list[torch.Tensor]], None, None]:
+        """Yield HF checkpoint tensors for the given runtime params.
+
+        Args:
+            params (list[tuple[torch.Tensor, LoadSpec]]): Runtime tensors and their new-schema LoadSpecs.
+            dtype (torch.dtype): Target checkpoint dtype, currently bfloat16 or float8_e4m3fn.
+            device (torch.device | str): Device to move yielded tensors to.
+            bucket_size (int | None): Approximate bucket size in bytes.
+            distributed_save (bool): Whether to apply the HF save write policy. When enabled, non-fused tensors are
+                yielded only on rank0 and fused HF keys are divided across save ranks.
+            preserved_fused_shard_group (dist.ProcessGroup | None): Communication group whose fused-dim shard should
+                stay local instead of being all-gathered. RL weight sync uses this to stream EP-local expert slices.
+
+        Returns:
+            Generator[tuple[list[str], list[torch.Tensor]], None, None]: HF key names and tensors to save.
+        """
+        assert not (distributed_save and preserved_fused_shard_group is not None), (
+            "distributed_save writes checkpoint files, while preserved_fused_shard_group streams local fused shards "
+            "for RL."
+        )
         if not params:
             return
 
-        ignored_params, params = self._split_ignored_params(params)
-        if ignored_params:
-            fp32_name_list: list[str] = [load_spec.hf_keys[0] for _, load_spec in ignored_params]
-            fp32_tensor_list: list[torch.Tensor] = [
-                param._local_tensor if isinstance(param, DTensor) else param for param, _ in ignored_params
-            ]
-            yield fp32_name_list, fp32_tensor_list
-
         if bucket_size is None:
             bucket_size = self.config.hf_save_cfg.bucket_size
+
         safetensor_size = 0
-        tensor_list: list[torch.Tensor] = []
-        load_spec_list: list[LoadSpec] = []
-        name_list: list[str] = []
-        buffer_tensor_list: list[torch.Tensor] = []
-        buffer_name_list: list[str] = []
+        bucket: list[_HFSaveBucketItem] = []
 
         for param, load_spec in params:
-            if not isinstance(param, DTensor):
-                # in case, param is a buffer of module, FSDP will not shard it, so it's not a DTensor
-                buffer_tensor_list.append(param)
-                buffer_name_list.append(load_spec.hf_keys[0])
-                continue
-            local_tensor = param._local_tensor if isinstance(param, DTensor) else param
-            if (
-                self.fsdp_config is not None
-                and self.fsdp_config.fp32_lm_head
-                and load_spec.hf_keys[0] == "lm_head.weight"
-            ):
-                logger.info(f"handling same hf param: {load_spec.hf_keys} separately")
-                lm_head_tensor_list = self._fsdp_foreach_allgather([local_tensor], [load_spec])
-                lm_head_tensor_list = [
-                    self.param_to_safetensor(safetensor, name)
-                    for safetensor, name in zip(lm_head_tensor_list, load_spec.hf_keys.copy())
-                ]
-                lm_head_tensor_list = [t.to(device=device) for t in lm_head_tensor_list]
-                yield load_spec.hf_keys.copy(), lm_head_tensor_list
-                del lm_head_tensor_list, local_tensor
-                continue
+            runtime_tensor = param._local_tensor if isinstance(param, DTensor) else param
+            runtime_is_float8 = is_float8_weight(runtime_tensor)
+            if runtime_tensor.is_floating_point():
+                save_dtype = self._get_save_dtype(load_spec.global_hf_keys[0], torch.bfloat16)
+                local_tensor = runtime_tensor.to(dtype=save_dtype)
             else:
-                local_tensor = local_tensor.to(dtype=self._get_save_dtype(load_spec.hf_keys[0], torch.bfloat16))
-                tensor_size = self._get_tensor_size(param, dtype)
-            if safetensor_size + tensor_size > bucket_size and tensor_list:
-                if self.fsdp_mesh is not None:
-                    gathered_tensor_list = self._fsdp_foreach_allgather(tensor_list, load_spec_list)
-                else:
-                    gathered_tensor_list = tensor_list
-                gathered_tensor_list = [
-                    self.param_to_safetensor(safetensor, name)
-                    for safetensor, name in zip(gathered_tensor_list, name_list)
-                ]
-                if dtype == torch.float8_e4m3fn:
-                    gathered_tensor_list, name_list = self._to_float8(
-                        gathered_tensor_list, name_list, tensor_list, dtype
-                    )
-                gathered_tensor_list = [t.to(device=device) for t in gathered_tensor_list]
-                yield name_list, gathered_tensor_list
-                safetensor_size = tensor_size
-                name_list = load_spec.hf_keys.copy()
-                tensor_list = [local_tensor]
-                load_spec_list = [load_spec]
-                continue
+                local_tensor = runtime_tensor
+            tensor_size = self._get_tensor_size(runtime_tensor, dtype)
+
+            if safetensor_size + tensor_size > bucket_size and bucket:
+                yield self._build_hf_param_bucket(
+                    bucket,
+                    dtype=dtype,
+                    device=device,
+                )
+                safetensor_size = 0
+                bucket = []
+
             safetensor_size += tensor_size
-            tensor_list.append(local_tensor)
-            name_list.append(load_spec.hf_keys[0])
-            load_spec_list.append(load_spec)
+            save_plan = load_spec.plan_hf_save(
+                distributed_save=distributed_save,
+                preserve_process_group=preserved_fused_shard_group,
+            )
+            bucket.append(
+                _HFSaveBucketItem(tensor=local_tensor, save_plan=save_plan, runtime_is_float8=runtime_is_float8)
+            )
 
-        if tensor_list:
-            if self.fsdp_mesh is not None:
-                gathered_tensor_list = self._fsdp_foreach_allgather(tensor_list, load_spec_list)
-            else:
-                gathered_tensor_list = tensor_list
+        if bucket:
+            yield self._build_hf_param_bucket(
+                bucket,
+                dtype=dtype,
+                device=device,
+            )
 
-            gathered_tensor_list = [
-                self.param_to_safetensor(safetensor, name) for safetensor, name in zip(gathered_tensor_list, name_list)
-            ]
-            if dtype == torch.float8_e4m3fn:
-                gathered_tensor_list, name_list = self._to_float8(gathered_tensor_list, name_list, tensor_list, dtype)
-            gathered_tensor_list = [t.to(device=device) for t in gathered_tensor_list]
-            yield name_list, gathered_tensor_list
+    def _load_spec_params(self) -> list[tuple[torch.Tensor, LoadSpec]]:
+        ret: list[tuple[torch.Tensor, LoadSpec]] = []
+        for name, param in self.state_dict().items():
+            name = self._clean_param_name(name)
+            load_spec = self.load_spec_mapping.get(name)
+            if load_spec is None:
+                raise ValueError(f"Internal Error. Parameter {name} not found in load_spec_mapping.")
+            ret.append((param, load_spec))
+        return ret
 
-        if buffer_tensor_list:
-            yield buffer_name_list, buffer_tensor_list
+    def _build_hf_param_bucket(
+        self,
+        bucket: list[_HFSaveBucketItem],
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> tuple[list[str], list[torch.Tensor]]:
+        name_list: list[str] = []
+        tensor_list: list[torch.Tensor] = []
+        runtime_is_float8_list: list[bool] = []
 
-    def _is_ignored_params(self, key: str):
-        patterns = self.config.hf_save_cfg.fp32_keys_pattern
-        if patterns is None:
-            return False
-        return any(re.search(p, key) for p in patterns)
+        full_tensor_list = unshard_tensors_for_hf_save(
+            [item.tensor for item in bucket],
+            [item.save_plan for item in bucket],
+        )
+        for full_tensor, save_item in zip(full_tensor_list, bucket, strict=True):
+            hf_names, hf_tensors = self._split_hf_tensors_for_save(full_tensor, save_item.save_plan)
+            name_list.extend(hf_names)
+            tensor_list.extend(hf_tensors)
+            runtime_is_float8_list.extend([save_item.runtime_is_float8] * len(hf_tensors))
 
-    def _split_ignored_params(
-        self, params: list[tuple[torch.Tensor, LoadSpec]]
-    ) -> tuple[list[tuple[torch.Tensor, LoadSpec]], list[tuple[torch.Tensor, LoadSpec]]]:
-        if not self.config.hf_save_cfg.fp32_keys_pattern:
-            return [], params
-        ignored_params = [(p, l) for p, l in params if self._is_ignored_params(l.hf_keys[0])]
-        remaining = [(p, l) for p, l in params if not self._is_ignored_params(l.hf_keys[0])]
-        return ignored_params, remaining
+        if dtype == torch.float8_e4m3fn:
+            tensor_list, name_list = self._to_float8(tensor_list, name_list, runtime_is_float8_list, dtype)
+
+        tensor_list = [tensor.to(device=device) for tensor in tensor_list]
+        return name_list, tensor_list
+
+    def _split_hf_tensors_for_save(
+        self,
+        full_tensor: torch.Tensor,
+        save_plan: HFSavePlan,
+    ) -> tuple[list[str], list[torch.Tensor]]:
+        if not save_plan.hf_keys:
+            return [], []
+
+        if len(save_plan.hf_keys) == 1:
+            if (
+                not save_plan.preserves_shards
+                and save_plan.distributed_save
+                and dist.is_initialized()
+                and dist.get_rank() != 0
+            ):
+                return [], []
+            hf_name = save_plan.hf_keys[0]
+            return [hf_name], [self.param_to_safetensor(full_tensor, hf_name)]
+
+        dim = save_plan.fused_dim
+        assert dim is not None, "fused_dim must be set when saving fused HF tensors"
+        if save_plan.preserves_shards:
+            hf_names = save_plan.hf_keys
+            tensor_to_split = full_tensor
+        else:
+            hf_names = save_plan.hf_keys.copy()
+            key_start, key_end = (
+                self._hf_save_key_range(save_plan)
+                if save_plan.distributed_save
+                else (
+                    0,
+                    len(hf_names),
+                )
+            )
+            if key_start == key_end:
+                return [], []
+            hf_names = hf_names[key_start:key_end]
+            key_size = full_tensor.shape[dim] / len(save_plan.hf_keys)
+            assert key_size.is_integer(), (
+                f"Fused dim size {full_tensor.shape[dim]} is not divisible by "
+                f"{len(save_plan.hf_keys)} HF keys for {save_plan.name}"
+            )
+            key_size = int(key_size)
+            # Keep the legacy save behavior here: fp8 per-block quant kernels have had correctness issues with
+            # non-zero-storage-offset views, so materialize the save-rank slice before splitting HF keys.
+            index = torch.arange(
+                key_start * key_size,
+                key_end * key_size,
+                dtype=torch.int64,
+                device=full_tensor.device,
+            )
+            tensor_to_split = torch.index_select(full_tensor, dim=dim, index=index)
+
+        if not hf_names:
+            return [], []
+
+        hf_tensor_size = tensor_to_split.shape[dim] / len(hf_names)
+        assert hf_tensor_size.is_integer(), (
+            f"Fused dim size {tensor_to_split.shape[dim]} is not divisible by "
+            f"{len(hf_names)} HF keys for {save_plan.name}"
+        )
+        split_size = int(hf_tensor_size)
+        hf_tensors = tensor_to_split.split([split_size] * len(hf_names), dim=dim)
+        return (
+            hf_names,
+            [self.param_to_safetensor(safetensor, name) for safetensor, name in zip(hf_tensors, hf_names)],
+        )
+
+    def _hf_save_key_range(self, save_plan: HFSavePlan) -> tuple[int, int]:
+        if not dist.is_initialized():
+            return 0, len(save_plan.hf_keys)
+
+        current_rank = dist.get_rank()
+        save_ranks = self._get_fused_save_ranks(len(save_plan.hf_keys))
+        if current_rank not in save_ranks:
+            return 0, 0
+
+        key_per_rank = len(save_plan.hf_keys) // len(save_ranks)
+        rank_index = save_ranks.index(current_rank)
+        start = rank_index * key_per_rank
+        return start, start + key_per_rank
 
     # TODO: Using `xtuenr.v1.utils.misc.clean_param_name`
     def _clean_param_name(self, name: str) -> str:
@@ -1294,45 +1120,10 @@ class BaseModel(nn.Module):
             name = name.replace("_orig_mod.", "")
         return name
 
-    def _group_param_by_load_spec(self, load_enum: LoadEnum):
-        """Group the parameters by load spec."""
-        ret = []
-        for name, param in self.state_dict().items():
-            load_spec = self.load_spec_mapping.get(name)
-            if load_spec is None:
-                raise ValueError(f"Internal Error. Parameter {name} not found in load_spec_mapping.")
-            if load_spec.load_enum == load_enum:
-                ret.append((param, load_spec))
-            else:
-                continue
-        return ret
-
     def _get_tensor_size(self, tensor: torch.Tensor, dtype: torch.dtype) -> int:
         """Get the size of the tensor in bytes."""
         # return tensor.element_size() * tensor.numel()
         return dtype.itemsize * tensor.numel()
-
-    def _get_safe_tensor_num(self, dtype: torch.dtype) -> int:
-        """Get the size of the model in bytes."""
-        bucket_size = self.config.hf_save_cfg.bucket_size
-        shard_size = 0
-        same_size = 0
-        fused_size = 0
-        for name, param in self.state_dict().items():
-            load_spec = self.load_spec_mapping.get(name)
-            if load_spec is None:
-                raise ValueError(f"Internal Error. Parameter {name} not found in load_spec_mapping.")
-            if load_spec.load_enum == LoadEnum.SHARD:
-                shard_size += self._get_tensor_size(param, dtype)
-            elif load_spec.load_enum == LoadEnum.SAME:
-                same_size += self._get_tensor_size(param, dtype)
-            elif load_spec.load_enum == LoadEnum.FUSED:
-                fused_size += self._get_tensor_size(param, dtype)
-        return (
-            math.ceil(shard_size / bucket_size)
-            + math.ceil(same_size / bucket_size)
-            + math.ceil(fused_size / bucket_size)
-        )
 
     def _save_hf(
         self, hf_dir: Path | str, save_dtype: torch.dtype = torch.bfloat16, safetensors_prefix: str = "model"
@@ -1355,12 +1146,7 @@ class BaseModel(nn.Module):
         DEVICE_MODULE.empty_cache()
         assert save_dtype in [torch.float8_e4m3fn, torch.bfloat16], f"save_dtype {save_dtype} is not supported"
 
-        # TODO: Support fp8 saving
-        shard_gen = self._get_shard_hf_param(self._group_param_by_load_spec(LoadEnum.SHARD), dtype=save_dtype)
-        same_gen = self._get_same_hf_param(self._group_param_by_load_spec(LoadEnum.SAME), dtype=save_dtype)
-        fused_gen = self._get_fused_hf_param(self._group_param_by_load_spec(LoadEnum.FUSED), dtype=save_dtype)
-
-        is_others_save_rank = not dist.is_initialized() or dist.get_rank() == 0
+        param_gen = self._get_hf_param(self._load_spec_params(), dtype=save_dtype, distributed_save=True)
 
         # Tell me why! why! old cao! @HIT-cwh
         # mp_context = multiprocessing.get_context("fork")
@@ -1372,52 +1158,37 @@ class BaseModel(nn.Module):
         else:
             save_rank = 0
 
-        # Sepreately save fused parameters and others to make sure each saving rank will not save
-        # dupilicated keys
-        #
         save_futures = []
         weight_map = {}
         safetensor_index = 0
 
-        for name_list, hf_tensor_list in fused_gen:
+        for name_list, hf_tensor_list in param_gen:
             if not name_list:
                 continue
 
+            # Tied weights may map multiple runtime tensors to the same HF key; keep the first one.
+            unique_name_list = []
+            unique_hf_tensor_list = []
+            for name, hf_tensor in zip(name_list, hf_tensor_list):
+                if name in weight_map:
+                    continue
+                unique_name_list.append(name)
+                unique_hf_tensor_list.append(hf_tensor)
+
+            if not unique_name_list:
+                continue
+
             safetensor_index += 1
-            safetensor_name = f"{safetensors_prefix}-{safetensor_index:04d}-fused-save_rank{save_rank}.safetensors"
-            weight_map.update(dict.fromkeys(name_list, safetensor_name))
+            safetensor_name = f"{safetensors_prefix}-{safetensor_index:04d}-save_rank{save_rank}.safetensors"
+            weight_map.update(dict.fromkeys(unique_name_list, safetensor_name))
             assert save_executor is not None, "Internal Error, save_executor should not be None"
             future = save_executor.submit(
                 _save_file,
-                dict(zip(name_list, hf_tensor_list)),
+                dict(zip(unique_name_list, unique_hf_tensor_list)),
                 hf_dir / safetensor_name,
             )
             save_futures.append(future)
             self._wait_save_task(save_futures)
-
-        safetensor_index = 0
-        for name_list, hf_tensor_list in chain(same_gen, shard_gen):
-            safetensor_index += 1
-            safetensor_name = f"{safetensors_prefix}-{safetensor_index:04d}-others-save_rank{save_rank}.safetensors"
-
-            if is_others_save_rank:
-                # for tie_word_embeddings, we need to make sure each key is only saved once
-                unique_name_list = []
-                unique_hf_tensor_list = []
-                for name, hf_tensor in zip(name_list, hf_tensor_list):
-                    if name not in weight_map:
-                        unique_name_list.append(name)
-                        unique_hf_tensor_list.append(hf_tensor)
-                        weight_map[name] = safetensor_name
-
-                assert save_executor is not None, "Internal Error, save_executor should not be None"
-                future = save_executor.submit(
-                    _save_file,
-                    dict(zip(unique_name_list, unique_hf_tensor_list)),
-                    hf_dir / safetensor_name,
-                )
-                save_futures.append(future)
-                self._wait_save_task(save_futures)
 
         if save_futures:
             wait(save_futures)
@@ -1496,14 +1267,7 @@ class BaseModel(nn.Module):
                 if load_spec is None:
                     raise RuntimeError(f"Internal Error. Parameter {name} not found in load_spec_mapping.")
 
-                if load_spec.load_enum == LoadEnum.SAME:
-                    _missing_keys = self._load_same_hf_param(param, load_spec, checkpoint_loader)
-                elif load_spec.load_enum == LoadEnum.FUSED:
-                    _missing_keys = self._load_fused_hf_param(param, load_spec, checkpoint_loader)
-                elif load_spec.load_enum == LoadEnum.SHARD:
-                    _missing_keys = self._load_shard_hf_param(param, load_spec, checkpoint_loader)
-                else:
-                    raise RuntimeError(f"Unsupported load_enum: {load_spec.load_enum}")
+                _missing_keys = self._load_hf_param(param, load_spec, checkpoint_loader)
                 missing_keys.update(_missing_keys)
 
                 if not _missing_keys:
@@ -1545,178 +1309,50 @@ class BaseModel(nn.Module):
         )
         return loaded_tensor
 
-    def _load_same_hf_param(
-        self, param: torch.Tensor, load_spec: LoadSpec, checkpoint_loader: HFCheckpointLoader
-    ) -> list[str]:  # return missing key
-        local_tensor = param._local_tensor if isinstance(param, DTensor) else param
-        hf_key = load_spec.hf_keys[0]
-        if self._is_loaded_param_fp8(hf_key, checkpoint_loader):
-            if not _is_float8_available():
-                raise RuntimeError(
-                    f"Float8 is not available on {DEVICE}. Please convert the checkpoint from float8 to bfloat16 on SM89 or later (H100+ GPUs)."
-                )
-            loaded_tensor = self._load_fp8(hf_key, checkpoint_loader)
-        else:
-            loaded_tensor = checkpoint_loader.load(hf_key)
-        if loaded_tensor is None:
-            return [hf_key]
-
-        loaded_tensor = loaded_tensor.to(local_tensor.device)
-
-        if (
-            self.fsdp_mesh is not None
-            and isinstance(param, nn.Parameter)
-            and isinstance(param, DTensor)
-            and any(isinstance(p, Shard) for p in param.placements)
-        ):
-            shape_before_fsdp = load_spec.shape
-            _, _offset = compute_local_shape_and_global_offset(
-                shape_before_fsdp, self.fsdp_mesh, [Shard(self.FSDP_SHARD_DIM)]
-            )
-            fsdp_start = _offset[self.FSDP_SHARD_DIM]
-            fsdp_end = fsdp_start + local_tensor.shape[self.FSDP_SHARD_DIM]
-
-            start = fsdp_start
-            end = fsdp_end
-        else:
-            start = None
-            end = None
-
-        self.safetensors_to_params(
-            [loaded_tensor], local_tensor, param_name=load_spec.name, start=start, end=end, dim=load_spec.dim
-        )
-        return []
-
-    def _load_fused_hf_param(
+    def _load_hf_param(
         self, param: torch.Tensor, load_spec: LoadSpec, checkpoint_loader: HFCheckpointLoader
     ) -> list[str]:
-        # For expert parallel
-        # NOTE:
-        # 1. Get `hf-keys` required by sharded param (sharded by ep group)
-        # 2. Asumming FSDP sharding the tensor at the same dim as ep group, Get the twice sharded
-        #    `hf-keys`. For example, if we have 128 experts with ep-size 8 and fsdp-size 16. The
-        #    the param sharded by ep group will have 128/8 = 16 `hf-keys`, and the param further sharded
-        #    by FSDP will only have 128/8/16 = 1 `hf-keys`
-        # 3. Calculating the `offset` and `size` of FSDP param base on the ep sharded params, and fill
-        #    the FSDP param with the loaded tensor.
+        """Unified HF load path for a single parameter / buffer.
 
-        hf_keys = load_spec.hf_keys
+        ``LoadSpec.plan_hf_load`` computes this rank's HF keys and loaded-tensor-relative slices from the new
+        schema. This method only executes that plan: load keys, dequantize fp8 when needed, then hand off to
+        ``safetensors_to_params`` for cat + narrow + copy.
+
+        Returns the list of hf_keys that were expected but missing from the
+        checkpoint; callers aggregate these for strict-mode reporting.
+        """
         local_tensor = param._local_tensor if isinstance(param, DTensor) else param
-
-        assert load_spec.dim == self.FSDP_SHARD_DIM, "Only support FSDP and model parallel sharding at the same dim!"
-        if self.fsdp_mesh is not None:
-            shape_before_fsdp = load_spec.shape
-            if is_float8_weight(local_tensor):
-                # fp8 weights may be padded, so we need to calculate the hf_key_size base on local_tensor._ori_shape
-                if load_spec.group is None:
-                    hf_key_size = local_tensor._ori_shape[self.FSDP_SHARD_DIM] / len(hf_keys)  # type: ignore
-                else:
-                    hf_key_size = (
-                        local_tensor._ori_shape[self.FSDP_SHARD_DIM]  # type: ignore
-                        / dist.get_world_size(group=load_spec.group)
-                        / len(hf_keys)
-                    )
-            else:
-                # shape_before_fsdp[self.FSDP_SHARD_DIM] == local_tensor.shape[self.FSDP_SHARD_DIM] / dist.get_world_size(group=load_spec.group)
-                hf_key_size = shape_before_fsdp[self.FSDP_SHARD_DIM] / len(hf_keys)
-            assert hf_key_size.is_integer(), (
-                "Model parallel sharding size should be divisible by fused huggingface tensors!"
-            )
-            hf_key_size = int(hf_key_size)
-            _, _offset = compute_local_shape_and_global_offset(
-                shape_before_fsdp, self.fsdp_mesh, [Shard(self.FSDP_SHARD_DIM)]
-            )
-            fsdp_start = _offset[self.FSDP_SHARD_DIM]
-            fsdp_end = fsdp_start + local_tensor.shape[self.FSDP_SHARD_DIM]
-
-            hf_keys_start = int(fsdp_start / hf_key_size)
-            hf_keys_end = math.ceil(fsdp_end / hf_key_size)
-
-            # Empty pad by fsdp
-            if hf_keys_start == hf_keys_end:
-                return []
-
-            hf_keys = hf_keys[hf_keys_start:hf_keys_end]
-
-            start = fsdp_start % hf_key_size
-            end = start + local_tensor.shape[self.FSDP_SHARD_DIM]
-        else:
-            start = None
-            end = None
+        load_plan = load_spec.plan_hf_load()
+        if load_plan.zero_fill:
+            # This rank owns only XTuner runtime padding, so no checkpoint key overlaps its local slice.
+            assert load_spec.origin_shape is not None, "Empty load plan is only legal for runtime pad-only ranks"
+            local_tensor.zero_()  # type: ignore
+            return []
 
         missing_keys: list[str] = []
-        _loaded_tensor: list[torch.Tensor] = []
-        for hf_key in hf_keys:
-            weight = self._load_fp8(hf_key, checkpoint_loader)
-            if weight is None:
+        loaded_tensors: list[torch.Tensor] = []
+        for hf_key in load_plan.hf_keys:
+            if self._is_loaded_param_fp8(hf_key, checkpoint_loader):
+                if not _is_float8_available():
+                    raise RuntimeError(
+                        f"Float8 is not available on {DEVICE}. Please convert the checkpoint from float8 "
+                        "to bfloat16 on SM89 or later (H100+ GPUs)."
+                    )
+                weight = self._load_fp8(hf_key, checkpoint_loader)
+            else:
                 weight = checkpoint_loader.load(hf_key)
             if weight is None:
                 missing_keys.append(hf_key)
                 continue
-            _loaded_tensor.append(weight.to(local_tensor.device))
-
-        if not _loaded_tensor:
-            return missing_keys
-
-        if not hf_keys:
-            # fp8 pad
-            assert self.config.float8_cfg is not None
-            # assert self.fsdp_config is not None and self.fsdp_config.ep_size == 1, (
-            #     "Only support fp8 pad for MoE with ep_size == 1"
-            # )
-            local_tensor.zero_()  # type: ignore  # padded part must be set to 0
-            return missing_keys
+            loaded_tensors.append(weight.to(local_tensor.device))
 
         if missing_keys:
             return missing_keys
 
         self.safetensors_to_params(
-            _loaded_tensor, local_tensor, param_name=load_spec.name, start=start, end=end, dim=load_spec.dim
-        )
-        return missing_keys
-
-    def _load_shard_hf_param(
-        self, param: torch.Tensor, load_spec: LoadSpec, checkpoint_loader: HFCheckpointLoader
-    ) -> list[str]:
-        # For tensor parallel
-        # NOTE:
-        # 1. Get `hf-keys` required by sharded param (sharded by tp group, only 1 key)
-        # 2. all gather the sharded param across tp group
-        # 3 Fill the sharded param with the sliced gathered tensor.
-        hf_key = load_spec.hf_keys[0]
-        local_tensor = param._local_tensor if isinstance(param, DTensor) else param
-
-        loaded_tensor = checkpoint_loader.load(hf_key)
-        if loaded_tensor is None:
-            return [hf_key]
-
-        loaded_tensor = loaded_tensor.to(local_tensor.device)
-
-        assert load_spec.shard_start is not None and load_spec.shard_end is not None, (
-            "load_spec.shard_start and load_spec.shard_end should not be None for sharded params"
-        )
-
-        if self.fsdp_mesh is not None:
-            shape_before_fsdp = load_spec.shape
-            _, _offset = compute_local_shape_and_global_offset(
-                shape_before_fsdp, self.fsdp_mesh, [Shard(self.FSDP_SHARD_DIM)]
-            )
-            fsdp_start = _offset[self.FSDP_SHARD_DIM]
-            fsdp_end = fsdp_start + local_tensor.shape[self.FSDP_SHARD_DIM]
-
-            start = fsdp_start + load_spec.shard_start
-            end = fsdp_end + load_spec.shard_start
-        else:
-            start = load_spec.shard_start
-            end = load_spec.shard_end
-
-        self.safetensors_to_params(
-            safetensors=[loaded_tensor],
-            local_tensor=local_tensor,
-            param_name=load_spec.name,
-            start=start,
-            end=end,
-            dim=load_spec.dim,
+            loaded_tensors,
+            local_tensor,
+            load_plan,
         )
         return []
 
@@ -1730,125 +1366,26 @@ class BaseModel(nn.Module):
     def _fsdp_foreach_allgather(
         self, tensor_list: list[torch.Tensor], load_spec_list: list[LoadSpec]
     ) -> list[torch.Tensor]:
-        assert self.fsdp_mesh is not None, "Internal Error, fsdp_mesh should not be None"
-        origin_fsdp_size = []
-        padded_tensor_list = []
+        if self.fsdp_mesh is None:
+            return tensor_list
 
-        for param, load_spec in zip(tensor_list, load_spec_list):
-            shape_before_fsdp = load_spec.shape[self.FSDP_SHARD_DIM]
-            padded_size = math.ceil(shape_before_fsdp / self.fsdp_mesh.size())
-            pad_list = [0] * (2 * param.dim())
-            pad_idx = 2 * (param.dim() - 1 - self.FSDP_SHARD_DIM)
-            pad_list[pad_idx + 1] = padded_size - param.shape[self.FSDP_SHARD_DIM]
-            padded_tensor = F.pad(param, pad_list)
-            padded_tensor_list.append(padded_tensor)
-            if is_float8_weight(param):
-                dim_before_fsdp: int
-                if load_spec.group is None:
-                    dim_before_fsdp = param._ori_shape[self.FSDP_SHARD_DIM]  # type: ignore
-                else:
-                    dim_before_fsdp = param._ori_shape[self.FSDP_SHARD_DIM] // dist.get_world_size(  # type: ignore
-                        group=load_spec.group
-                    )
-                origin_fsdp_size.append(dim_before_fsdp)
-            else:
-                origin_fsdp_size.append(load_spec.shape[self.FSDP_SHARD_DIM])
-
-        _fsdp_unsharded_tensor_list = foreach_all_gather(padded_tensor_list, self.fsdp_mesh.get_group())
-        fsdp_unsharded_tensor_list = []
-
-        # Concatenate the tensors along the FSDP shard dim
-        fuse_without_alloc = self.FSDP_SHARD_DIM == 0 and len(_fsdp_unsharded_tensor_list) == 1
-        for tensors, size in zip(_fsdp_unsharded_tensor_list, origin_fsdp_size):
-            if fuse_without_alloc:
-                # In the case of only one big tensor in tensor_list, the partition of tensors are contiguous.
-                # Therefore the cat and index_select operation can be omitted,
-                # and use _fuse_contiguous_chunks_without_alloc instead to reduce device peak memory.
-                # e.g. When a fused MoE weight exceeds bucket_size given, len(tensor_list) would be 1,
-                # and tensor is not None reducing peak device memory.
-                tensor = self._fuse_contiguous_chunks_without_alloc(tensors)
-            else:
-                tensor = torch.cat(tensors, dim=self.FSDP_SHARD_DIM)
-            unpaded_tensor = tensor.narrow(self.FSDP_SHARD_DIM, 0, size)
-            pad_tensor = tensor.narrow(self.FSDP_SHARD_DIM, size, tensor.shape[self.FSDP_SHARD_DIM] - size)
-            assert (pad_tensor == 0).all(), f"Internal Error, padded tensor is not zero {pad_tensor}!"
-            # when self.FSDP_SHARD_DIM != 0, narrow operation may lead to non-contiguous tensor
-            fsdp_unsharded_tensor_list.append(unpaded_tensor.contiguous())
-
-        return fsdp_unsharded_tensor_list
+        fsdp_group = self.fsdp_mesh.get_group()
+        save_plan_list = [load_spec.plan_hf_save(gather_process_group=fsdp_group) for load_spec in load_spec_list]
+        return unshard_tensors_for_hf_save(list(tensor_list), save_plan_list)
 
     @staticmethod
-    def _fuse_contiguous_chunks_without_alloc(tensors: list[torch.Tensor]) -> torch.Tensor:
-        """Fuse contiguous chunks without extra memory allocation.
+    def _is_same_process_group(left: dist.ProcessGroup, right: dist.ProcessGroup) -> bool:
+        if left is right:
+            return True
+        return dist.get_process_group_ranks(left) == dist.get_process_group_ranks(right)
 
-        Return None if not possible.
-        """
-        if not tensors:
-            raise ValueError("tensors should not be empty")
-        base = tensors[0]
-        storage = base.untyped_storage()
-        dtype = base.dtype
-        device = base.device
-        stride = base.stride()
-
-        inner_stride = stride[1:]
-        inner_elems = math.prod(base.shape[1:]) if base.dim() > 1 else 1
-
-        chunks = []
-        for t in tensors:
-            # we should check both storage and stride to ensure contiguity
-            # regardless of the implementation of foreach_all_gather
-            if t.untyped_storage().data_ptr() != storage.data_ptr():
-                raise RuntimeError("Tensors are not sharing the same storage.")
-            if t.stride()[1:] != inner_stride:
-                raise RuntimeError("Tensors have mismatched strides.")
-            chunks.append((t.storage_offset(), t.shape[0], t))
-        chunks.sort(key=lambda x: x[0])
-
-        expected_offset = chunks[0][0]
-        total_rows = 0
-        for offset, rows, _ in chunks:
-            if offset != expected_offset:
-                raise RuntimeError("Tensors are not contiguous in the storage")
-            expected_offset += rows * inner_elems
-            total_rows += rows
-
-        size = (total_rows, *base.shape[1:])
-        flat = torch.empty(0, dtype=dtype, device=device)
-        flat.set_(storage, chunks[0][0], size, stride)
-        return flat
-
-    def _get_ranks_to_save_fused_tensor(self, fused_size: int) -> list[int]:
-        # Goal: decide how many ranks are used to store model/expert parameters.
-        # Policy: choose d such that:
-        #   1) d is a positive divisor of world_size,
-        #   2) d <= num_experts,
-        #   3) d is as close to num_experts as possible under (1)(2).
-        # This is equivalent to: pick the largest divisor of world_size that does not exceed num_experts.
-        # Rationale: ensures feasibility under expert count, maximizes utilization, and yields balanced groups.
-        # Implementation hint: enumerate divisor pairs (i, world_size // i) for i up to sqrt(world_size) and keep the max d <= num_experts.
-        # Complexity: O(sqrt(world_size)).
+    def _get_fused_save_ranks(self, hf_key_count: int) -> list[int]:
         world_size = dist.get_world_size()
-
-        if world_size >= fused_size:
-            return list(range(fused_size))
-
-        num_ranks_to_save = None
-        best_diff = None
-
-        i = 1
-        while i * i <= fused_size:
-            if fused_size % i == 0:
-                for d in (i, fused_size // i):
-                    diff = abs(d - world_size)
-                    if (
-                        num_ranks_to_save is None
-                        or (diff < best_diff)  # type: ignore
-                        or (diff == best_diff and d < num_ranks_to_save)
-                    ):
-                        num_ranks_to_save, best_diff = d, diff
-            i += 1
-        return list(range(cast(int, num_ranks_to_save)))
+        max_save_ranks = min(world_size, self.config.hf_save_cfg.max_save_rank, hf_key_count)
+        for save_rank_count in range(max_save_ranks, 0, -1):
+            if hf_key_count % save_rank_count == 0:
+                return list(range(save_rank_count))
+        raise RuntimeError(f"Unable to choose save ranks for {hf_key_count} fused HF keys")
 
     def to_device(self, device: torch.device | str):
         if self.fsdp_config is not None and self.fsdp_config.cpu_offload:

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -958,14 +958,18 @@ class BaseModel(nn.Module):
 
         safetensor_size = 0
         bucket: list[_HFSaveBucketItem] = []
+        buffer_names = {self._clean_param_name(name) for name, _ in self.named_buffers()}
 
         for param, load_spec in params:
             runtime_tensor = param._local_tensor if isinstance(param, DTensor) else param
             runtime_is_float8 = is_float8_weight(runtime_tensor)
-            if runtime_tensor.is_floating_point():
+            is_buffer = load_spec.name in buffer_names
+            if runtime_tensor.is_floating_point() and not is_buffer:
                 save_dtype = self._get_save_dtype(load_spec.global_hf_keys[0], torch.bfloat16)
                 local_tensor = runtime_tensor.to(dtype=save_dtype)
             else:
+                # Persistent buffers, e.g. FoPE rotary coefficients, are part of HF state but are not trainable
+                # weights. Keep the legacy behavior and write them in their runtime dtype instead of save_dtype.
                 local_tensor = runtime_tensor
             tensor_size = self._get_tensor_size(runtime_tensor, dtype)
 
@@ -1324,8 +1328,11 @@ class BaseModel(nn.Module):
         local_tensor = param._local_tensor if isinstance(param, DTensor) else param
         load_plan = load_spec.plan_hf_load()
         if load_plan.zero_fill:
-            # This rank owns only XTuner runtime padding, so no checkpoint key overlaps its local slice.
-            assert load_spec.origin_shape is not None, "Empty load plan is only legal for runtime pad-only ranks"
+            # No checkpoint key overlaps this rank. This can be fp8 runtime padding, or a legal zero-sized DTensor
+            # shard when a tiny tensor dimension is split across more ranks than it has elements.
+            assert load_spec.origin_shape is not None or local_tensor.numel() == 0, (
+                "Empty load plan is only legal for runtime pad-only or zero-sized local tensors"
+            )
             local_tensor.zero_()  # type: ignore
             return []
 

--- a/xtuner/v1/model/dense/dense.py
+++ b/xtuner/v1/model/dense/dense.py
@@ -288,6 +288,7 @@ class Dense(BaseModel):
         )
         self.set_modules_to_forward_prefetch([self.embed_tokens, self.layers["0"]])  # type: ignore
 
+        self._init_load_spec()
         self._to_empty_meta()
 
         # Make sure it works properly when using fsdp

--- a/xtuner/v1/model/moe/gpt_oss.py
+++ b/xtuner/v1/model/moe/gpt_oss.py
@@ -12,6 +12,7 @@ from xtuner.v1.module.attention import MHAConfig
 from xtuner.v1.module.decoder_layer.moe_decoder_layer import MoEActFnConfig
 from xtuner.v1.module.rope import RopeScalingConfig
 from xtuner.v1.module.router.greedy import GreedyRouterConfig
+from xtuner.v1.utils.load_spec import HFLoadPlan
 
 from .moe import MoE
 
@@ -44,18 +45,11 @@ class GptOss(MoE):
         self,
         safetensors: list[torch.Tensor],
         local_tensor: torch.Tensor,
-        param_name: str,
-        start: int | None,
-        end: int | None,
-        dim: int | None,
-    ):
-        if len(safetensors) > 1:
-            assert dim is not None, "Internal Error dim must not be None when len(safetensors) > 1"
-            loaded_tensor = torch.cat(safetensors, dim=dim)
-        else:
-            loaded_tensor = safetensors[0]
+        load_plan: HFLoadPlan,
+    ) -> None:
+        loaded_tensor = self._cat_safetensors(safetensors, load_plan)
 
-        if "fused_w1w3.weight" in param_name:
+        if "fused_w1w3.weight" in load_plan.name:
             # hf: num_experts, hidden_size, expert_dim * 2
             # xtuner: num_experts * 2 * expert_dim, hidden_size
             num_experts, hidden_size = loaded_tensor.shape[:2]
@@ -64,32 +58,20 @@ class GptOss(MoE):
             # # num_experts *2 * expert_dim, hidden_size
             loaded_tensor = loaded_tensor.transpose(1, 2).reshape(-1, hidden_size)
 
-        elif "fused_w2.weight" in param_name:
+        elif "fused_w2.weight" in load_plan.name:
             # hf: num_experts, expert_dim, hidden_size
             # xtuner: num_experts * hidden_size, expert_dim
             loaded_tensor = loaded_tensor.transpose(1, 2).flatten(0, 1)
 
-        if "fused_w1w3.bias" in param_name:
+        if "fused_w1w3.bias" in load_plan.name:
             # hf: num_experts, expert_dim * 2
             # xtuner: num_experts, 2 * expert_dim
             num_experts = loaded_tensor.size(0)
             loaded_tensor = loaded_tensor.reshape(num_experts, -1, 2)
             loaded_tensor = loaded_tensor.transpose(1, 2).reshape(num_experts, -1)
 
-        if start is not None and end is not None:
-            start = min(start, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            end = min(end, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            loaded_tensor_slice = loaded_tensor.index_select(
-                dim=self.FSDP_SHARD_DIM, index=torch.arange(start, end, dtype=torch.int64, device=loaded_tensor.device)
-            )
-            non_pad_len = end - start
-            local_tensor[:non_pad_len].copy_(loaded_tensor_slice)
-
-            if non_pad_len < local_tensor.shape[self.FSDP_SHARD_DIM]:
-                assert self.config.float8_cfg is not None
-                local_tensor[non_pad_len:].copy_(0.0)  # type: ignore  # padded part must be set to 0
-        else:
-            local_tensor.copy_(loaded_tensor)
+        loaded_tensor = self._apply_load_slices(loaded_tensor, load_plan)
+        self._copy_loaded_tensor_to_local(loaded_tensor, local_tensor)
 
     def param_to_safetensor(
         self,

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -1052,6 +1052,7 @@ class MoE(BaseModel):
             if isinstance(module, nn.Embedding):
                 module.forward = types.MethodType(self.patched_emb_forward, module)  # type: ignore
 
+        self._init_load_spec()
         self._to_empty_meta()
         return self
 

--- a/xtuner/v1/model/moe/qwen3_5_text.py
+++ b/xtuner/v1/model/moe/qwen3_5_text.py
@@ -14,6 +14,7 @@ from xtuner.v1.model.moe.moe import BalancingLossConfig, MoEConfig, ZLossConfig
 from xtuner.v1.module.attention import GatedDeltaNetConfig, MHAConfig
 from xtuner.v1.module.rope import RopeScalingConfig
 from xtuner.v1.module.router.greedy import GreedyRouterConfig
+from xtuner.v1.utils.load_spec import HFLoadPlan
 
 from .qwen3vl_text import Qwen3VLTextMoE
 
@@ -126,42 +127,23 @@ class Qwen3_5_VLTextMoE(Qwen3VLTextMoE):
         self,
         safetensors: list[torch.Tensor],
         local_tensor: torch.Tensor,
-        param_name: str,
-        start: int | None,
-        end: int | None,
-        dim: int | None,
-    ):
-        if len(safetensors) > 1:
-            assert dim is not None, "Internal Error dim must not be None when len(safetensors) > 1"
-            loaded_tensor = torch.cat(safetensors, dim=dim)
-        else:
-            loaded_tensor = safetensors[0]
+        load_plan: HFLoadPlan,
+    ) -> None:
+        loaded_tensor = self._cat_safetensors(safetensors, load_plan)
 
-        if "fused_w1w3.weight" in param_name and "mtp" not in param_name:
+        if "fused_w1w3.weight" in load_plan.name and "mtp" not in load_plan.name:
             # hf: num_experts, 2 * expert_dim, hidden_size
             # xtuner: num_experts * 2 * expert_dim, hidden_size
             # num_experts * 2 * expert_dim, hidden_size
             loaded_tensor = loaded_tensor.flatten(0, 1)
 
-        elif "fused_w2.weight" in param_name and "mtp" not in param_name:
+        elif "fused_w2.weight" in load_plan.name and "mtp" not in load_plan.name:
             # hf: num_experts, hidden_size, expert_dim
             # xtuner: num_experts * hidden_size, expert_dim
             loaded_tensor = loaded_tensor.flatten(0, 1)
 
-        if start is not None and end is not None:
-            start = min(start, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            end = min(end, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            loaded_tensor_slice = loaded_tensor.index_select(
-                dim=self.FSDP_SHARD_DIM, index=torch.arange(start, end, dtype=torch.int64, device=loaded_tensor.device)
-            )
-            non_pad_len = end - start
-            local_tensor[:non_pad_len].copy_(loaded_tensor_slice)
-
-            if non_pad_len < local_tensor.shape[self.FSDP_SHARD_DIM]:
-                assert self.config.float8_cfg is not None
-                local_tensor[non_pad_len:].copy_(0.0)  # type: ignore  # padded part must be set to 0
-        else:
-            local_tensor.copy_(loaded_tensor)
+        loaded_tensor = self._apply_load_slices(loaded_tensor, load_plan)
+        self._copy_loaded_tensor_to_local(loaded_tensor, local_tensor)
 
     def param_to_safetensor(
         self,

--- a/xtuner/v1/model/moe/qwen3vl_text.py
+++ b/xtuner/v1/model/moe/qwen3vl_text.py
@@ -5,6 +5,7 @@ import torch
 
 from xtuner.v1.data_proto import SequenceContext
 from xtuner.v1.utils.activation_offload import async_save_on_cpu
+from xtuner.v1.utils.load_spec import HFLoadPlan
 
 from .moe import MoELossContextDict, MoEModelOutputs
 from .qwen3 import Qwen3MoE, Qwen3MoE30BA3Config, Qwen3MoE235BA22Config
@@ -39,18 +40,11 @@ class Qwen3VLTextMoE(Qwen3MoE):
         self,
         safetensors: list[torch.Tensor],
         local_tensor: torch.Tensor,
-        param_name: str,
-        start: int | None,
-        end: int | None,
-        dim: int | None,
-    ):
-        if len(safetensors) > 1:
-            assert dim is not None, "Internal Error dim must not be None when len(safetensors) > 1"
-            loaded_tensor = torch.cat(safetensors, dim=dim)
-        else:
-            loaded_tensor = safetensors[0]
+        load_plan: HFLoadPlan,
+    ) -> None:
+        loaded_tensor = self._cat_safetensors(safetensors, load_plan)
 
-        if "fused_w1w3.weight" in param_name:
+        if "fused_w1w3.weight" in load_plan.name:
             # hf: num_experts, hidden_size, 2 * expert_dim
             # xtuner: num_experts * 2 * expert_dim, hidden_size
             num_experts, hidden_size = loaded_tensor.shape[:2]
@@ -58,25 +52,13 @@ class Qwen3VLTextMoE(Qwen3MoE):
             # num_experts * 2 * expert_dim, hidden_size
             loaded_tensor = loaded_tensor.reshape(-1, hidden_size)
 
-        elif "fused_w2.weight" in param_name:
+        elif "fused_w2.weight" in load_plan.name:
             # hf: num_experts, expert_dim, hidden_size
             # xtuner: num_experts * hidden_size, expert_dim
             loaded_tensor = loaded_tensor.transpose(1, 2).flatten(0, 1)
 
-        if start is not None and end is not None:
-            start = min(start, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            end = min(end, loaded_tensor.shape[self.FSDP_SHARD_DIM])
-            loaded_tensor_slice = loaded_tensor.index_select(
-                dim=self.FSDP_SHARD_DIM, index=torch.arange(start, end, dtype=torch.int64, device=loaded_tensor.device)
-            )
-            non_pad_len = end - start
-            local_tensor[:non_pad_len].copy_(loaded_tensor_slice)
-
-            if non_pad_len < local_tensor.shape[self.FSDP_SHARD_DIM]:
-                assert self.config.float8_cfg is not None
-                local_tensor[non_pad_len:].copy_(0.0)  # type: ignore  # padded part must be set to 0
-        else:
-            local_tensor.copy_(loaded_tensor)
+        loaded_tensor = self._apply_load_slices(loaded_tensor, load_plan)
+        self._copy_loaded_tensor_to_local(loaded_tensor, local_tensor)
 
     def param_to_safetensor(
         self,

--- a/xtuner/v1/rl/base/worker.py
+++ b/xtuner/v1/rl/base/worker.py
@@ -2,9 +2,8 @@ import json
 import math
 import os
 import time
-from itertools import chain
 from pathlib import Path
-from typing import Dict, Iterable, List, Sequence, TypeAlias, TypedDict, cast
+from typing import Any, Dict, Iterable, List, Sequence, TypeAlias, TypedDict, cast
 
 import ray
 import requests
@@ -29,7 +28,7 @@ from xtuner.v1.float8.float8_handler import Float8Handler
 from xtuner.v1.loss import CELossConfig, LogProbConfig
 from xtuner.v1.loss.ce_loss import CELossContext
 from xtuner.v1.model.base import BaseModel as XtunerBaseModel
-from xtuner.v1.model.base import ModelItem, TransformerConfig
+from xtuner.v1.model.base import ModelItem, TransformerConfig, is_float8_weight
 from xtuner.v1.model.compose.base import BaseComposeConfig, BaseComposeModel
 from xtuner.v1.model.compose.qwen3_vl import Qwen3VLForConditionalGeneration
 from xtuner.v1.model.utils.misc import ModelForwardExtraLogInfo
@@ -46,7 +45,6 @@ from xtuner.v1.utils import (
     monkey_unpatch_torch_reductions,
     ray_method,
 )
-from xtuner.v1.utils.load_spec import LoadEnum
 
 from ..loss_fn import kl_penalty
 from .loss import BaseRLLossConfig
@@ -878,53 +876,47 @@ class TrainingWorker(SingleAcceleratorWorker):
         dtype = torch.bfloat16
 
         bucket_size = int(self.config.update_weight_bucket_size_in_gb * 1024**3)
-        same_gen = model._get_same_hf_param(
-            model._group_param_by_load_spec(LoadEnum.SAME), dtype=dtype, device=DEVICE, bucket_size=bucket_size
-        )
-        fused_gen = model._get_fused_hf_param(
-            model._group_param_by_load_spec(LoadEnum.FUSED),
+        ep_fused_params = []
+        other_params = []
+        ep_mesh = getattr(model, "ep_mesh", None)
+        ep_group = ep_mesh.get_group() if ep_mesh is not None and ep_mesh.size() > 1 else None
+        for param, load_spec in model._load_spec_params():
+            is_ep_fused = (
+                ep_group is not None
+                and load_spec.is_fused
+                and load_spec.fused_dim is not None
+                and any(
+                    shard.dim == load_spec.fused_dim and model._is_same_process_group(shard.group, ep_group)
+                    for shard in load_spec.shards
+                )
+            )
+            if is_ep_fused:
+                ep_fused_params.append((param, load_spec))
+            else:
+                other_params.append((param, load_spec))
+
+        fused_gen = model._get_hf_param(
+            ep_fused_params,
             dtype=dtype,
             device=DEVICE,
             bucket_size=bucket_size,
-            update_weights_for_rl=True,
+            preserved_fused_shard_group=ep_group,
         )
-        shard_gen = model._get_shard_hf_param(
-            model._group_param_by_load_spec(LoadEnum.SHARD), dtype=dtype, device=DEVICE, bucket_size=bucket_size
+        for name_list, param_list in fused_gen:
+            state_dict = {name: param.detach() for name, param in zip(name_list, param_list)}
+            assert ep_group is not None
+            # Stream one EP rank's fused expert slice at a time. This keeps RL weight sync at the old
+            # peak-memory behavior instead of materializing the full expert tensor on every rank.
+            self._request_ep_sequential_update(state_dict, ep_group)
+            del state_dict, name_list, param_list
+
+        other_gen = model._get_hf_param(
+            other_params,
+            dtype=dtype,
+            device=DEVICE,
+            bucket_size=bucket_size,
         )
-
-        for name_list, fused_param_list in fused_gen:
-            state_dict = {name: param.detach() for name, param in zip(name_list, fused_param_list)}
-            if model.fsdp_config.ep_size > 1:
-                # When ep_size > 1, generator generates part of the fused param on each ep rank in one ep_group.
-                # We can all gather them to get full fused param but it would lead to a larger memory usage.
-                # So we broadcast the part fused param from each ep rank in ep_group sequentially,
-                # and update the part of the fused param sequentially to reduce memory usage.
-                if isinstance(model.config, BaseComposeConfig):
-                    ep_mesh: DeviceMesh = model.language_model.ep_mesh
-                else:
-                    ep_mesh: DeviceMesh = model.ep_mesh
-                ep_group = ep_mesh.get_group()
-                global_rank = dist.get_rank()
-                for src_global_rank in dist.get_process_group_ranks(ep_group):
-                    broadcast_state_dict = dict()
-                    for key, tensor in state_dict.items():
-                        obj_to_broadcast = [key, tensor.to("meta")] if global_rank == src_global_rank else [None, None]
-                        dist.broadcast_object_list(obj_to_broadcast, src=src_global_rank, group=ep_group)
-                        real_key, meta_tensor = obj_to_broadcast
-                        buffer = (
-                            state_dict[real_key]
-                            if global_rank == src_global_rank
-                            else torch.empty_like(meta_tensor, device=DEVICE)
-                        )
-                        dist.broadcast(buffer, src=src_global_rank, group=ep_group)
-                        broadcast_state_dict[real_key] = buffer
-                    self.request_update_params(broadcast_state_dict, finished=False)
-                    del broadcast_state_dict, buffer
-            else:
-                self.request_update_params(state_dict, finished=False)
-            del state_dict, name_list, fused_param_list
-
-        for name_list, param_list in chain(same_gen, shard_gen):
+        for name_list, param_list in other_gen:
             state_dict = {name: param.detach() for name, param in zip(name_list, param_list)}
             self.request_update_params(state_dict, finished=False)
             del state_dict, name_list, param_list
@@ -935,6 +927,43 @@ class TrainingWorker(SingleAcceleratorWorker):
         dist.barrier()
         DEVICE_MODULE.empty_cache()
         return
+
+    def _request_ep_sequential_update(
+        self,
+        local_state_dict: dict[str, torch.Tensor],
+        ep_group: dist.ProcessGroup,
+    ) -> None:
+        global_rank = dist.get_rank()
+        ep_ranks = dist.get_process_group_ranks(ep_group)
+        local_items = list(local_state_dict.items())
+
+        for src_global_rank in ep_ranks:
+            item_count_obj: list[int | None] = [len(local_items)] if global_rank == src_global_rank else [None]
+            dist.broadcast_object_list(item_count_obj, src=src_global_rank, group=ep_group)
+            item_count = cast(int, item_count_obj[0])
+            broadcast_state_dict: dict[str, torch.Tensor] = {}
+
+            for item_idx in range(item_count):
+                source_tensor: torch.Tensor | None = None
+                if global_rank == src_global_rank:
+                    source_key, source_tensor = local_items[item_idx]
+                    obj_to_broadcast = [source_key, tuple(source_tensor.shape), source_tensor.dtype]
+                else:
+                    obj_to_broadcast = [None, None, None]
+
+                dist.broadcast_object_list(obj_to_broadcast, src=src_global_rank, group=ep_group)
+                real_key = cast(str, obj_to_broadcast[0])
+                tensor_shape = cast(tuple[int, ...], obj_to_broadcast[1])
+                tensor_dtype = cast(torch.dtype, obj_to_broadcast[2])
+                if source_tensor is not None:
+                    buffer = source_tensor
+                else:
+                    buffer = torch.empty(tensor_shape, dtype=tensor_dtype, device=DEVICE)
+                dist.broadcast(buffer, src=src_global_rank, group=ep_group)
+                broadcast_state_dict[real_key] = buffer
+
+            if broadcast_state_dict:
+                cast(Any, self.request_update_params)(broadcast_state_dict, finished=False)
 
     def _update_weights_by_layer(self):
         """Update the model weights."""
@@ -954,11 +983,16 @@ class TrainingWorker(SingleAcceleratorWorker):
                 dtype = torch.bfloat16
 
         def get_params(tensor_list, name_list, save_dtype):
-            _tensor_list, _spec_list = list(zip(*tensor_list))
+            _tensor_list = [item[0] for item in tensor_list]
+            _spec_list = [item[1] for item in tensor_list]
+            runtime_is_float8_list = [item[2] for item in tensor_list]
             fsdp_unshard_tensor_list = model._fsdp_foreach_allgather(_tensor_list, _spec_list)
             if save_dtype == torch.float8_e4m3fn:
                 fsdp_unshard_tensor_list, name_list = model._to_float8(
-                    fsdp_unshard_tensor_list, name_list, _tensor_list, save_dtype
+                    fsdp_unshard_tensor_list,
+                    name_list,
+                    runtime_is_float8_list,
+                    save_dtype,
                 )
             return fsdp_unshard_tensor_list, name_list
 
@@ -987,6 +1021,7 @@ class TrainingWorker(SingleAcceleratorWorker):
                 else:
                     saved_list.append(f"layers.{i}.{sub_name}")
                 local_tensor = param._local_tensor if isinstance(param, DTensor) else param
+                runtime_is_float8 = is_float8_weight(local_tensor)
                 local_tensor = local_tensor.bfloat16()
                 load_spec = language_model.load_spec_mapping.get(f"layers.{i}.{sub_name}")
 
@@ -1000,7 +1035,7 @@ class TrainingWorker(SingleAcceleratorWorker):
                 if ".gate." in name and ".mlp.gate." not in name:
                     name = name.replace(".gate.", ".mlp.gate.")
                 name_list.append(name)
-                tensor_list.append((local_tensor, load_spec))
+                tensor_list.append((local_tensor, load_spec, runtime_is_float8))
             fsdp_unshard_tensor_list, name_list = get_params(tensor_list, name_list, dtype)
             state_dict = dict(zip(name_list, fsdp_unshard_tensor_list))
             self.request_update_params(state_dict)
@@ -1009,6 +1044,7 @@ class TrainingWorker(SingleAcceleratorWorker):
             if name in saved_list:
                 continue
             local_tensor = param._local_tensor if isinstance(param, DTensor) else param
+            runtime_is_float8 = is_float8_weight(local_tensor)
             local_tensor = local_tensor.bfloat16()
             load_spec = model.load_spec_mapping.get(name)
 
@@ -1028,7 +1064,7 @@ class TrainingWorker(SingleAcceleratorWorker):
                     name = "model.norm.weight"
                 elif name == "embed_tokens.weight":
                     name = "model.embed_tokens.weight"
-            tensor_list = [(local_tensor, load_spec)]
+            tensor_list = [(local_tensor, load_spec, runtime_is_float8)]
             name_list = [name]
             fsdp_unshard_tensor_list, name_list = get_params(tensor_list, name_list, dtype)
             state_dict = dict(zip(name_list, fsdp_unshard_tensor_list))
@@ -1040,183 +1076,6 @@ class TrainingWorker(SingleAcceleratorWorker):
         dist.barrier()
         DEVICE_MODULE.empty_cache()
         return
-
-    # def update_weights1(self):
-    #     """Update the model weights."""
-    #     self.endpoints["update_weights"] = "update_weights"
-    #     assert self.rollout_device_mesh is not None
-    #     time1 = time.time()
-
-    #     model = self._engine.model
-    #     DEVICE_MODULE.empty_cache()
-
-    #     if (model.config.float8_cfg is not None) and (model.config.float8_cfg.enable_float8):
-    #         dtype = torch.float8_e4m3fn
-    #     else:
-    #         dtype = torch.bfloat16
-
-    #     fused_params = []
-    #     for name, param in model.state_dict().items():
-    #         load_spec = model.load_spec_mapping.get(name)
-    #         if load_spec.load_enum == LoadEnum.FUSED:
-    #             fused_params.append((name, param, load_spec))
-
-    #     # TODO: decouple update_weights from the model structure
-    #     bucket_size = 1024**3
-    #     safetensor_size = 0
-    #     tensor_list: list[tuple[torch.Tensor, LoadSpec]] = []
-    #     name_list: list[str] = []
-    #     for name, param, load_spec in fused_params:
-    #         local_tensor = param._local_tensor if isinstance(param, DTensor) else param
-    #         local_tensor = local_tensor.bfloat16()
-    #         if safetensor_size + model._get_tensor_size(param, dtype) > bucket_size:
-    #             _tensor_list, _spec_list = list(zip(*tensor_list))
-    #             fsdp_unshard_tensor_list = model._fsdp_foreach_allgather(_tensor_list, _spec_list)
-    #             if dtype == torch.float8_e4m3fn:
-    #                 fsdp_unshard_tensor_list, name_list = model._to_float8(
-    #                     fsdp_unshard_tensor_list, name_list, _tensor_list, dtype
-    #                 )
-    #             state_dict = dict(zip(name_list, fsdp_unshard_tensor_list))
-    #             self.request_update_params(state_dict)
-    #             safetensor_size = 0
-    #             tensor_list = [(local_tensor, load_spec)]
-    #             name_list = ["model." + name.replace(".experts.", ".mlp.experts.")]
-    #             continue
-    #         safetensor_size += model._get_tensor_size(param, dtype)
-    #         tensor_list.append((local_tensor, load_spec))
-    #         name_list.append("model." + name.replace(".experts.", ".mlp.experts."))
-
-    #     if tensor_list:
-    #         assert len(name_list) == len(tensor_list)
-    #         _tensor_list, _spec_list = list(zip(*tensor_list))
-    #         fsdp_unshard_tensor_list = model._fsdp_foreach_allgather(_tensor_list, _spec_list)
-    #         if dtype == torch.float8_e4m3fn:
-    #             fsdp_unshard_tensor_list, name_list = model._to_float8(
-    #                 fsdp_unshard_tensor_list, name_list, _tensor_list, dtype
-    #             )
-    #         state_dict = dict(zip(name_list, fsdp_unshard_tensor_list))
-    #         self.request_update_params(state_dict)
-
-    #     same_gen = model._get_same_hf_param(
-    #         model._group_param_by_load_spec(LoadEnum.SAME),
-    #         dtype=dtype,
-    #         device="cuda",
-    #         bucket_size=1024**3,
-    #     )
-    #     for name_list, gathered_tensor_list in tqdm.tqdm(same_gen, desc="[update dense weights]"):
-    #         state_dict = dict(zip(name_list, gathered_tensor_list))
-    #         self.request_update_params(state_dict)
-    #         del state_dict
-
-    #     self.request_update_params({}, finished=True)
-
-    #     dist.barrier()
-    #     logger.info(f"update weights time: {time.time() - time1}")
-    #     DEVICE_MODULE.empty_cache()
-    #     return
-
-    # def update_weights(self):
-    #     """Update the model weights."""
-    #     self.endpoints["update_weights"] = "update_weights"
-    #     assert self.rollout_device_mesh is not None
-
-    #     model = self._engine.model
-    #     DEVICE_MODULE.empty_cache()
-
-    #     saved_keys = []
-    #     gather_duration = []
-    #     weight_duration = []
-    #     reshard_duration = []
-
-    #     # update decoder layers
-    #     for i, layer in tqdm.tqdm(model.layers.items(), desc="[gather weight]"):
-    #         start = time.perf_counter()
-    #         layer.unshard()
-    #         layer_state_dict = {}
-
-    #         for sub_name, param in layer.named_parameters():
-    #             if "_checkpoint_wrapped_module." in sub_name:
-    #                 sub_name = sub_name.replace("_checkpoint_wrapped_module.", "")
-    #             if isinstance(param, DTensor):
-    #                 param = param.to_local()
-
-    #             if isinstance(param, WeightWithDynamicTilewiseFloat8CastTensor):
-    #                 param = param._tensor
-
-    #             if isinstance(param, Float8Tensor):
-    #                 scale_name = f"model.layers.{i}.{sub_name}_scale_inv"
-    #                 assert "fused_w1w3" in sub_name or "fused_w2" in sub_name
-    #                 # save scale_inv parameter to state_dict
-    #                 scale_tensor = param._scale
-    #                 quant_tensor = param._data
-    #                 ep_mesh = model.ep_mesh
-    #                 if ep_mesh.size() > 1:
-    #                     scale_tensor = torch.cat(dist.nn.all_gather(scale_tensor, group=ep_mesh.get_group()), dim=0)
-    #                     quant_tensor = torch.cat(dist.nn.all_gather(quant_tensor, group=ep_mesh.get_group()), dim=0)
-    #                 layer_state_dict[scale_name] = scale_tensor.detach()
-    #                 # set `param` which will be added to state_dict at the bottom of the for-block
-    #                 param = quant_tensor
-
-    #             param = param.to(DEVICE)
-    #             name = f"model.layers.{i}.{sub_name}"
-    #             saved_keys.append(name.replace("model.", ""))
-    #             if ".experts." in name and ".mlp." not in name:
-    #                 name = name.replace(".experts.", ".mlp.experts.")
-    #             if ".gate." in name and ".mlp." not in name:
-    #                 name = name.replace(".gate.", ".mlp.gate.")
-    #             layer_state_dict[name] = param.detach()
-    #         gather_duration.append(time.perf_counter() - start)
-    #         start = time.perf_counter()
-    #         self.request_update_params(layer_state_dict, finished=True)
-    #         breakpoint()
-    #         weight_duration.append(time.perf_counter() - start)
-
-    #         start = time.perf_counter()
-    #         del layer_state_dict
-    #         layer.reshard()
-    #         reshard_duration.append(time.perf_counter() - start)
-
-    #     if dist.get_rank() == 0:
-    #         logger.debug(
-    #             f"Rank 0 Gather decoder layers done, total {sum(gather_duration):.2f}s, avg "
-    #             f"{sum(gather_duration) / len(gather_duration):.2f}s"
-    #         )
-    #         logger.debug(
-    #             f"Rank 0 migrate/save decoder layers done, total {sum(weight_duration):.2f}s, avg "
-    #             f"{sum(weight_duration) / len(weight_duration):.2f}s"
-    #         )
-    #         logger.debug(
-    #             f"Rank 0 reshard decoder layers done, total {sum(reshard_duration):.2f}s, avg "
-    #             f"{sum(reshard_duration) / len(reshard_duration):.2f}s"
-    #         )
-
-    #     # update other params
-    #     model.norm.unshard()
-    #     model.lm_head.unshard()
-    #     model.embed_tokens.unshard()
-    #     others_state_dict = {}
-    #     for name, param in model.named_parameters():
-    #         if "_checkpoint_wrapped_module." in name:
-    #             continue
-    #         if name not in saved_keys:
-    #             saved_keys.append(name)
-    #             if name == "norm.weight":
-    #                 name = "model.norm.weight"
-    #             if name == "embed_tokens.weight":
-    #                 name = "model.embed_tokens.weight"
-    #             if isinstance(param, DTensor):
-    #                 param = param.to_local()
-    #             others_state_dict[name] = param.detach()
-    #     self.request_update_params(others_state_dict, finished=True)
-    #     model.norm.reshard()
-    #     model.lm_head.reshard()
-    #     model.embed_tokens.reshard()
-    #     del others_state_dict
-    #     del param
-
-    #     dist.barrier()
-    #     DEVICE_MODULE.empty_cache()
-    #     return
 
     @ray_method
     def request_update_params(self, state_dict, finished=False):

--- a/xtuner/v1/utils/load_spec.py
+++ b/xtuner/v1/utils/load_spec.py
@@ -1,8 +1,10 @@
 import math
-from typing import NamedTuple
+from collections.abc import Callable
+from typing import Any, NamedTuple, cast
 
 import torch
 import torch.distributed as dist
+import torch.distributed.tensor._utils as dtensor_utils
 import torch.nn.functional as F
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from torch.distributed.tensor import DTensor, Shard
@@ -42,12 +44,13 @@ class ShardDescriptor(BaseModel):
 def _dtensor_shards(tensor: DTensor) -> list[ShardDescriptor]:
     current_shape = list(tensor.shape)
     shards: list[ShardDescriptor] = []
-    for mesh_dim, placement in enumerate(tensor.placements):
+    for mesh_dim, placement in _ordered_dtensor_placements(tensor):
         if not isinstance(placement, Shard):
             continue
 
-        # DTensor applies placements in mesh-dim order. ShardDescriptor keeps the same order and stores each
-        # boundary in the coordinate system produced by the previous shard descriptors.
+        # DTensor placement order is not always the raw mesh-dim order. FSDP2 can represent right-to-left sharding
+        # with _StridedShard, and PyTorch's checkpoint offset helper first expands that into the effective shard
+        # order. LoadSpec must preserve the same order so its descriptor intervals match DTensor local tensors.
         #
         # XTuner may initialize modules while the default device is "meta". PyTorch's Shard placement helpers can
         # inherit that default device for temporary shape arithmetic, so force XTuner's real runtime device before
@@ -68,6 +71,16 @@ def _dtensor_shards(tensor: DTensor) -> list[ShardDescriptor]:
         )
         current_shape[placement.dim] = local_size
     return shards
+
+
+def _ordered_dtensor_placements(tensor: DTensor) -> list[tuple[int, object]]:
+    # PyTorch keeps this helper private and does not expose it in type stubs, but it is the same ordering logic used
+    # by `compute_local_shape_and_global_offset`. Access it dynamically so mypy does not reject the private symbol.
+    explicit_order_placements = cast(
+        Callable[[Any, Any], list[tuple[int, object]]],
+        getattr(dtensor_utils, "_explicit_order_placements"),
+    )
+    return explicit_order_placements(tensor.device_mesh.shape, tensor.placements)
 
 
 class LoadSlice(BaseModel):
@@ -647,7 +660,7 @@ class LoadSpec(BaseModel):
                 f"Invalid shard dim {shard.dim} for global_shape={self.global_shape}"
             )
             current_size = current_shape[shard.dim]
-            assert 0 <= shard.start < shard.end <= current_size, (
+            assert 0 <= shard.start <= shard.end <= current_size, (
                 f"Invalid shard descriptor {shard} against current_shape={tuple(current_shape)}"
             )
             current_shape[shard.dim] = shard.end - shard.start

--- a/xtuner/v1/utils/load_spec.py
+++ b/xtuner/v1/utils/load_spec.py
@@ -1,36 +1,755 @@
+import math
+from typing import NamedTuple
+
+import torch
 import torch.distributed as dist
-from pydantic import BaseModel, ConfigDict
+import torch.nn.functional as F
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+from torch.distributed.tensor import DTensor, Shard
 
-from .enum_helper import StrEnum
+from xtuner.v1.ops.comm.foreach_allgather import foreach_all_gather
+from xtuner.v1.utils.device import get_device
 
 
-class LoadEnum(StrEnum):
-    FUSED = "fused"
-    SAME = "same"
-    SHARD = "shard"
+def _is_same_process_group(left: dist.ProcessGroup, right: dist.ProcessGroup) -> bool:
+    if left is right:
+        return True
+    return dist.get_process_group_ranks(left) == dist.get_process_group_ranks(right)
+
+
+class ShardDescriptor(BaseModel):
+    """A single partition applied to the fused full tensor.
+
+    The full tensor is obtained by concatenating every ``LoadSpec.global_hf_keys`` along
+    ``LoadSpec.fused_dim`` (or taking the sole HF tensor when ``len(global_hf_keys) == 1``).
+    Descriptors are applied in order; later descriptors use offsets relative to the sub-tensor produced by all
+    earlier descriptors, matching DTensor placement semantics.
+
+    Args:
+        dim (int): Tensor dim on which this partition cuts.
+        start (int): Inclusive start offset relative to the current sub-tensor.
+        end (int): Exclusive end offset relative to the current sub-tensor.
+        group (dist.ProcessGroup): Communication group that produced this partition.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+    dim: int
+    start: int
+    end: int
+    group: dist.ProcessGroup
+
+
+def _dtensor_shards(tensor: DTensor) -> list[ShardDescriptor]:
+    current_shape = list(tensor.shape)
+    shards: list[ShardDescriptor] = []
+    for mesh_dim, placement in enumerate(tensor.placements):
+        if not isinstance(placement, Shard):
+            continue
+
+        # DTensor applies placements in mesh-dim order. ShardDescriptor keeps the same order and stores each
+        # boundary in the coordinate system produced by the previous shard descriptors.
+        #
+        # XTuner may initialize modules while the default device is "meta". PyTorch's Shard placement helpers can
+        # inherit that default device for temporary shape arithmetic, so force XTuner's real runtime device before
+        # calling the helper.
+        with torch.device(get_device()):
+            local_size, offset = placement._local_shard_size_and_offset(  # type: ignore[attr-defined]
+                current_shape[placement.dim],
+                tensor.device_mesh.size(mesh_dim),
+                tensor.device_mesh.get_local_rank(mesh_dim),
+            )
+        shards.append(
+            ShardDescriptor(
+                dim=placement.dim,
+                start=offset,
+                end=offset + local_size,
+                group=tensor.device_mesh.get_group(mesh_dim),
+            )
+        )
+        current_shape[placement.dim] = local_size
+    return shards
+
+
+class LoadSlice(BaseModel):
+    """A narrow operation in the loaded HF tensor coordinate system.
+
+    Args:
+        dim (int): Tensor dimension to narrow.
+        start (int): Inclusive start offset in the loaded tensor.
+        end (int): Exclusive end offset in the loaded tensor.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    dim: int
+    start: int
+    end: int
+
+
+class HFLoadPlan(BaseModel):
+    """Execution plan for reading HF safetensors into one local tensor.
+
+    Args:
+        name (str): Fully-qualified parameter or buffer name on the xtuner side.
+        hf_keys (list[str]): HF keys that must be read for this rank.
+        fused_dim (int | None): Concatenation dimension when multiple HF keys are loaded.
+        slices (list[LoadSlice]): Narrow operations to apply after loading. Offsets are relative to the loaded
+            tensor, not the original ``LoadSpec.global_shape``.
+        zero_fill (bool): Whether this rank falls entirely in a padded region and should skip checkpoint reads.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    hf_keys: list[str]
+    fused_dim: int | None = None
+    slices: list[LoadSlice] = Field(default_factory=list)
+    zero_fill: bool = False
+
+
+def _final_intervals(
+    global_shape: tuple[int, ...],
+    shards: list[ShardDescriptor],
+) -> list[tuple[int, int]]:
+    intervals = [(0, dim_size) for dim_size in global_shape]
+    for shard in shards:
+        current_start, _ = intervals[shard.dim]
+        intervals[shard.dim] = (current_start + shard.start, current_start + shard.end)
+    return intervals
+
+
+class SaveShardStep(BaseModel):
+    """Save-time work item derived from one ``LoadSpec.shards`` entry.
+
+    ``LoadSpec.shards`` is a layout description: each descriptor says how the previous tensor was partitioned.
+    Saving needs the inverse operation. ``LoadSpec._save_shard_steps`` converts every shard descriptor into a work
+    item that contains the shard itself plus the tensor shapes that existed immediately before that shard was applied.
+    The save path then executes these work items in reverse order and batches compatible all-gathers by process group.
+
+    ``load_spec_shard_index`` is only needed when some original shards should stay sharded. RL weight sync preserves
+    the EP shard on the fused HF dimension so each EP rank streams only its local expert keys, while later shards such
+    as FSDP still need to be all-gathered. Because execution reverses and groups the work items, their list positions
+    no longer match ``LoadSpec.shards``. The original index is the stable handle used by the save plan to decide
+    which work items to skip and which preserved shards should define the final expected shape.
+
+    Example:
+        ``LoadSpec.shards == [ep_shard, fsdp_shard]`` means the full HF tensor was first cut by EP, then the
+        EP-local tensor was cut by FSDP. Normal HF save executes ``[fsdp_step, ep_step]`` to rebuild the full tensor.
+        RL weight sync can mark ``ep_step`` as preserved, so only the FSDP work item is executed and the result stays
+        EP-local.
+
+    Args:
+        load_spec_shard_index (int): Index of ``shard`` in the original ``LoadSpec.shards`` list.
+        shard (ShardDescriptor): Shard descriptor this save step reverses.
+        shape_before_shard (tuple[int, ...]): Runtime tensor shape immediately before ``shard`` was applied.
+        unpadded_shape_before_shard (tuple[int, ...]): Checkpoint-visible shape before ``shard`` was applied.
+        preserved (bool): Whether this shard should remain applied instead of being all-gathered.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+    load_spec_shard_index: int
+    shard: ShardDescriptor
+    shape_before_shard: tuple[int, ...]
+    unpadded_shape_before_shard: tuple[int, ...]
+    preserved: bool = False
+
+
+class HFSavePlan(BaseModel):
+    """Execution plan for preparing one runtime tensor for HF safetensors save.
+
+    Args:
+        name (str): Fully-qualified parameter or buffer name on the xtuner side.
+        hf_keys (list[str]): HF keys represented by the tensor after this plan's pending unshard steps finish.
+        global_shape (tuple[int, ...]): Runtime full tensor shape before any shard is applied.
+        unpadded_global_shape (tuple[int, ...]): Checkpoint-visible full tensor shape after removing runtime padding.
+        fused_dim (int | None): HF key concatenation dim when the underlying ``LoadSpec`` is fused; ``None``
+            otherwise.
+        distributed_save (bool): Whether non-fused tensors are written only on rank0 and fused keys are split across
+            save ranks.
+        preserves_shards (bool): Whether the save tensor intentionally remains sharded by some original
+            ``LoadSpec.shards`` entries.
+        unshard_steps (list[SaveShardStep]): Forward-order shard history with save-time preserved flags.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+    name: str
+    hf_keys: list[str]
+    global_shape: tuple[int, ...]
+    unpadded_global_shape: tuple[int, ...]
+    fused_dim: int | None = None
+    distributed_save: bool = False
+    preserves_shards: bool = False
+    unshard_steps: list[SaveShardStep] = Field(default_factory=list)
+
+    def _pending_unshard_steps(self) -> list[SaveShardStep]:
+        return [step for step in reversed(self.unshard_steps) if not step.preserved]
+
+    def _preserved_shards(self) -> list[ShardDescriptor]:
+        return [step.shard for step in self.unshard_steps if step.preserved]
+
+    def _expected_unsharded_shape(self) -> tuple[int, ...]:
+        """Return the save tensor shape after intentionally preserved shards
+        remain applied.
+
+        The save path starts from the local tensor and all-gathers every pending shard step. If no shard is preserved,
+        the final shape should be ``unpadded_global_shape``. If some shards are preserved, for example an EP shard
+        during RL weight sync, the final tensor should still be cut by those preserved shards. This helper applies
+        only the preserved shard descriptors to ``unpadded_global_shape`` to compute that expected partially-unsharded
+        shape for the final assert.
+
+        Example:
+            Suppose the runtime full tensor shape is ``(16, 8)`` because fp8 padding added rows, while
+            ``unpadded_global_shape == (14, 8)`` is the shape that should exist in HF. If the preserved EP shard is
+            ``ShardDescriptor(dim=0, start=8, end=16)``, that shard owns runtime rows ``[8, 16)``. The last two rows
+            are padding-only in HF coordinates, so the checkpoint-visible interval is clipped to ``[8, 14)`` and the
+            expected preserved tensor shape is ``(6, 8)``. If a shard were ``[14, 16)``, both boundaries would clip to
+            ``14`` and the expected shape on that rank would be ``(0, 8)``.
+
+        Returns:
+            tuple[int, ...]: Expected shape after the preserved shards are still applied.
+        """
+        effective_shape = list(self.unpadded_global_shape)
+        for shard in self._preserved_shards():
+            # ShardDescriptor offsets are defined against the runtime shape, which may include XTuner-only padding.
+            # Clip preserved shard boundaries to the currently visible unpadded shape before computing its length.
+            clipped_start = min(shard.start, effective_shape[shard.dim])
+            clipped_end = min(shard.end, effective_shape[shard.dim])
+            effective_shape[shard.dim] = max(0, clipped_end - clipped_start)
+        return tuple(effective_shape)
+
+
+class _SaveUnshardGroup(NamedTuple):
+    """One compatible foreach all-gather batch in the save unshard loop.
+
+    ``tensors`` and ``shard_steps`` are the grouped work payload. ``tensor_indices`` is kept only because the gathered
+    tensors must be written back to their original positions in the bucket after the collective finishes.
+    """
+
+    tensor_indices: list[int]
+    tensors: list[torch.Tensor]
+    shard_steps: list[SaveShardStep]
+
+
+def unshard_tensors_for_hf_save(
+    tensors: list[torch.Tensor],
+    save_plans: list[HFSavePlan],
+) -> list[torch.Tensor]:
+    """Run the all-gathers needed to turn local runtime tensors into
+    checkpoint-visible save tensors.
+
+    Args:
+        tensors (list[torch.Tensor]): Local runtime tensors to unshard.
+        save_plans (list[HFSavePlan]): HF save plans corresponding to ``tensors``.
+
+    Returns:
+        list[torch.Tensor]: Tensors after all pending save unshard steps have been executed.
+    """
+    assert len(tensors) == len(save_plans), "Internal error: save tensor and plan count mismatch"
+    if not tensors:
+        return []
+
+    # Shallow-copy the list, not the tensors. Entries with no gather work can be returned as-is, while entries
+    # that do need all-gather are overwritten in this working list with their gathered tensor.
+    tensor_list = list(tensors)
+
+    # Convert each tensor's forward shard history into the save-time work queue. Save must undo shards from
+    # inner to outer, so the steps are reversed; preserved shards, such as an EP shard kept local for RL weight
+    # sync, are removed from the queue and only used later to compute the expected partially-unsharded shape.
+
+    # Example:
+    #   tensor A: [ep_a(index=0), fsdp_a(index=1)], preserved {0} -> pending [fsdp_a]
+    #   tensor B: [ep_b(index=0), fsdp_b(index=1)], preserved {} -> pending [fsdp_b, ep_b]
+    #   tensor C: [fsdp_c(index=0)], preserved {} -> pending [fsdp_c]
+    #   tensor D: [tp_d(index=0)], preserved {} -> pending [tp_d]
+    #   tensor E: [ep_e(index=0)], preserved {0} -> pending []
+    # This produces one pending queue per tensor; the loop below consumes compatible queue heads by group.
+    pending_shard_steps_list = [save_plan._pending_unshard_steps() for save_plan in save_plans]
+
+    while True:
+        # Build one all-gather round. For one tensor, reverse-unshard steps must run one by one: if a local
+        # tensor needs to undo FSDP and then EP, the EP gather must use the tensor produced by the FSDP gather.
+        # `_build_ready_save_unshard_groups` consumes `pending_shard_steps_list` gradually. For example, a queue
+        # `[fsdp_step, ep_step]` contributes `fsdp_step` in the first round; after its gathered tensor is written
+        # back, the next loop consumes `ep_step`. Independent tensors with compatible group/dtype can still be
+        # batched together in each round.
+        #
+        # With the A-E example above, round 1 consumes fsdp_a/fsdp_b/fsdp_c together if they share group/dtype,
+        # and consumes tp_d in another group. tensor E contributes no work. Round 2 can then consume ep_b, because
+        # ep_b must use tensor B after fsdp_b has been gathered and written back.
+        unshard_groups = _build_ready_save_unshard_groups(tensor_list, pending_shard_steps_list)
+        if not unshard_groups:
+            break
+
+        for unshard_group in unshard_groups:
+            gathered_tensors = _foreach_all_gather_save_shards(
+                unshard_group.tensors,
+                unshard_group.shard_steps,
+            )
+            for index, gathered_tensor in zip(unshard_group.tensor_indices, gathered_tensors, strict=True):
+                tensor_list[index] = gathered_tensor
+
+    for tensor, save_plan in zip(tensor_list, save_plans, strict=True):
+        expected_shape = save_plan._expected_unsharded_shape()
+        assert tuple(tensor.shape) == expected_shape, (
+            f"Saved tensor shape {tuple(tensor.shape)} is incompatible with HFSavePlan global_shape="
+            f"{save_plan.global_shape} and unpadded_global_shape={save_plan.unpadded_global_shape} "
+            f"for {save_plan.name}"
+        )
+    return tensor_list
+
+
+def _build_ready_save_unshard_groups(
+    tensor_list: list[torch.Tensor],
+    pending_shard_steps_list: list[list[SaveShardStep]],
+) -> list[_SaveUnshardGroup]:
+    """Build foreach all-gather groups for the save unshard steps that are
+    ready to run now."""
+    unshard_groups: list[_SaveUnshardGroup] = []
+    group_list: list[dist.ProcessGroup] = []
+    dtype_list: list[torch.dtype] = []
+
+    for index, pending_shard_steps in enumerate(pending_shard_steps_list):
+        if not pending_shard_steps:
+            # This tensor has no gather work in the current save context. Common cases are unsharded tensors or
+            # tensors whose remaining shards are intentionally preserved, e.g. an EP-only tensor when this pass is
+            # only gathering FSDP shards.
+            continue
+
+        # Consume one dependency-ready head step from this tensor and place it into a compatible foreach group.
+        shard_step = pending_shard_steps.pop(0)
+        shard_group = shard_step.shard.group
+        tensor_dtype = tensor_list[index].dtype
+        for group_index, (existing_group, existing_dtype) in enumerate(zip(group_list, dtype_list, strict=True)):
+            if tensor_dtype == existing_dtype and _is_same_process_group(existing_group, shard_group):
+                unshard_groups[group_index].tensor_indices.append(index)
+                unshard_groups[group_index].tensors.append(tensor_list[index])
+                unshard_groups[group_index].shard_steps.append(shard_step)
+                break
+        else:
+            group_list.append(shard_group)
+            dtype_list.append(tensor_dtype)
+            unshard_groups.append(
+                _SaveUnshardGroup(
+                    tensor_indices=[index],
+                    tensors=[tensor_list[index]],
+                    shard_steps=[shard_step],
+                )
+            )
+
+    return unshard_groups
+
+
+def _foreach_all_gather_save_shards(
+    tensor_list: list[torch.Tensor],
+    shard_steps: list[SaveShardStep],
+) -> list[torch.Tensor]:
+    assert len(tensor_list) == len(shard_steps), "Internal error: tensor and shard-step count mismatch"
+    assert tensor_list, "Internal error: empty save all-gather group"
+    group = shard_steps[0].shard.group
+    assert all(_is_same_process_group(group, shard_step.shard.group) for shard_step in shard_steps), (
+        "Internal error: save all-gather group contains different process groups"
+    )
+    padded_tensor_list = [
+        _pad_tensor_for_save_shard(tensor, shard_step)
+        for tensor, shard_step in zip(tensor_list, shard_steps, strict=True)
+    ]
+    gathered_chunks_list = foreach_all_gather(padded_tensor_list, group)
+    return [
+        _merge_gathered_save_shard(gathered_chunks, shard_step)
+        for gathered_chunks, shard_step in zip(gathered_chunks_list, shard_steps, strict=True)
+    ]
+
+
+def _pad_tensor_for_save_shard(tensor: torch.Tensor, shard_step: SaveShardStep) -> torch.Tensor:
+    world_size = dist.get_world_size(group=shard_step.shard.group)
+    dim = shard_step.shard.dim
+    shard_dim_size = shard_step.shape_before_shard[dim]
+    padded_local_size = math.ceil(shard_dim_size / world_size)
+    pad_len = padded_local_size - tensor.shape[dim]
+    assert pad_len >= 0, (
+        f"Local tensor shape {tuple(tensor.shape)} exceeds padded shard size {padded_local_size} "
+        f"for {shard_step.shard} in save path"
+    )
+    if not pad_len:
+        return tensor
+
+    pad_list = [0] * (2 * tensor.dim())
+    pad_idx = 2 * (tensor.dim() - 1 - dim)
+    pad_list[pad_idx + 1] = pad_len
+    return F.pad(tensor, pad_list)
+
+
+def _merge_gathered_save_shard(
+    gathered_chunks: list[torch.Tensor],
+    shard_step: SaveShardStep,
+) -> torch.Tensor:
+    dim = shard_step.shard.dim
+    gathered_tensor = torch.cat(gathered_chunks, dim=dim)
+    return gathered_tensor.narrow(dim, 0, shard_step.unpadded_shape_before_shard[dim]).contiguous()
 
 
 class LoadSpec(BaseModel):
-    # TODO: (yehaochen) Add more description
-    name: str
+    """Mapping between a local param / buffer and its HF checkpoint keys.
+
+    Args:
+        name (str): Fully-qualified parameter or buffer name on the xtuner side.
+        global_hf_keys (list[str]): Full HF key list. Concatenating these keys along ``fused_dim`` produces the
+            full tensor before local sharding.
+        global_shape (tuple[int, ...]): Shape of the fused full tensor before any ``shards`` partition is applied.
+            This is the runtime shape and may include padding introduced by XTuner float8 weights.
+        fused_dim (int | None): HF key concatenation dim when ``len(global_hf_keys) > 1``; ``None`` otherwise.
+        shards (list[ShardDescriptor]): Partitions applied to the full tensor in outer-to-inner order.
+        origin_shape (tuple[int, ...] | None): Checkpoint-visible global shape after trimming runtime-only padding.
+            The current caller sets it from fp8 tensor metadata; ``None`` means the runtime shape is already the
+            checkpoint shape.
+    """
+
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
-    hf_keys: list[str]
-    shape: tuple[int, ...]
-    dim: int | None = None
-    load_enum: LoadEnum
-    shard_start: int | None = None
-    shard_end: int | None = None
-    group: dist.ProcessGroup | None = None
+    name: str
+    global_hf_keys: list[str]
+    global_shape: tuple[int, ...]
+    fused_dim: int | None = None
+    shards: list[ShardDescriptor] = Field(default_factory=list)
+    origin_shape: tuple[int, ...] | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_fused(self) -> bool:
+        return len(self.global_hf_keys) > 1
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_sharded(self) -> bool:
+        return bool(self.shards)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def unpadded_global_shape(self) -> tuple[int, ...]:
+        return tuple(self.origin_shape or self.global_shape)
+
+    @classmethod
+    def from_tensor(
+        cls,
+        *,
+        name: str,
+        hf_keys: list[str],
+        tensor: torch.Tensor | DTensor,
+        origin_shape: tuple[int, ...] | None = None,
+    ) -> "LoadSpec":
+        """Build a load spec from a runtime tensor and its HF key mapping.
+
+        This is the conversion boundary from PyTorch runtime layout to ``LoadSpec``. It derives the fused HF
+        dimension from ``hf_keys`` and converts DTensor ``Shard`` placements into ``ShardDescriptor`` entries. It does
+        not inspect XTuner fp8 wrapper types; callers should pass ``origin_shape`` when runtime-only padding makes the
+        checkpoint-visible shape smaller than the runtime shape.
+
+        Args:
+            name (str): Fully-qualified parameter or buffer name on the xtuner side.
+            hf_keys (list[str]): HF key list corresponding to ``tensor``.
+            tensor (torch.Tensor | DTensor): Runtime tensor whose DTensor placements should be captured.
+            origin_shape (tuple[int, ...] | None): Optional checkpoint-visible shape after trimming runtime-only
+                padding.
+
+        Returns:
+            LoadSpec: Spec derived from the runtime tensor layout.
+        """
+        global_hf_keys = list(hf_keys)
+        return cls(
+            name=name,
+            global_hf_keys=global_hf_keys,
+            global_shape=tuple(tensor.shape),
+            fused_dim=0 if len(global_hf_keys) > 1 else None,
+            shards=_dtensor_shards(tensor) if isinstance(tensor, DTensor) else [],
+            origin_shape=origin_shape,
+        )
+
+    def plan_hf_load(self) -> HFLoadPlan:
+        """Build a safetensors read plan from this layout spec.
+
+        Runtime-only padding currently comes from XTuner float8 weights. In that case, ``origin_shape`` is used as
+        the checkpoint-visible full tensor shape, while ``global_shape`` and ``shards`` still describe the padded
+        runtime layout that this rank owns.
+
+        Returns:
+            HFLoadPlan: The selected HF keys and loaded-tensor-relative slices for this rank.
+        """
+        effective_intervals = self._effective_intervals_for_shards(self.shards)
+        if effective_intervals is None:
+            return HFLoadPlan(name=self.name, hf_keys=[], fused_dim=self.fused_dim, zero_fill=True)
+
+        loaded_starts = [0 for _ in self.global_shape]
+        loaded_ends = list(self.unpadded_global_shape)
+        key_start, key_end = self._local_hf_key_indices(effective_intervals)
+        hf_keys = self.global_hf_keys[key_start:key_end]
+
+        if self.is_fused:
+            key_size = self._fused_key_size()
+            assert self.fused_dim is not None
+            loaded_starts[self.fused_dim] = key_start * key_size
+            loaded_ends[self.fused_dim] = key_end * key_size
+
+        slices: list[LoadSlice] = []
+        for dim, (effective_start, effective_end) in enumerate(effective_intervals):
+            loaded_start = loaded_starts[dim]
+            loaded_end = loaded_ends[dim]
+            if effective_start == loaded_start and effective_end == loaded_end:
+                continue
+            slices.append(
+                LoadSlice(
+                    dim=dim,
+                    start=effective_start - loaded_start,
+                    end=effective_end - loaded_start,
+                )
+            )
+
+        return HFLoadPlan(name=self.name, hf_keys=hf_keys, fused_dim=self.fused_dim, slices=slices)
+
+    def plan_hf_save(
+        self,
+        *,
+        distributed_save: bool = False,
+        preserve_process_group: dist.ProcessGroup | None = None,
+        gather_process_group: dist.ProcessGroup | None = None,
+    ) -> HFSavePlan:
+        """Build a safetensors save plan from this layout spec.
+
+        Args:
+            distributed_save (bool): Whether non-fused tensors are written only on rank0 and fused HF keys are split
+                across save ranks.
+            preserve_process_group (dist.ProcessGroup | None): Fused-dim shard group that should remain sharded,
+                used by RL weight sync to stream EP-local expert slices.
+            gather_process_group (dist.ProcessGroup | None): If set, only shards from this group are gathered and
+                all other shards are preserved. This is used by callers that need an FSDP-only all-gather.
+
+        Returns:
+            HFSavePlan: Save-time unshard and HF key planning information.
+        """
+        assert not (preserve_process_group is not None and gather_process_group is not None), (
+            "preserve_process_group and gather_process_group describe different save policies and cannot be combined"
+        )
+        preserved_shard_indices = self._preserved_shard_indices(
+            preserve_process_group=preserve_process_group,
+            gather_process_group=gather_process_group,
+        )
+        unshard_steps = self._save_shard_steps(preserved_shard_indices)
+        preserved_shards = [step.shard for step in unshard_steps if step.preserved]
+        hf_keys = (
+            self._local_hf_keys_for_shards(preserved_shards, require_fused_key_aligned=True)
+            if preserved_shards
+            else list(self.global_hf_keys)
+        )
+
+        return HFSavePlan(
+            name=self.name,
+            hf_keys=hf_keys,
+            global_shape=self.global_shape,
+            unpadded_global_shape=self.unpadded_global_shape,
+            fused_dim=self.fused_dim,
+            distributed_save=distributed_save,
+            preserves_shards=bool(preserved_shards),
+            unshard_steps=unshard_steps,
+        )
 
     def model_post_init(self, _) -> None:
-        if self.load_enum == LoadEnum.SAME:
-            assert len(self.hf_keys) == 1, "hf_keys should have exactly one key when load_enum is SAME"
-        elif self.load_enum == LoadEnum.FUSED:
-            if self.dim is None:
-                self.dim = 0
-            assert self.dim == 0, "dim should be 0 when load_enum is FUSED"
-        elif self.load_enum == LoadEnum.SHARD:
-            assert self.dim is not None, "dim should not be None when load_enum is SHARD"
-            assert len(self.hf_keys) == 1, "hf_keys should have more than one key when load_enum is SHARD"
-            assert self.shard_start is not None, "shard_start should not be None when load_enum is SHARD"
-            assert self.shard_end is not None, "shard_end should not be None when load_enum is SHARD"
+        if self.is_fused:
+            assert self.fused_dim is not None, "fused_dim must be set when global_hf_keys has multiple entries"
+        else:
+            assert self.fused_dim is None, "fused_dim must be None when global_hf_keys has one entry"
+        self._validate_origin_shape()
+        self._validate_shards()
+
+    def _effective_intervals_for_shards(
+        self,
+        shards: list[ShardDescriptor],
+    ) -> list[tuple[int, int]] | None:
+        effective_shape = self.unpadded_global_shape
+        assert len(effective_shape) == len(self.global_shape), (
+            f"origin_shape={effective_shape} must have the same rank as global_shape={self.global_shape}"
+        )
+        assert all(effective <= global_ for effective, global_ in zip(effective_shape, self.global_shape)), (
+            f"origin_shape={effective_shape} must not exceed global_shape={self.global_shape}"
+        )
+
+        final_intervals = _final_intervals(self.global_shape, shards)
+        effective_intervals: list[tuple[int, int]] = []
+        for dim, (start, end) in enumerate(final_intervals):
+            effective_start = min(start, effective_shape[dim])
+            effective_end = min(end, effective_shape[dim])
+            if effective_start >= effective_end:
+                return None
+            effective_intervals.append((effective_start, effective_end))
+        return effective_intervals
+
+    def _fused_key_size(self) -> int:
+        assert self.fused_dim is not None, "fused_dim must be set when global_hf_keys has multiple entries"
+        key_size = self.unpadded_global_shape[self.fused_dim] / len(self.global_hf_keys)
+        assert key_size.is_integer(), (
+            f"Fused dim size {self.unpadded_global_shape[self.fused_dim]} is not divisible by "
+            f"{len(self.global_hf_keys)} HF keys for {self.name}"
+        )
+        return int(key_size)
+
+    def _local_hf_key_indices(
+        self,
+        effective_intervals: list[tuple[int, int]],
+        *,
+        require_fused_key_aligned: bool = False,
+    ) -> tuple[int, int]:
+        if not self.is_fused:
+            return 0, len(self.global_hf_keys)
+
+        assert self.fused_dim is not None
+        key_size = self._fused_key_size()
+        fused_start, fused_end = effective_intervals[self.fused_dim]
+        if require_fused_key_aligned:
+            assert fused_start % key_size == 0 and fused_end % key_size == 0, (
+                f"Preserved fused shard range [{fused_start}, {fused_end}) for {self.name} must align with "
+                f"HF key size {key_size}"
+            )
+
+        # Shards may start or end inside a fused HF key, e.g. FSDP slicing an EP-local expert tensor.
+        # floor/ceil keeps every overlapping key; LoadSlice later trims load tensors to the exact local range.
+        key_start = fused_start // key_size
+        key_end = math.ceil(fused_end / key_size)
+        assert 0 <= key_start < key_end <= len(self.global_hf_keys), (
+            f"Invalid fused key range [{key_start}, {key_end}) for {self.name}"
+        )
+        return key_start, key_end
+
+    def _local_hf_keys_for_shards(
+        self,
+        shards: list[ShardDescriptor],
+        *,
+        require_fused_key_aligned: bool = False,
+    ) -> list[str]:
+        effective_intervals = self._effective_intervals_for_shards(shards)
+        if effective_intervals is None:
+            return []
+        key_start, key_end = self._local_hf_key_indices(
+            effective_intervals,
+            require_fused_key_aligned=require_fused_key_aligned,
+        )
+        return self.global_hf_keys[key_start:key_end]
+
+    def _validate_origin_shape(self) -> None:
+        if self.origin_shape is None:
+            return
+
+        assert len(self.origin_shape) == len(self.global_shape), (
+            f"origin_shape={self.origin_shape} must have the same rank as global_shape={self.global_shape}"
+        )
+        assert all(origin <= global_ for origin, global_ in zip(self.origin_shape, self.global_shape)), (
+            f"origin_shape={self.origin_shape} must not exceed global_shape={self.global_shape}"
+        )
+
+    def _validate_shards(self) -> None:
+        current_shape = list(self.global_shape)
+        for shard in self.shards:
+            assert 0 <= shard.dim < len(current_shape), (
+                f"Invalid shard dim {shard.dim} for global_shape={self.global_shape}"
+            )
+            current_size = current_shape[shard.dim]
+            assert 0 <= shard.start < shard.end <= current_size, (
+                f"Invalid shard descriptor {shard} against current_shape={tuple(current_shape)}"
+            )
+            current_shape[shard.dim] = shard.end - shard.start
+
+    def _preserved_shard_indices(
+        self,
+        *,
+        preserve_process_group: dist.ProcessGroup | None,
+        gather_process_group: dist.ProcessGroup | None,
+    ) -> set[int]:
+        """Return ``self.shards`` indices that should remain sharded in this
+        save plan.
+
+        ``preserve_process_group`` is only used when a fused HF tensor has an additional runtime partition on
+        ``fused_dim``. For example, MoE expert parallel may shard the concatenated expert keys on the same dim that
+        HF uses for fused keys, and FSDP may further shard that EP-local tensor on the same dim. RL weight sync wants
+        to preserve the EP shard so it can derive the local HF key range from that shard, while all remaining shards
+        such as FSDP must still be all-gathered to recover a complete weight for that preserved EP slice.
+
+        ``gather_process_group`` is the inverse policy used by FSDP-only all-gather callers: gather shards from this
+        group and preserve every other shard.
+
+        Example:
+            Suppose ``global_hf_keys`` represents experts ``[0..7]`` concatenated on dim 0, and the runtime layout is
+            ``shards=[ep_shard(dim=0, group=ep_group), fsdp_shard(dim=0, group=fsdp_group)]``. Passing ``ep_group`` as
+            ``preserve_process_group`` returns ``{0}``: the EP shard is preserved for local HF key planning, while the
+            FSDP shard at index 1 is still all-gathered so the local EP expert slice becomes complete. Passing
+            ``fsdp_group`` as ``gather_process_group`` produces the same preserved index set for an FSDP-only gather.
+
+        Returns:
+            set[int]: Indices into ``self.shards``, not tensor dimensions.
+        """
+        if gather_process_group is not None:
+            return {
+                shard_index
+                for shard_index, shard in enumerate(self.shards)
+                if not _is_same_process_group(shard.group, gather_process_group)
+            }
+
+        if preserve_process_group is None or not self.is_fused:
+            return set()
+
+        assert self.fused_dim is not None, (
+            f"Internal error: fused LoadSpec {self.name} has no fused_dim. "
+            "LoadSpec.model_post_init should reject this layout before save planning."
+        )
+        return {
+            shard_index
+            for shard_index, shard in enumerate(self.shards)
+            if shard.dim == self.fused_dim and _is_same_process_group(shard.group, preserve_process_group)
+        }
+
+    def _save_shard_steps(self, preserved_shard_indices: set[int]) -> list[SaveShardStep]:
+        """Convert ``LoadSpec.shards`` into save-time reverse-unshard work
+        items.
+
+        ``LoadSpec.shards`` is ordered in the forward partitioning direction: start from the full runtime tensor,
+        apply one shard after another, and end at this rank's local tensor. The returned steps keep that same
+        largest-to-smallest order. Each step snapshots the runtime shape and the unpadded checkpoint-visible shape
+        that existed immediately before its shard was applied.
+
+        Save executes these steps in reverse. Starting from the smallest local tensor, each reverse step all-gathers
+        one shard and narrows the gathered tensor back to ``unpadded_shape_before_shard``. This is how the save path
+        reconstructs the original shape information one partition layer at a time, while still avoiding fp8 runtime
+        padding in the checkpoint-visible tensor.
+
+        Example:
+            Suppose ``global_shape=(16, 8)``, ``unpadded_global_shape=(14, 8)``, and
+            ``LoadSpec.shards == [ep(dim=0, start=8, end=16), fsdp(dim=0, start=3, end=5)]``. The returned steps are
+            in forward order:
+
+            * ``ep_step`` records ``shape_before_shard=(16, 8)`` and
+              ``unpadded_shape_before_shard=(14, 8)``.
+            * ``fsdp_step`` records ``shape_before_shard=(8, 8)`` and
+              ``unpadded_shape_before_shard=(6, 8)``.
+
+            A local save tensor has shape ``(2, 8)``. Save runs ``[fsdp_step, ep_step]``: gather FSDP back toward
+            ``(6, 8)``, then gather EP back toward ``(14, 8)``. If EP is preserved, only ``fsdp_step`` remains
+            pending and the result stays EP-local.
+
+        Args:
+            preserved_shard_indices (set[int]): Original ``LoadSpec.shards`` indices that should remain sharded.
+
+        Returns:
+            list[SaveShardStep]: Work items in the same largest-to-smallest order as ``LoadSpec.shards``.
+        """
+        current_shape = list(self.global_shape)
+        effective_shape = list(self.unpadded_global_shape)
+        steps: list[SaveShardStep] = []
+
+        for shard_index, shard in enumerate(self.shards):
+            steps.append(
+                SaveShardStep(
+                    load_spec_shard_index=shard_index,
+                    shard=shard,
+                    shape_before_shard=tuple(current_shape),
+                    unpadded_shape_before_shard=tuple(effective_shape),
+                    preserved=shard_index in preserved_shard_indices,
+                )
+            )
+            effective_start = min(shard.start, effective_shape[shard.dim])
+            effective_end = min(shard.end, effective_shape[shard.dim])
+            effective_shape[shard.dim] = max(0, effective_end - effective_start)
+            current_shape[shard.dim] = shard.end - shard.start
+        return steps


### PR DESCRIPTION
## Summary

This PR continues the `LoadSpec` refactor and moves HF load/save layout planning behind clearer plan objects and helpers.

## Changes

- Add `LoadSpec.from_tensor(...)` so DTensor + HF key metadata can be converted into a runtime `LoadSpec` through one entry point.
- Keep `LoadSpec` focused on same-dtype runtime tensor <-> safetensors layout mapping, with fp8 runtime details handled outside the schema.
- Introduce HF save planning and unshard scheduling in `xtuner/v1/utils/load_spec.py`, so `BaseModel` no longer needs to understand preserved fused shard indices directly.
- Simplify `HFSavePlan`: it exposes the concrete `hf_keys` covered by the save tensor plus `preserves_shards`, instead of nesting a load plan or exposing separate global/local key concepts.
- Add targeted unit coverage for deriving `LoadSpec` from plain tensors/DTensors, preserved-shard save key selection, and the save unshard scheduler batching/serialization behavior.

## RL Weight Sync

- Restore the RL EP sequential update behavior so large fused MoE weights can be pushed bucket-by-bucket instead of materializing and submitting the full fused tensor on every EP rank.

## Cleanup

- Remove legacy/commented update code and the old dim-0 no-allocation fuse helper that no longer matched the batched foreach allgather scheduler.
