### PR TITLE
Pin flash-linear-attention to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ all = [
   "parametrize",
   "mathruler",
   "pylatexenc",
-  "flash-linear-attention"
+  "flash-linear-attention==0.4.1"
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ all = [
   "parametrize",
   "mathruler",
   "pylatexenc",
-  "flash-linear-attention==0.4.1"
+  "flash-linear-attention==0.4.2"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary
- Pin the flash-linear-attention optional dependency to 0.4.2.

## Verification
- python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
- git diff --check