### PR TITLE
Add async checkpoint support

### DIFF
--- a/examples/v1/config/sft_qwen3_30b_async_verify.py
+++ b/examples/v1/config/sft_qwen3_30b_async_verify.py
@@ -1,0 +1,133 @@
+"""Verification config for async checkpoint with ~30B parameter model.
+
+Uses Qwen3-32B Dense architecture (64 layers, hidden=5120) to produce ~237 GB
+checkpoint (model ~79GB + optimizer ~158GB), large enough to stress async I/O.
+
+Hardware: 8x H200 (141GB each)
+Memory estimate per GPU (FSDP 8-way):
+  - Model weights (bf16):     ~60GB / 8 =  ~7.5GB
+  - Optimizer states (fp32): ~120GB / 8 = ~15.0GB
+  - Gradients (bf16):         ~60GB / 8 =  ~7.5GB
+  - Activations (grad ckpt):              ~10-20GB
+  Total: ~40-50GB per GPU  (well within 141GB)
+
+Requires >= 256 GB host memory per node for CPU staging.
+
+Environment variables:
+  ASYNC_CKPT    - "1" (default) for async, "0" for sync
+  CKPT_INTERVAL - checkpoint interval in steps (default: 10)
+  TOTAL_STEP    - total training steps (default: 100)
+  WORK_DIR      - override work directory path (optional)
+
+Usage:
+  # Async (default)
+  torchrun --nproc_per_node=8 xtuner/v1/train/cli/sft.py \
+      --config examples/v1/config/sft_qwen3_30b_async_verify.py \
+    2>&1 | tee logs/sft_async_qwen3_30b_$(date +%Y%m%d_%H%M%S).log
+
+  # Sync baseline
+  ASYNC_CKPT=0 torchrun --nproc_per_node=8 xtuner/v1/train/cli/sft.py \
+      --config examples/v1/config/sft_qwen3_30b_async_verify.py \
+    2>&1 | tee logs/sft_sync_qwen3_30b_$(date +%Y%m%d_%H%M%S).log
+
+  # Test on slow storage
+  WORK_DIR=/mnt/nfs/ckpt_bench torchrun --nproc_per_node=8 \
+      xtuner/v1/train/cli/sft.py \
+      --config examples/v1/config/sft_qwen3_30b_async_verify.py \
+    2>&1 | tee logs/sft_async_nfs_qwen3_30b_$(date +%Y%m%d_%H%M%S).log
+
+Analysis:
+  Compare logs by grepping for these key timing markers:
+    [Checkpoint Breakdown]      - per-checkpoint blocking time breakdown
+    [Async Checkpoint] Staging  - GPU->CPU staging wait (async only)
+    [Async Checkpoint] Upload   - disk I/O wait (async only)
+    Training finished in        - total training wall-clock
+"""
+
+import os
+
+from xtuner.v1.config import AdamWConfig, LRConfig
+from xtuner.v1.datasets.config import DataloaderConfig, DatasetConfig
+from xtuner.v1.datasets.pt_tokenize_fn import PretrainTokenizeFunctionConfig
+from xtuner.v1.loss import CELossConfig
+from xtuner.v1.model.dense.qwen3 import Qwen3DenseConfig
+from xtuner.v1.module.attention import MHAConfig
+from xtuner.v1.train import TrainerConfig
+
+# ---------------------------------------------------------------------------
+# Environment switches
+# ---------------------------------------------------------------------------
+async_checkpoint = os.environ.get("ASYNC_CKPT", "1") != "0"
+checkpoint_interval = int(os.environ.get("CKPT_INTERVAL", "50"))
+total_step = int(os.environ.get("TOTAL_STEP", "500"))
+work_dir = os.environ.get("WORK_DIR", None)
+
+# ---------------------------------------------------------------------------
+# Model — Qwen3-32B Dense architecture (no pretrained weights, pure verify)
+# ---------------------------------------------------------------------------
+model_cfg = Qwen3DenseConfig(
+    vocab_size=151936,
+    max_position_embeddings=32768,
+    bos_token_id=151643,
+    eos_token_id=151645,
+    num_hidden_layers=64,
+    max_window_layers=64,
+    hidden_size=5120,
+    intermediate_size=17408,
+    rms_norm_eps=1e-6,
+    rope_theta=1000000.0,
+    hidden_act="silu",
+    attention=MHAConfig(
+        num_attention_heads=40,
+        num_key_value_heads=8,
+        head_dim=128,
+        qk_norm=True,
+        sliding_window=None,
+    ),
+    tie_word_embeddings=False,
+)
+
+# ---------------------------------------------------------------------------
+# Data — reuse existing test data
+# ---------------------------------------------------------------------------
+dataset_config = [
+    {
+        "dataset": DatasetConfig(
+            name="pretrain_text",
+            anno_path="tests/resource/pretrain_example_data.jsonl",
+            sample_ratio=1.0,
+        ),
+        "tokenize_fn": PretrainTokenizeFunctionConfig(
+            add_bos_token=False,
+            add_eos_token=True,
+        ),
+    },
+]
+
+dataloader_config = DataloaderConfig(
+    dataset_config_list=dataset_config,
+    pack_max_length=4096,
+)
+
+# ---------------------------------------------------------------------------
+# Optimizer & LR
+# ---------------------------------------------------------------------------
+optim_cfg = AdamWConfig(lr=2e-5, foreach=True)
+lr_cfg = LRConfig(lr_type="cosine", warmup_ratio=0.05)
+
+# ---------------------------------------------------------------------------
+# Trainer
+# ---------------------------------------------------------------------------
+trainer = TrainerConfig(
+    model_cfg=model_cfg,
+    optim_cfg=optim_cfg,
+    dataloader_cfg=dataloader_config,
+    lr_cfg=lr_cfg,
+    loss_cfg=CELossConfig(mode="chunk", chunk_size=1024),
+    global_batch_size=32,
+    total_step=total_step,
+    checkpoint_interval=checkpoint_interval,
+    async_checkpoint=async_checkpoint,
+    work_dir=work_dir,
+    hf_interval=0,
+)

--- a/examples/v1/config/sft_qwen3_8b_async_verify.py
+++ b/examples/v1/config/sft_qwen3_8b_async_verify.py
@@ -1,0 +1,128 @@
+"""Verification config for async checkpoint with ~8B parameter model.
+
+Uses Qwen3-8B architecture (36 layers, hidden=4096) to produce ~87 GB
+checkpoint (model + optimizer), large enough to demonstrate async benefit.
+
+Requires >= 128 GB host memory per rank for CPU staging.
+
+Environment variables:
+  ASYNC_CKPT   - "1" (default) for async, "0" for sync
+  CKPT_INTERVAL - checkpoint interval in steps (default: 10)
+  TOTAL_STEP    - total training steps (default: 100)
+  WORK_DIR      - override work directory path (optional)
+
+Usage:
+  # ---- Experiment 1: High-frequency checkpoint, local SSD ----
+  # Async
+  torchrun --nproc_per_node=8 xtuner/v1/train/cli/sft.py \
+    --config examples/v1/config/sft_qwen3_8b_async_verify.py \
+    2>&1 | tee logs/sft_async_highfreq_qwen3_8b_$(date +%Y%m%d_%H%M%S).log
+
+  # Sync baseline
+  ASYNC_CKPT=0 torchrun --nproc_per_node=8 xtuner/v1/train/cli/sft.py \
+    --config examples/v1/config/sft_qwen3_8b_async_verify.py \
+    2>&1 | tee logs/sft_sync_highfreq_qwen3_8b_$(date +%Y%m%d_%H%M%S).log
+
+  # ---- Experiment 2: Slow storage (NFS/HDFS mount) ----
+  # Point WORK_DIR to a network mount to amplify I/O gap
+  WORK_DIR=/mnt/nfs/ckpt_bench torchrun --nproc_per_node=8 \
+    xtuner/v1/train/cli/sft.py \
+    --config examples/v1/config/sft_qwen3_8b_async_verify.py \
+    2>&1 | tee logs/sft_async_nfs_qwen3_8b_$(date +%Y%m%d_%H%M%S).log
+
+  ASYNC_CKPT=0 WORK_DIR=/mnt/nfs/ckpt_bench torchrun --nproc_per_node=8 \
+    xtuner/v1/train/cli/sft.py \
+    --config examples/v1/config/sft_qwen3_8b_async_verify.py \
+    2>&1 | tee logs/sft_sync_nfs_qwen3_8b_$(date +%Y%m%d_%H%M%S).log
+
+Analysis:
+  Compare logs by grepping for these key timing markers:
+    [Checkpoint Breakdown]      - per-checkpoint blocking time breakdown
+    [Checkpoint Total Blocking] - total wall-clock blocking per save
+    [Async Checkpoint] Staging  - GPU->CPU staging wait (async only)
+    [Async Checkpoint] Upload   - disk I/O wait (async only)
+    [DCP Collect Model/Optimizer State Dict] - state_dict collection time
+    [DCP save/async_save]       - actual save/async_save API time
+    Training finished in        - total training wall-clock
+
+Verification checklist:
+  - [ ] Async run exits cleanly (no hang after last step)
+  - [ ] Checkpoint files are complete: ls <work_dir>/checkpoints/ckpt-step-*/
+  - [ ] Loss/grad_norm matches between async and sync runs (diff < 1e-4)
+  - [ ] Compare total [Checkpoint Total Blocking] sums between runs
+  - [ ] Check if [Async Checkpoint] Staging shows non-zero waits
+        (means checkpoint_interval is tight enough to stress the pipeline)
+"""
+
+import os
+
+from xtuner.v1.config import AdamWConfig, LRConfig
+from xtuner.v1.datasets.config import DataloaderConfig, DatasetConfig
+from xtuner.v1.datasets.pt_tokenize_fn import PretrainTokenizeFunctionConfig
+from xtuner.v1.loss import CELossConfig
+from xtuner.v1.model import Qwen3Dense8BConfig
+from xtuner.v1.train import TrainerConfig
+
+# Toggle via environment variable for easy A/B comparison
+async_checkpoint = os.environ.get("ASYNC_CKPT", "1") != "0"
+
+# Configurable checkpoint frequency and total steps for different experiments:
+#   - checkpoint_interval=10 with step_time~2s means ~20s between saves.
+#     Since each save takes ~11s (async) or ~14s (sync), the pipeline is
+#     stressed enough that wait_prev > 0 will appear in async mode,
+#     revealing the true overlap benefit.
+#   - total_step=100 gives 10 checkpoint events, enough to average out
+#     cold-start effects while keeping wall-clock under 10 minutes.
+checkpoint_interval = int(os.environ.get("CKPT_INTERVAL", "10"))
+total_step = int(os.environ.get("TOTAL_STEP", "100"))
+
+# Optional: override work_dir to test on slow storage (NFS/HDFS)
+work_dir = os.environ.get("WORK_DIR", None)
+
+# 36 layers with full hidden dimensions (~8.7B params)
+model_cfg = Qwen3Dense8BConfig(
+    num_hidden_layers=36,
+    hidden_size=4096,
+    intermediate_size=14336,
+    vocab_size=151936,
+)
+
+# Reuse existing test data
+sample_max_length = 4096
+pack_max_length = 4096
+
+dataset_config = [
+    {
+        "dataset": DatasetConfig(
+            name="pretrain_text",
+            anno_path="tests/resource/pretrain_example_data.jsonl",
+            sample_ratio=1.0,
+        ),
+        "tokenize_fn": PretrainTokenizeFunctionConfig(
+            add_bos_token=False,
+            add_eos_token=True,
+        ),
+    },
+]
+
+dataloader_config = DataloaderConfig(
+    dataset_config_list=dataset_config,
+    pack_max_length=pack_max_length,
+)
+
+optim_cfg = AdamWConfig(lr=2e-5, foreach=True)
+lr_cfg = LRConfig(lr_type="cosine", warmup_ratio=0.05)
+
+trainer = TrainerConfig(
+    model_cfg=model_cfg,
+    optim_cfg=optim_cfg,
+    dataloader_cfg=dataloader_config,
+    lr_cfg=lr_cfg,
+    loss_cfg=CELossConfig(mode="chunk", chunk_size=1024),
+    global_batch_size=32,
+    total_step=total_step,
+    checkpoint_interval=checkpoint_interval,
+    async_checkpoint=async_checkpoint,
+    work_dir=work_dir,
+    hf_interval=0,
+)

--- a/examples/v1/scripts/bench_async_checkpoint.sh
+++ b/examples/v1/scripts/bench_async_checkpoint.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Async checkpoint A/B benchmark script.
+#
+# Runs async then sync checkpoint saves for a given model config,
+# removes checkpoints after the async run, then runs sync,
+# and removes checkpoints again after the sync run.
+#
+# Usage:
+#   bash examples/v1/scripts/bench_async_checkpoint.sh 8b
+#   bash examples/v1/scripts/bench_async_checkpoint.sh 30b
+#
+# Env:
+#   CKPT_INTERVAL - checkpoint interval in steps (default: 20)
+#   TOTAL_STEP    - total training steps (default: 100)
+#   WORK_DIR      - override checkpoint save path
+#   NPROC         - number of GPUs (default: 8)
+
+set -euo pipefail
+
+MODEL="${1:?Usage: $0 <8b|30b>}"
+NPROC="${NPROC:-8}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_DIR="logs"
+
+export CKPT_INTERVAL="${CKPT_INTERVAL:-20}"
+export TOTAL_STEP="${TOTAL_STEP:-100}"
+
+mkdir -p "$LOG_DIR"
+
+case "$MODEL" in
+    8b)  CONFIG="examples/v1/config/sft_qwen3_8b_async_verify.py" ;;
+    30b) CONFIG="examples/v1/config/sft_qwen3_30b_async_verify.py" ;;
+    *)   echo "Unknown model: $MODEL (use 8b or 30b)"; exit 1 ;;
+esac
+
+WORK_DIR="${WORK_DIR:-$(pwd)}"
+export WORK_DIR
+CKPT_DIR="${WORK_DIR}/checkpoints"
+
+SYNC_LOG="$LOG_DIR/xtuner_sync_${MODEL}_${TIMESTAMP}_interval_${CKPT_INTERVAL}.log"
+ASYNC_LOG="$LOG_DIR/xtuner_async_${MODEL}_${TIMESTAMP}_interval_${CKPT_INTERVAL}.log"
+
+cleanup_checkpoints() {
+    local tag="$1"
+
+    echo "--------------------------------------------"
+    echo " Cleaning checkpoints after ${tag} run"
+    echo "--------------------------------------------"
+
+    if [ -d "$CKPT_DIR" ]; then
+        du -sh "$CKPT_DIR" 2>/dev/null || true
+        rm -rf "$CKPT_DIR"
+        echo "Removed checkpoint dir: $CKPT_DIR"
+    else
+        echo "No checkpoint dir found: $CKPT_DIR"
+    fi
+
+    if [ -f "${WORK_DIR}/meta.json" ]; then
+        rm -f "${WORK_DIR}/meta.json"
+        echo "Removed meta file: ${WORK_DIR}/meta.json"
+    fi
+
+    echo ""
+}
+
+echo "============================================"
+echo " Async Checkpoint Benchmark — ${MODEL^^}"
+echo "============================================"
+echo "Config:         $CONFIG"
+echo "GPUs:           $NPROC"
+echo "Total steps:    $TOTAL_STEP"
+echo "Save interval:  $CKPT_INTERVAL"
+echo "Work dir:       $WORK_DIR"
+echo "Checkpoint dir: $CKPT_DIR"
+echo "Sync log:       $SYNC_LOG"
+echo "Async log:      $ASYNC_LOG"
+echo ""
+
+# ---- Run 1/2: Async ----
+echo "============================================"
+echo " [1/2] Running ASYNC mode..."
+echo "============================================"
+env ASYNC_CKPT=1 \
+    torchrun --nproc_per_node="$NPROC" xtuner/v1/train/cli/sft.py \
+    --config "$CONFIG" \
+    2>&1 | tee "$ASYNC_LOG"
+echo ""
+
+# ---- Delete async checkpoints before sync run ----
+cleanup_checkpoints "ASYNC"
+
+# ---- Run 2/2: Sync ----
+echo "============================================"
+echo " [2/2] Running SYNC mode..."
+echo "============================================"
+env ASYNC_CKPT=0 \
+    torchrun --nproc_per_node="$NPROC" xtuner/v1/train/cli/sft.py \
+    --config "$CONFIG" \
+    2>&1 | tee "$SYNC_LOG"
+echo ""
+
+# ---- Delete sync checkpoints after sync run ----
+cleanup_checkpoints "SYNC"
+
+# ---- Extract & compare ----
+echo "============================================"
+echo " Results Summary"
+echo "============================================"
+echo ""
+
+echo "--- Total Training Time ---"
+echo "Sync:  $(grep 'Training finished in' "$SYNC_LOG" | head -1 || echo '(not found)')"
+echo "Async: $(grep 'Training finished in' "$ASYNC_LOG" | head -1 || echo '(not found)')"
+echo ""
+
+echo "--- Checkpoint Breakdown ---"
+echo "[Sync]"
+grep -E '\[Checkpoint Breakdown\]' "$SYNC_LOG" | head -20 || echo "  (not found)"
+echo ""
+echo "[Async]"
+grep -E '\[Checkpoint Breakdown\]' "$ASYNC_LOG" | head -20 || echo "  (not found)"
+echo ""
+
+echo "--- Async Staging/Upload Waits ---"
+grep -E '\[Async Checkpoint\]' "$ASYNC_LOG" | head -20 || echo "  (not found)"
+echo ""
+
+echo "--- Final Loss & Grad Norm ---"
+echo "Sync:  $(grep -E 'loss=|reduced_llm_loss:|grad_norm:' "$SYNC_LOG" | tail -1 || echo '(not found)')"
+echo "Async: $(grep -E 'loss=|reduced_llm_loss:|grad_norm:' "$ASYNC_LOG" | tail -1 || echo '(not found)')"
+echo ""
+
+echo "--- GPU Memory ---"
+echo "Sync:  $(grep -E 'max_memory' "$SYNC_LOG" | tail -1 || echo '(not found)')"
+echo "Async: $(grep -E 'max_memory' "$ASYNC_LOG" | tail -1 || echo '(not found)')"
+echo ""
+
+echo "Logs saved to:"
+echo "  $SYNC_LOG"
+echo "  $ASYNC_LOG"

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from concurrent.futures import Future
 from pathlib import Path
 from unittest.mock import patch, Mock
 import pickle
@@ -30,6 +31,7 @@ from xtuner.v1.loss import CELossConfig
 from xtuner._testing import DeterministicDDPTestCase
 from unittest import TestCase
 from xtuner.v1.train.trainer import XTunerMeta, ExpInfo, ExpHistory, GitInfo
+from xtuner.v1.engine.train_engine import AsyncCheckpointFutures
 from xtuner.v1.utils.device import get_device
 from xtuner.v1.datasets.dataloader import Dataloader
 from torch.optim.lr_scheduler import SequentialLR
@@ -78,12 +80,27 @@ class FakeEngine:
         return torch.tensor(1.0)
 
     load_dcp = Mock()
+    load_dcp_merged = Mock()
 
     def save_dcp(self, model_dir: Path, optimizer_dir: Path | None):
         model_dir.mkdir(parents=True, exist_ok=True)
         if optimizer_dir is not None:
             optimizer_dir.mkdir(parents=True, exist_ok=True)
 
+    def async_save_dcp(self, model_dir: Path, optimizer_dir: Path | None) -> AsyncCheckpointFutures:
+        self.save_dcp(model_dir, optimizer_dir)
+        f: Future = Future()
+        f.set_result(None)
+        return AsyncCheckpointFutures(staging=[f], upload=[f])
+
+    def async_save_dcp_merged(self, weights_dir: Path) -> AsyncCheckpointFutures:
+        weights_dir.mkdir(parents=True, exist_ok=True)
+        f: Future = Future()
+        f.set_result(None)
+        return AsyncCheckpointFutures(staging=[f], upload=[f])
+
+    def destroy_async_checkpoint_pg(self) -> None:
+        pass
 
 def prepare(fn):
     def wrapper(self, *args, **kwargs):
@@ -255,6 +272,58 @@ class TestTrainerSaveHF(DistributedTestBase):
         for checkpoint, step in zip(trainer.meta.latest_exp.checkpoint_list, [3, 6, 9, 10]):
             assert f"step-{step}" in str(checkpoint)
             assert os.path.exists(checkpoint)
+
+    @patch("xtuner.v1.train.trainer.is_hf_model_path", Mock(return_value=True))
+    @patch("xtuner.v1.train.trainer.Trainer.build_engine", Mock(side_effect=lambda *args, **kwargs: FakeEngine()))
+    @prepare
+    def test_async_save_checkpoint_interval(self):
+        self.create_pg(DEVICE)
+        work_dir_list = [self.work_dir]
+        dist.broadcast_object_list(work_dir_list, src=0)
+        self.work_dir = Path(work_dir_list[0])
+        model_cfg = Qwen3MoE30BA3Config()
+        optim_cfg = AdamWConfig(lr=1e-4, weight_decay=0.01)
+        fsdp_cfg = FSDPConfig(tp_size=1)
+        dataset_cfg = [
+            {
+                "dataset": DatasetConfig(name="alpaca", anno_path=self.alpaca_path, sample_ratio=1.0),
+                "tokenize_fn": FTDPTokenizeFnConfig(),
+            },
+        ]
+        dataloader_cfg = DataloaderConfig()
+        lr_cfg = LRConfig(lr_type="constant", warmup_ratio=0.1, lr_min=1e-6)
+
+        trainer = Trainer(
+            load_from=str(self.fake_hf_model_dir),
+            model_cfg=model_cfg,
+            optim_cfg=optim_cfg,
+            fsdp_cfg=fsdp_cfg,
+            dataset_cfg=dataset_cfg,
+            dataloader_cfg=dataloader_cfg,
+            lr_cfg=lr_cfg,
+            tokenizer_path=self.tokenizer_path,
+            global_batch_size=2,
+            total_step=10,
+            work_dir=str(self.work_dir),
+            hf_interval=3,
+            hf_max_keep=2,
+            seed=42,
+            debug=False,
+            checkpoint_interval=5,
+            async_checkpoint=True,
+        )
+
+        trainer.fit()
+        dist.barrier()
+        assert len(trainer.meta.latest_exp.checkpoint_list) == 2
+        for checkpoint, step in zip(trainer.meta.latest_exp.checkpoint_list, [5, 10]):
+            assert f"step-{step}" in str(checkpoint)
+            assert os.path.exists(checkpoint)
+            # Verify new merged format: 'weights/' dir exists, not 'model/' + 'optimizer/'
+            weights_dir = Path(checkpoint) / "weights"
+            model_dir = Path(checkpoint) / "model"
+            assert weights_dir.exists(), f"Expected merged weights dir at {weights_dir}"
+            assert not model_dir.exists(), f"Legacy model dir should not exist at {model_dir}"
 
     @patch("xtuner.v1.train.trainer.is_hf_model_path", Mock(return_value=True))
     @patch("xtuner.v1.train.trainer.Trainer.build_engine", Mock(side_effect=lambda *args, **kwargs: FakeEngine()))

--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import os
 import threading
-from concurrent.futures import wait
+from concurrent.futures import Future, wait
 from pathlib import Path
 from typing import Any, Dict, List, cast
 
@@ -9,6 +11,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
 from safetensors import safe_open
+from torch.distributed.checkpoint.filesystem import FileSystemWriter
 from torch.distributed.checkpoint.state_dict import (
     StateDictOptions,
     get_model_state_dict,
@@ -16,6 +19,21 @@ from torch.distributed.checkpoint.state_dict import (
     set_model_state_dict,
     set_optimizer_state_dict,
 )
+from typing_extensions import TypedDict
+
+
+try:
+    from torch.distributed.checkpoint.state_dict_saver import AsyncSaveResponse
+except ImportError:
+    AsyncSaveResponse = None
+
+try:
+    from torch.distributed.checkpoint.staging import AsyncStager, BlockingAsyncStager
+except ImportError:
+    AsyncStager = None  # type: ignore[assignment,misc]
+    BlockingAsyncStager = None  # type: ignore[assignment,misc]
+
+
 from torch.nn.utils.clip_grad import _no_grad
 from torch.utils._foreach_utils import (
     _device_has_foreach_support,
@@ -34,6 +52,52 @@ from xtuner.v1.model.base import (
 from xtuner.v1.profiler.prober import ProberList
 from xtuner.v1.utils import get_device, get_logger, get_torch_device_module, profile_time_and_memory
 from xtuner.v1.utils.grad_norm import cal_grad_norm
+
+
+if BlockingAsyncStager is not None:
+
+    class _CachingStagingWriter(FileSystemWriter):
+        """FileSystemWriter that delegates staging to a shared BlockingAsyncStager.
+
+        PyTorch 2.8's ``dcp.async_save()`` activates pinned-memory staging only
+        when ``storage_writer`` implements the ``AsyncStager`` protocol.  This
+        thin wrapper inherits ``FileSystemWriter`` (for disk I/O) and registers
+        as a virtual subclass of ``AsyncStager`` so the ``isinstance`` check
+        inside ``async_save`` passes, while the actual staging logic is
+        delegated to an externally-owned ``BlockingAsyncStager`` whose pinned
+        buffers are reused across checkpoint calls.
+
+        Args:
+            path (str): Directory for checkpoint files.
+            stager (BlockingAsyncStager): Shared stager that owns the pinned buffer cache.
+        """
+
+        _synchronize_after_execute: bool = False
+
+        def __init__(self, path: str, stager: BlockingAsyncStager) -> None:
+            super().__init__(path)
+            self._stager = stager
+
+        def stage(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+            return self._stager.stage(state_dict)
+
+        def synchronize_staging(self) -> None:
+            self._stager.synchronize_staging()
+
+    # Register as virtual subclass so isinstance(writer, AsyncStager) is True.
+    AsyncStager.register(_CachingStagingWriter)  # type: ignore[union-attr]
+
+
+class AsyncCheckpointFutures(TypedDict):
+    """Futures returned by async_save_dcp for two-phase checkpoint tracking.
+
+    Args:
+        staging (list[Future]): Futures that complete when GPU->pinned CPU staging finishes (GPU memory released).
+        upload (list[Future]): Futures that complete when background disk I/O finishes.
+    """
+
+    staging: list[Future]
+    upload: list[Future]
 
 
 class TrainStepInfo(DataBatchInfo, BatchForwardInfo):
@@ -133,6 +197,7 @@ class TrainEngine:
         optim_cfg: OptimConfig,
         fsdp_cfg: FSDPConfig,
         intra_layer_micro_batch: int = 1,
+        async_checkpoint: bool = False,
     ) -> None:
         self.model_cfg = model_cfg
         self.optim_cfg = optim_cfg
@@ -142,6 +207,12 @@ class TrainEngine:
         self.intra_layer_micro_batch = intra_layer_micro_batch
         self._count = 0
         self.has_freeze_params = self.__has_freeze_params()
+        self._async_checkpoint_pg: dist.ProcessGroup | None = None
+        self._stager: BlockingAsyncStager | None = None
+        if async_checkpoint:
+            self._async_checkpoint_pg = dist.new_group(backend="gloo")
+            if BlockingAsyncStager is not None:
+                self._stager = BlockingAsyncStager(cache_staged_state_dict=True)
 
     def __has_freeze_params(self) -> bool:
         has_freeze_params = False
@@ -293,7 +364,6 @@ class TrainEngine:
         """
         self.model.save_hf(hf_dir=hf_dir, save_dtype=save_dtype)
 
-    # TODO: Support async save
     def save_dcp(
         self,
         model_dir: Path,
@@ -307,20 +377,293 @@ class TrainEngine:
                 optimizer_dir.mkdir(parents=True, exist_ok=True)
 
         _options = StateDictOptions(cpu_offload=True, ignore_frozen_params=self.model_cfg.dcp_ignore_frozen_params)
-        with profile_time_and_memory(f"[DCP Checkpoint to {model_dir}]"):
+
+        with profile_time_and_memory(f"[DCP Collect Model State Dict for {model_dir}]"):
             model_state = get_model_state_dict(self.model, options=_options)
+
+        with profile_time_and_memory(f"[DCP save(model) for {model_dir}]"):
             dcp.save(
                 model_state,
                 checkpoint_id=model_dir,
             )
 
-        with profile_time_and_memory(f"[DCP Checkpoint to {optimizer_dir}]"):
-            if optimizer_dir is not None:
+        if optimizer_dir is not None:
+            with profile_time_and_memory(f"[DCP Collect Optimizer State Dict for {optimizer_dir}]"):
                 shard_optimizer_state_dict = get_optimizer_state_dict(self.model, self.optimizer, options=_options)
+
+            with profile_time_and_memory(f"[DCP save(optimizer) for {optimizer_dir}]"):
                 dcp.save(
                     shard_optimizer_state_dict,
                     checkpoint_id=optimizer_dir,
                 )
+
+    # def benchmark_cpu_offload(self) -> None:
+    #     """Benchmark get_model/optimizer_state_dict with cpu_offload=True vs False.
+
+    #     Measures the FSDP state dict collection overhead with and without D2H copy
+    #     to determine whether building a custom async pipeline (bypassing PyTorch DCP)
+    #     is worthwhile.  Results are logged at INFO level on all ranks.
+
+    #     This method does NOT save to disk — it only collects state dicts and discards
+    #     them immediately.  Safe to call at any point during training.
+    #     """
+    #     import gc
+    #     import time
+
+    #     logger = get_logger()
+    #     rank = dist.get_rank()
+    #     ignore_frozen = self.model_cfg.dcp_ignore_frozen_params
+
+    #     # Warmup: ensure CUDA caches are populated
+    #     torch.cuda.synchronize()
+    #     dist.barrier()
+
+    #     results: dict[str, dict[str, float]] = {}
+
+    #     for offload_label, cpu_offload in [("cpu_offload=True", True), ("cpu_offload=False", False)]:
+    #         opts = StateDictOptions(cpu_offload=cpu_offload, ignore_frozen_params=ignore_frozen)
+
+    #         # --- model state dict ---
+    #         torch.cuda.synchronize()
+    #         dist.barrier()
+    #         t0 = time.perf_counter()
+    #         model_sd = get_model_state_dict(self.model, options=opts)
+    #         torch.cuda.synchronize()
+    #         t_model = time.perf_counter() - t0
+
+    #         # Check tensor device
+    #         sample_device = "N/A"
+    #         for v in model_sd.values():
+    #             if isinstance(v, torch.Tensor):
+    #                 sample_device = str(v.device)
+    #                 break
+
+    #         del model_sd
+    #         gc.collect()
+    #         if not cpu_offload:
+    #             torch.cuda.empty_cache()
+
+    #         # --- optimizer state dict ---
+    #         torch.cuda.synchronize()
+    #         dist.barrier()
+    #         t0 = time.perf_counter()
+    #         optim_sd = get_optimizer_state_dict(self.model, self.optimizer, options=opts)
+    #         torch.cuda.synchronize()
+    #         t_optim = time.perf_counter() - t0
+
+    #         del optim_sd
+    #         gc.collect()
+    #         if not cpu_offload:
+    #             torch.cuda.empty_cache()
+
+    #         results[offload_label] = {
+    #             "model": t_model,
+    #             "optimizer": t_optim,
+    #             "total": t_model + t_optim,
+    #             "sample_device": sample_device,
+    #         }
+
+    #         logger.info(
+    #             f"[Benchmark cpu_offload] RANK {rank} | {offload_label}: "
+    #             f"model={t_model:.3f}s, optimizer={t_optim:.3f}s, "
+    #             f"total={t_model + t_optim:.3f}s, tensor_device={sample_device}"
+    #         )
+
+    #     # Summary comparison
+    #     t_true = results["cpu_offload=True"]["total"]
+    #     t_false = results["cpu_offload=False"]["total"]
+    #     diff = t_true - t_false
+    #     logger.info(
+    #         f"[Benchmark cpu_offload] RANK {rank} | SUMMARY: "
+    #         f"cpu_offload=True total={t_true:.3f}s, "
+    #         f"cpu_offload=False total={t_false:.3f}s, "
+    #         f"D2H overhead estimate={diff:.3f}s ({diff / t_true * 100:.1f}% of True)"
+    #     )
+
+    #     dist.barrier()
+
+    def async_save_dcp_merged(
+        self,
+        weights_dir: Path,
+    ) -> AsyncCheckpointFutures:
+        """Asynchronously save model and optimizer in a single DCP call (Megatron-style).
+
+        Uses ``cpu_offload=False`` so that ``get_model/optimizer_state_dict``
+        only collects GPU tensor references (~0.04s each) instead of doing
+        synchronous GPU-to-CPU copies (~7.7s total).  The single
+        ``dcp.async_save()`` call stages all tensors from GPU to pinned CPU
+        via ``BlockingAsyncStager`` in one pass, then writes to disk
+        asynchronously in the background.
+
+        Compared to the legacy ``async_save_dcp``, this eliminates:
+        - D2H copy inside state_dict collection (7.7s → 0.08s)
+        - The redundant CPU → pinned-CPU staging copy (~1.0s saved)
+        - Two-call serialisation overhead (~0.5s saved)
+
+        Args:
+            weights_dir (Path): Directory to save the merged checkpoint.
+
+        Returns:
+            AsyncCheckpointFutures: Staging and upload futures.
+        """
+        if not hasattr(dcp, "async_save"):
+            raise RuntimeError(
+                "dcp.async_save is not available in this PyTorch version. "
+                "Please upgrade PyTorch or set async_checkpoint=False."
+            )
+
+        rank = dist.get_rank()
+        if rank == 0:
+            weights_dir.mkdir(parents=True, exist_ok=True)
+
+        # cpu_offload=False: collect GPU tensor references only, no D2H copy.
+        # D2H will happen once during BlockingAsyncStager.stage() (GPU → pinned CPU).
+        _options = StateDictOptions(
+            cpu_offload=False,
+            ignore_frozen_params=self.model_cfg.dcp_ignore_frozen_params,
+        )
+
+        with profile_time_and_memory(f"[DCP Collect Model State Dict (no offload) for {weights_dir}]"):
+            model_state = get_model_state_dict(self.model, options=_options)
+
+        with profile_time_and_memory(f"[DCP Collect Optimizer State Dict (no offload) for {weights_dir}]"):
+            optim_state = get_optimizer_state_dict(self.model, self.optimizer, options=_options)
+
+        # Merge into single state dict for one DCP call (eliminates gloo PG deadlock
+        # risk and two-call serialisation overhead).
+        merged: dict[str, Any] = {"model": model_state, "optimizer": optim_state}
+
+        with profile_time_and_memory(f"[DCP async_save(merged) for {weights_dir}]"):
+            async_save_kwargs: dict[str, Any] = {
+                "checkpoint_id": weights_dir,
+                "process_group": self._async_checkpoint_pg,
+            }
+            if self._stager is not None:
+                async_save_kwargs["storage_writer"] = _CachingStagingWriter(
+                    str(weights_dir), self._stager
+                )
+            result = dcp.async_save(merged, **async_save_kwargs)
+
+        staging_futures: list[Future] = []
+        upload_futures: list[Future] = []
+        if AsyncSaveResponse is not None and isinstance(result, AsyncSaveResponse):
+            staging_futures.append(result.staging_completion)
+            upload_futures.append(result.upload_completion)
+        else:
+            staging_futures.append(result)
+            upload_futures.append(result)
+
+        return AsyncCheckpointFutures(staging=staging_futures, upload=upload_futures)
+
+    # def async_save_dcp(
+    #     self,
+    #     model_dir: Path,
+    #     optimizer_dir: Path | None = None,
+    # ) -> AsyncCheckpointFutures:
+    #     """Asynchronously save model and optimizer via DCP (legacy, deprecated).
+
+    #     .. deprecated::
+    #         Use :meth:`async_save_dcp_merged` instead, which collects state
+    #         dicts with ``cpu_offload=False`` and saves in a single DCP call
+    #         for significantly lower blocking time.
+
+    #     Args:
+    #         model_dir (Path): Directory to save the model checkpoint.
+    #         optimizer_dir (Path | None): Directory to save the optimizer checkpoint.
+
+    #     Returns:
+    #         AsyncCheckpointFutures: Two groups of futures for staging and upload.
+    #     """
+    #     import warnings
+
+    #     warnings.warn(
+    #         "async_save_dcp() is deprecated. Use async_save_dcp_merged() instead "
+    #         "for ~5x lower blocking time.",
+    #         DeprecationWarning,
+    #         stacklevel=2,
+    #     )
+    #     if not hasattr(dcp, "async_save"):
+    #         raise RuntimeError(
+    #             "dcp.async_save is not available in this PyTorch version. "
+    #             "Please upgrade PyTorch or set async_checkpoint=False."
+    #         )
+
+    #     rank = dist.get_rank()
+
+    #     if rank == 0:
+    #         model_dir.mkdir(parents=True, exist_ok=True)
+    #         if optimizer_dir is not None:
+    #             optimizer_dir.mkdir(parents=True, exist_ok=True)
+
+    #     staging_futures: list[Future] = []
+    #     upload_futures: list[Future] = []
+
+    #     # Use cpu_offload=True so that get_*_state_dict copies tensors to CPU
+    #     # synchronously (no extra GPU memory).  dcp.async_save() then only
+    #     # needs to asynchronise the disk I/O, which benefits slow storage
+    #     # (NFS/S3) without risking OOM on large models.
+    #     _options = StateDictOptions(
+    #         cpu_offload=True,
+    #         ignore_frozen_params=self.model_cfg.dcp_ignore_frozen_params,
+    #     )
+
+    #     with profile_time_and_memory(f"[DCP Collect Model State Dict for {model_dir}]"):
+    #         model_state = get_model_state_dict(self.model, options=_options)
+
+    #     with profile_time_and_memory(f"[DCP async_save(model) for {model_dir}]"):
+    #         async_save_kwargs: dict[str, Any] = {
+    #             "checkpoint_id": model_dir,
+    #             "process_group": self._async_checkpoint_pg,
+    #         }
+    #         if self._stager is not None:
+    #             async_save_kwargs["storage_writer"] = _CachingStagingWriter(
+    #                 str(model_dir), self._stager
+    #             )
+    #         result = dcp.async_save(model_state, **async_save_kwargs)
+    #     if AsyncSaveResponse is not None and isinstance(result, AsyncSaveResponse):
+    #         staging_futures.append(result.staging_completion)
+    #         upload_futures.append(result.upload_completion)
+    #     else:
+    #         # Older PyTorch: single future covers both staging and upload
+    #         staging_futures.append(result)
+    #         upload_futures.append(result)
+
+    #     if optimizer_dir is not None:
+    #         # Wait for the model save thread to finish before starting the
+    #         # optimizer save.  Both background threads use the same gloo
+    #         # process group for collectives (reduce_scatter / all_reduce).
+    #         # Concurrent collectives on a single gloo PG from different
+    #         # threads cause message interleaving and deadlock.
+    #         staging_futures[-1].result()
+
+    #         with profile_time_and_memory(f"[DCP Collect Optimizer State Dict for {optimizer_dir}]"):
+    #             shard_optimizer_state_dict = get_optimizer_state_dict(self.model, self.optimizer, options=_options)
+
+    #         with profile_time_and_memory(f"[DCP async_save(optimizer) for {optimizer_dir}]"):
+    #             async_save_kwargs = {
+    #                 "checkpoint_id": optimizer_dir,
+    #                 "process_group": self._async_checkpoint_pg,
+    #             }
+    #             if self._stager is not None:
+    #                 async_save_kwargs["storage_writer"] = _CachingStagingWriter(
+    #                     str(optimizer_dir), self._stager
+    #                 )
+    #             result = dcp.async_save(shard_optimizer_state_dict, **async_save_kwargs)
+    #         if AsyncSaveResponse is not None and isinstance(result, AsyncSaveResponse):
+    #             staging_futures.append(result.staging_completion)
+    #             upload_futures.append(result.upload_completion)
+    #         else:
+    #             staging_futures.append(result)
+    #             upload_futures.append(result)
+
+    #     return AsyncCheckpointFutures(staging=staging_futures, upload=upload_futures)
+
+    def destroy_async_checkpoint_pg(self) -> None:
+        """Destroy the dedicated gloo process group used for async checkpoint."""
+        self._stager = None
+        if self._async_checkpoint_pg is not None:
+            dist.destroy_process_group(self._async_checkpoint_pg)
+            self._async_checkpoint_pg = None
 
     def load_dcp(
         self,
@@ -385,6 +728,59 @@ class TrainEngine:
                     optim_state_dict=shard_optimizer_state_dict,
                     options=_set_options,
                 )
+
+    def load_dcp_merged(
+        self,
+        weights_dir: Path,
+        load_states: bool = True,
+        load_args: bool = True,
+    ) -> None:
+        """Load a merged model+optimizer checkpoint saved by :meth:`async_save_dcp_merged`.
+
+        Args:
+            weights_dir (Path): Directory containing the merged checkpoint.
+            load_states (bool): Whether to load optimizer states (momentum, variance, etc.).
+            load_args (bool): Whether to load optimizer hyperparameters (lr, betas, etc.).
+        """
+        _load_options = StateDictOptions(
+            cpu_offload=True, ignore_frozen_params=self.model_cfg.dcp_ignore_frozen_params
+        )
+        if self.has_freeze_params:
+            _set_options = StateDictOptions(cpu_offload=True, strict=False)
+        else:
+            _set_options = StateDictOptions(cpu_offload=True, strict=True)
+
+        with profile_time_and_memory(f"[Load DCP Merged from {weights_dir}]"):
+            model_sd = get_model_state_dict(self.model, options=_load_options)
+            optim_sd = get_optimizer_state_dict(self.model, self.optimizer, options=_load_options)
+            merged: dict[str, Any] = {"model": model_sd, "optimizer": optim_sd}
+
+            dcp.load(state_dict=merged, checkpoint_id=weights_dir)
+
+            set_model_state_dict(self.model, merged["model"], options=_set_options)
+
+            shard_optimizer_state_dict = merged["optimizer"]
+            if not load_states:
+                logger.info("Not loading optimizer states")
+                shard_optimizer_state_dict["state"] = {}
+            if not load_args:
+                logger.info("Not loading arg defaults")
+                param_groups = self.optimizer.state_dict()["param_groups"]
+                assert len(param_groups) == 1, "Only one param_group is supported now"
+                init_defaults = param_groups[0]
+                init_defaults.pop("params")
+                for param_group in cast(List[Dict[str, Any]], shard_optimizer_state_dict["param_groups"]):
+                    default_keys = list(filter(lambda x: x != "params", param_group.keys()))
+                    for key in default_keys:
+                        param_group.pop(key)
+                    param_group.update(init_defaults)
+
+            set_optimizer_state_dict(
+                self.model,
+                self.optimizer,
+                optim_state_dict=shard_optimizer_state_dict,
+                options=_set_options,
+            )
 
     def put_model_to_device(self, device: torch.device | str):
         """Put the model to the given device."""

--- a/xtuner/v1/train/arguments/arguments.py
+++ b/xtuner/v1/train/arguments/arguments.py
@@ -105,6 +105,7 @@ class TrainingArguments(BaseModel):
     load_scheduler: Annotated[bool, Parameter(group=checkpoint_group, help="load scheduler state from checkpoint")] = (
         True
     )
+    async_checkpoint: Annotated[bool, Parameter(group=checkpoint_group, help="enable async checkpoint saving")] = False
     fsdp_config: Annotated[FSDPConfig | None, Parameter(group=parallel_group, help="FSDP configuration")] = None
     float8_config: Annotated[Float8Config | None, Parameter(group=parallel_group, help="use float8 training")] = None
 
@@ -165,6 +166,7 @@ class TrainingArguments(BaseModel):
             total_epoch=self.epoch_num,
             resume_cfg=resume_cfg,
             work_dir=self.work_dir,
+            async_checkpoint=self.async_checkpoint,
         )
 
     def _get_dataset_config(self) -> DatasetConfigList:

--- a/xtuner/v1/train/trainer.py
+++ b/xtuner/v1/train/trainer.py
@@ -6,6 +6,7 @@ import os
 import pickle
 import sys
 import time
+from concurrent.futures import Future, wait
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -95,6 +96,18 @@ class PerformanceStatistics(TypedDict):
     eta_seconds: float
     eta_hms: str
     e2e_train_time: float
+
+
+class _CheckpointFinalize(TypedDict):
+    checkpoint_path: Path
+    meta_path: Path
+    train_state_path: Path
+    is_snapshot: bool
+    cur_step: int
+    cur_epoch: int
+    total_consumed_samples: int
+    total_consumed_tokens: int
+    train_time_offset: float
 
 
 class ExpInfo(BaseModel):
@@ -337,6 +350,7 @@ class TrainerConfig(BaseModel):
     checkpoint_interval: int | None = -1
     checkpoint_maxkeep: int | None = -1
     skip_checkpoint_validation: bool = False  # Suggest enabled if fsdp_size is larger than 512
+    async_checkpoint: bool = False
     snapshot_interval: int | None = None
     check_health_interval: int | None = None
     hf_interval: int | None = None
@@ -429,6 +443,7 @@ class Trainer:
 
     _SAVE_OPTIMIZER_DIR = "optimizer"
     _SAVE_MODEL_DIR = "model"
+    _SAVE_WEIGHTS_DIR = "weights"
     _SAVE_DATALOADER_DIR = "dataloader"
     _SAVE_SCHEDULER_DIR = "lr_scheduler"
     _SAVE_TRAIN_STATE_PATH = "train_state.json"
@@ -459,6 +474,7 @@ class Trainer:
         checkpoint_interval: int | None = -1,
         checkpoint_maxkeep: int | None = -1,
         skip_checkpoint_validation: bool = False,  # Suggest enabled if fsdp_size is larger than 512
+        async_checkpoint: bool = False,
         snapshot_interval: int | None = None,
         check_health_interval: int | None = None,
         hf_interval: int | None = None,
@@ -516,10 +532,21 @@ class Trainer:
 
         self._checkpoint_interval = checkpoint_interval
         self._checkpoint_maxkeep = checkpoint_maxkeep
+        self._async_checkpoint = async_checkpoint
+        self._benchmark_cpu_offload_done = False
+        self._pending_staging_futures: list[Future] | None = None
+        self._pending_upload_futures: list[Future] | None = None
+        self._pending_checkpoint_finalize: _CheckpointFinalize | None = None
         self._snapshot_interval = snapshot_interval
         self._check_health_interval = check_health_interval
         self._hf_max_keep = hf_max_keep
         self._hf_interval = hf_interval
+        if self._hf_interval is not None and self._hf_interval <= 0:
+            logger.warning(
+                f"Found non-positive hf_interval={self._hf_interval}. "
+                "Disabling HuggingFace-format checkpoint saving."
+            )
+            self._hf_interval = None
 
         if fsdp_cfg is None:
             fsdp_cfg = FSDPConfig()
@@ -614,6 +641,7 @@ class Trainer:
             load_checkpoint_path=self._load_checkpoint_cfg.checkpoint_path,
             strict=strict_load,
             intra_layer_micro_batch=intra_layer_micro_batch,
+            async_checkpoint=self._async_checkpoint,
         )
         self._lr_cfg = lr_cfg
         self._lr_scheduler = self.build_lr_scheduler(lr_cfg, self.total_step)
@@ -625,7 +653,10 @@ class Trainer:
         if debug:
             self._register_debug_hook()
 
-        if self._can_save_hf and self._hf_interval is None:
+        if self._hf_interval == 0:
+            # Explicitly disable HF saving
+            self._hf_interval = None
+        elif self._can_save_hf and self._hf_interval is None:
             self._hf_interval = self.total_step
 
         if debug_skip_save:
@@ -675,6 +706,7 @@ class Trainer:
             checkpoint_interval=config.checkpoint_interval,
             checkpoint_maxkeep=config.checkpoint_maxkeep,
             skip_checkpoint_validation=config.skip_checkpoint_validation,
+            async_checkpoint=config.async_checkpoint,
             snapshot_interval=config.snapshot_interval,
             check_health_interval=config.check_health_interval,
             hf_interval=config.hf_interval,
@@ -705,6 +737,15 @@ class Trainer:
         This method executes the main training loop, iterating through the dataset and performing training steps. It
         handles data loading, forward pass, backward pass, optimization, logging, and checkpointing.
         """
+        # # Run cpu_offload benchmark before training starts, when the model and
+        # # optimizer are fully initialized but no checkpoint has been saved yet.
+        # if not self._benchmark_cpu_offload_done:
+        #     self._benchmark_cpu_offload_done = True
+        #     try:
+        #         self._engine.benchmark_cpu_offload()
+        #     except Exception as e:
+        #         logger.warning(f"[Benchmark cpu_offload] failed: {e}")
+
         train_begin = time.time()
         time_before_get_data = time.time()
         for data_batch in self._data_iter():
@@ -768,9 +809,14 @@ class Trainer:
             self._lr_scheduler.step()
             self._maybe_check_health()
             self._maybe_save_hf()
+
+            time_before_checkpoint = time.time()
             ckpt_saved = self._maybe_save(is_snapshot=False)
             if not ckpt_saved:
                 _ = self._maybe_save(is_snapshot=True)
+            checkpoint_time = time.time() - time_before_checkpoint
+            if ckpt_saved:
+                self.logger.info(f"[Checkpoint Total Blocking] step {self.cur_step}: {checkpoint_time:.2f}s")
 
             time_before_get_data = time.time()
 
@@ -778,10 +824,13 @@ class Trainer:
                 gc.collect()
 
         # TODO: Should use flush rather than close
+        self._wait_for_pending_checkpoint()
+        self._engine.destroy_async_checkpoint_pg()
         self._exp_tracker.close()
         if self._metrics_recorder:
             self._metrics_recorder.close()
         self.logger.info(f"Training finished in {time.time() - train_begin:.2f} seconds")
+        dist.barrier()
 
     def _prepare_model_input(self, data_batch) -> list[ModelItem]:
         loss_cfg: CELossConfig = self.loss_cfg
@@ -812,7 +861,7 @@ class Trainer:
     def _reduce_number_across_rank(self, rank_number: int | float) -> int:
         _gathered_list = [None for _ in range(self.world_size)]
         dist.all_gather_object(_gathered_list, rank_number)
-        reduced_number = sum(_gathered_list)  # type: ignore[arg-type]
+        reduced_number = sum(_gathered_list)
         return reduced_number
 
     def _maybe_init_model_metrics_recorder(
@@ -992,6 +1041,7 @@ class Trainer:
         load_checkpoint_path: str | Path | None,
         intra_layer_micro_batch: int = 1,
         strict: bool = True,
+        async_checkpoint: bool = False,
     ):
         """Build the training engine for the transformer model.
 
@@ -1003,6 +1053,7 @@ class Trainer:
             resume_cfg (ResumeConfig | None): Resume configuration for continuing training.
             intra_layer_micro_batch (int): Intra-layer micro batch size for gradient accumulation.
             strict (bool): Whether to strictly load model weights.
+            async_checkpoint (bool): Whether to create a dedicated gloo process group for async checkpoint.
 
         Returns:
             TrainEngine: Initialized training engine.
@@ -1012,6 +1063,7 @@ class Trainer:
             fsdp_cfg=fsdp_config,
             model_cfg=model_config,
             intra_layer_micro_batch=intra_layer_micro_batch,
+            async_checkpoint=async_checkpoint,
         )
         if model_path is not None and (model_config.dcp_ignore_frozen_params or load_checkpoint_path is None):
             engine.from_hf(hf_path=model_path, strict=strict)
@@ -1079,69 +1131,102 @@ class Trainer:
                 raise RuntimeError("Health check failed, exit training")
             logger.info(f"Health check passed at step {self.cur_step}")
 
-    def _maybe_save(self, is_snapshot: bool = False) -> bool:
-        ckp_interval = self._checkpoint_interval if not is_snapshot else self._snapshot_interval
-        if ckp_interval is None:
-            return False
+    def _wait_for_pending_checkpoint(self, timeout: int = 300) -> None:
+        has_error = False
 
-        if ckp_interval == -1:  # only save at the end of training
-            if self._cur_step != self.total_step:
-                return False
-        else:
-            if self.cur_step % ckp_interval != 0 and (is_snapshot or self._cur_step != self.total_step):
-                # if is_snapshot, only save at interval
-                # else save at interval or at the end of training
-                return False
+        # Step 1: Wait for staging futures (GPU memory release)
+        if self._pending_staging_futures is not None:
+            t0 = time.time()
+            done, not_done = wait(self._pending_staging_futures, timeout=timeout)
+            wait_time = time.time() - t0
+            if wait_time > 0.01:
+                logger.info(f"[Async Checkpoint] Staging waited {wait_time:.2f}s for GPU->CPU copy")
+            else:
+                logger.info("[Async Checkpoint] Staging already finished (0 wait)")
+            if not_done:
+                has_error = True
+                logger.error(
+                    f"Async checkpoint staging timed out after {timeout}s: "
+                    f"{len(not_done)}/{len(self._pending_staging_futures)} futures still pending"
+                )
+                for f in not_done:
+                    f.cancel()
+            for f in done:
+                exc = f.exception()
+                if exc is not None:
+                    has_error = True
+                    logger.error(f"Async checkpoint staging future failed: {exc}")
+            self._pending_staging_futures = None
 
-        checkpoint_path = self._get_checkpoint_path(epoch=self._cur_epoch, step=self.cur_step, is_snapshot=is_snapshot)
-        checkpoint_path.mkdir(parents=True, exist_ok=True)
+        # Step 2: Wait for upload futures (disk I/O completion)
+        if self._pending_upload_futures is not None:
+            t0 = time.time()
+            done, not_done = wait(self._pending_upload_futures, timeout=timeout)
+            wait_time = time.time() - t0
+            if wait_time > 0.01:
+                logger.info(f"[Async Checkpoint] Upload waited {wait_time:.2f}s for background I/O")
+            else:
+                logger.info("[Async Checkpoint] Upload already finished (0 wait)")
+            if not_done:
+                has_error = True
+                logger.error(
+                    f"Async checkpoint upload timed out after {timeout}s: "
+                    f"{len(not_done)}/{len(self._pending_upload_futures)} futures still pending"
+                )
+                for f in not_done:
+                    f.cancel()
+            for f in done:
+                exc = f.exception()
+                if exc is not None:
+                    has_error = True
+                    logger.error(f"Async checkpoint upload future failed: {exc}")
+            self._pending_upload_futures = None
 
-        meta_path = self.work_dir / self._META_PATH
+        if self._pending_checkpoint_finalize is not None:
+            if has_error:
+                ckpt_path = self._pending_checkpoint_finalize["checkpoint_path"]
+                logger.error(
+                    f"Skipping checkpoint finalization for {ckpt_path} due to async save failure. "
+                    f"This checkpoint will NOT be registered in meta and cannot be used for resume."
+                )
+                self._pending_checkpoint_finalize = None
+                return
 
-        optimizer_path = checkpoint_path / self._SAVE_OPTIMIZER_DIR
-        model_path = checkpoint_path / self._SAVE_MODEL_DIR
-        dataloader_path = checkpoint_path / self._SAVE_DATALOADER_DIR
-        scheduler_path = checkpoint_path / self._SAVE_SCHEDULER_DIR
-        train_state_path = checkpoint_path / self._SAVE_TRAIN_STATE_PATH
+            t0 = time.time()
+            dist.barrier()
+            t_barrier = time.time() - t0
+            t0 = time.time()
+            self._finalize_checkpoint_metadata(**self._pending_checkpoint_finalize)
+            t_finalize = time.time() - t0
+            logger.info(
+                f"[Async Checkpoint Finalize] barrier={t_barrier:.2f}s, "
+                f"metadata={t_finalize:.2f}s"
+            )
+            self._pending_checkpoint_finalize = None
 
-        # Save model and optimizer
-        self._engine.save_dcp(
-            model_dir=model_path,
-            optimizer_dir=optimizer_path,
-        )
-
-        # Save dataloader
-        self._save_dataloader(dataloader_path)
-
-        # Save scheduler
-        if self.rank == 0:
-            lr_scheduler_state = self._lr_scheduler.state_dict()
-            torch.save(lr_scheduler_state, scheduler_path)
-
-        # Save trainer config
-        if self._trainer_cfg is not None and self.rank == 0:
-            # TODO: Maybe we need a better way to serialize and deserialize config, rather than using pickle
-            config_path = checkpoint_path / "trainer_config.json"
-            config_bin = checkpoint_path / "trainer_config.bin"
-            with config_path.open("w") as f:
-                f.write(self._trainer_cfg.model_dump_json(indent=2))
-
-            with config_bin.open("wb") as f:
-                pickle.dump(self._trainer_cfg, f)
-
-        dist.barrier()
-
+    def _finalize_checkpoint_metadata(
+        self,
+        checkpoint_path: Path,
+        meta_path: Path,
+        train_state_path: Path,
+        is_snapshot: bool,
+        cur_step: int,
+        cur_epoch: int,
+        total_consumed_samples: int,
+        total_consumed_tokens: int,
+        train_time_offset: float,
+    ) -> None:
         # Save train state
         if self.rank == 0:
             with train_state_path.open("w") as f:
                 f.write(
                     json.dumps(
                         {
-                            "cur_step": self.cur_step,
-                            "cur_epoch": self._cur_epoch,
-                            "total_consumed_samples": self._total_consumed_samples,
-                            "total_consumed_tokens": self._total_consumed_tokens,
-                            "train_time_offset": self._train_time + self._train_time_offset,
+                            "cur_step": cur_step,
+                            "cur_epoch": cur_epoch,
+                            "total_consumed_samples": total_consumed_samples,
+                            "total_consumed_tokens": total_consumed_tokens,
+                            "train_time_offset": train_time_offset,
                         }
                     )
                 )
@@ -1150,11 +1235,11 @@ class Trainer:
         current_exp = self.meta.latest_exp
         ckp_list = current_exp.checkpoint_list if not is_snapshot else current_exp.snap_checkpoint_list
         ckp_list.append(str(checkpoint_path))
-        current_exp.cur_step = self.cur_step
-        current_exp.cur_epoch = self._cur_epoch
-        current_exp.consumed_samples = int(self._total_consumed_samples)
-        current_exp.consumed_tokens = int(self._total_consumed_tokens)
-        current_exp.history[-1]["end"] = self.cur_step
+        current_exp.cur_step = cur_step
+        current_exp.cur_epoch = cur_epoch
+        current_exp.consumed_samples = int(total_consumed_samples)
+        current_exp.consumed_tokens = int(total_consumed_tokens)
+        current_exp.history[-1]["end"] = cur_step
 
         # Delete checkpoints and update meta's checkpoint_list
         ckp_maxkeep = self._checkpoint_maxkeep if not is_snapshot else 1
@@ -1180,11 +1265,120 @@ class Trainer:
         for hook in hooks:
             hook(
                 checkpoint=checkpoint_path,
-                step=self.cur_step,
-                epoch=self._cur_epoch,
+                step=cur_step,
+                epoch=cur_epoch,
                 total_step=self.total_step,
                 total_epoch=self.total_epoch,
             )
+
+    def _maybe_save(self, is_snapshot: bool = False) -> bool:
+        ckp_interval = self._checkpoint_interval if not is_snapshot else self._snapshot_interval
+        if ckp_interval is None:
+            return False
+
+        if ckp_interval == -1:  # only save at the end of training
+            if self._cur_step != self.total_step:
+                return False
+        else:
+            if self.cur_step % ckp_interval != 0 and (is_snapshot or self._cur_step != self.total_step):
+                # if is_snapshot, only save at interval
+                # else save at interval or at the end of training
+                return False
+
+        checkpoint_path = self._get_checkpoint_path(epoch=self._cur_epoch, step=self.cur_step, is_snapshot=is_snapshot)
+        checkpoint_path.mkdir(parents=True, exist_ok=True)
+
+        t_wait = time.time()
+        self._wait_for_pending_checkpoint()
+        t_wait = time.time() - t_wait
+
+        meta_path = self.work_dir / self._META_PATH
+
+        optimizer_path = checkpoint_path / self._SAVE_OPTIMIZER_DIR
+        model_path = checkpoint_path / self._SAVE_MODEL_DIR
+        dataloader_path = checkpoint_path / self._SAVE_DATALOADER_DIR
+        scheduler_path = checkpoint_path / self._SAVE_SCHEDULER_DIR
+        train_state_path = checkpoint_path / self._SAVE_TRAIN_STATE_PATH
+
+        # Save model and optimizer
+        async_dcp_label = "save_dcp"
+        if self._async_checkpoint and not is_snapshot:
+            t_dcp = time.time()
+            async_dcp_label = "async_save_dcp_merged"
+            weights_path = checkpoint_path / self._SAVE_WEIGHTS_DIR
+            async_futures = self._engine.async_save_dcp_merged(
+                weights_dir=weights_path,
+            )
+            t_dcp = time.time() - t_dcp
+            self._pending_staging_futures = async_futures["staging"]
+            self._pending_upload_futures = async_futures["upload"]
+            # Defer barrier and metadata save until async futures complete.
+            # Calling dist.barrier() while dcp.async_save background threads may still
+            # use NCCL communication can cause a deadlock.
+            self._pending_checkpoint_finalize = _CheckpointFinalize(
+                checkpoint_path=checkpoint_path,
+                meta_path=meta_path,
+                train_state_path=train_state_path,
+                is_snapshot=is_snapshot,
+                cur_step=self.cur_step,
+                cur_epoch=self._cur_epoch,
+                total_consumed_samples=self._total_consumed_samples,
+                total_consumed_tokens=self._total_consumed_tokens,
+                train_time_offset=self._train_time + self._train_time_offset,
+            )
+        else:
+            t_dcp = time.time()
+            self._engine.save_dcp(
+                model_dir=model_path,
+                optimizer_dir=optimizer_path,
+            )
+            t_dcp = time.time() - t_dcp
+
+        # Save dataloader
+        t_misc = time.time()
+        self._save_dataloader(dataloader_path)
+
+        # Save scheduler
+        if self.rank == 0:
+            lr_scheduler_state = self._lr_scheduler.state_dict()
+            torch.save(lr_scheduler_state, scheduler_path)
+
+        # Save trainer config
+        if self._trainer_cfg is not None and self.rank == 0:
+            # TODO: Maybe we need a better way to serialize and deserialize config, rather than using pickle
+            config_path = checkpoint_path / "trainer_config.json"
+            config_bin = checkpoint_path / "trainer_config.bin"
+            with config_path.open("w") as f:
+                f.write(self._trainer_cfg.model_dump_json(indent=2))
+
+            with config_bin.open("wb") as f:
+                pickle.dump(self._trainer_cfg, f)
+        t_misc = time.time() - t_misc
+
+        dcp_label = async_dcp_label if (self._async_checkpoint and not is_snapshot) else "save_dcp"
+        logger.info(
+            f"[Checkpoint Breakdown] step {self.cur_step}: "
+            f"wait_prev={t_wait:.2f}s, {dcp_label}={t_dcp:.2f}s, "
+            f"save_dataloader+scheduler+config={t_misc:.2f}s"
+        )
+
+        if self._async_checkpoint and not is_snapshot:
+            # Skip barrier and metadata save; will be done in _wait_for_pending_checkpoint
+            return True
+
+        dist.barrier()
+
+        self._finalize_checkpoint_metadata(
+            checkpoint_path=checkpoint_path,
+            meta_path=meta_path,
+            train_state_path=train_state_path,
+            is_snapshot=is_snapshot,
+            cur_step=self.cur_step,
+            cur_epoch=self._cur_epoch,
+            total_consumed_samples=self._total_consumed_samples,
+            total_consumed_tokens=self._total_consumed_tokens,
+            train_time_offset=self._train_time + self._train_time_offset,
+        )
 
         return True
 
@@ -1292,8 +1486,8 @@ class Trainer:
             # bind numa node
             schedule.run_on_nodes(numa_id)
             memory.set_membind_nodes(numa_id)
-        except Exception:
-            logger.info(f"Rank: {self.rank} failed to bind process to numa node.")
+        except Exception as e:
+            logger.warning(f"Rank: {self.rank} failed to bind process to numa node: {e}")
             return  # try_bind_numa should not raise exception
         else:
             logger.info(f"Rank: {self.rank} success bind process to numa node: {numa_id}")
@@ -1549,7 +1743,7 @@ class Trainer:
         DEVICE_MODULE.reset_peak_memory_stats()  # type: ignore[attr-defined]
 
     def _maybe_save_hf(self):
-        if self._hf_interval is None:
+        if self._hf_interval is None or self._hf_interval <= 0:
             return
 
         assert self._can_save_hf, "Model does not support saving in Huggingface format."
@@ -1749,19 +1943,35 @@ class Trainer:
         if not resume_from.exists():
             raise FileNotFoundError(f"Checkpoint path {resume_from} does not exist.")
 
+        # Auto-detect checkpoint format: merged (weights/) or legacy (model/ + optimizer/)
+        weights_path = resume_from / self._SAVE_WEIGHTS_DIR
         model_path = resume_from / self._SAVE_MODEL_DIR
-        optimizer_path = (
-            resume_from / self._SAVE_OPTIMIZER_DIR
-            if load_checkpoint_cfg.load_optimizer_states or load_checkpoint_cfg.load_optimizer_args
-            else None
-        )
 
-        self._engine.load_dcp(
-            model_dir=model_path,
-            optimizer_dir=optimizer_path,
-            load_states=load_checkpoint_cfg.load_optimizer_states,
-            load_args=load_checkpoint_cfg.load_optimizer_args,
-        )
+        if weights_path.exists():
+            # New merged format saved by async_save_dcp_merged
+            self._engine.load_dcp_merged(
+                weights_dir=weights_path,
+                load_states=load_checkpoint_cfg.load_optimizer_states,
+                load_args=load_checkpoint_cfg.load_optimizer_args,
+            )
+        elif model_path.exists():
+            # Legacy separate format
+            optimizer_path = (
+                resume_from / self._SAVE_OPTIMIZER_DIR
+                if load_checkpoint_cfg.load_optimizer_states or load_checkpoint_cfg.load_optimizer_args
+                else None
+            )
+            self._engine.load_dcp(
+                model_dir=model_path,
+                optimizer_dir=optimizer_path,
+                load_states=load_checkpoint_cfg.load_optimizer_states,
+                load_args=load_checkpoint_cfg.load_optimizer_args,
+            )
+        else:
+            raise FileNotFoundError(
+                f"Checkpoint at {resume_from} has neither '{self._SAVE_WEIGHTS_DIR}/' "
+                f"nor '{self._SAVE_MODEL_DIR}/' directory."
+            )
 
         train_state_path = resume_from / self._SAVE_TRAIN_STATE_PATH
 


### PR DESCRIPTION
feat(checkpoint): add async DCP checkpoint support

Add async checkpoint saving for XTuner v1 with a merged DCP weights format,
dedicated async checkpoint process group, and cached pinned-memory staging.

- add async_checkpoint training argument and Trainer wiring
- implement async_save_dcp_merged and load_dcp_merged in TrainEngine
- manage staging/upload futures, metadata finalization, and shutdown cleanup
- support automatic resume from merged weights/ checkpoints
- add async checkpoint benchmark configs and A/B benchmark script
- add trainer test coverage for async checkpoint interval saves
