### PR TITLE
[Feature] support ep and enhance step latency for muon

### DIFF
--- a/xtuner/v1/config/optim.py
+++ b/xtuner/v1/config/optim.py
@@ -185,14 +185,9 @@ class MuonConfig(OptimConfig):
                     f"Muon params: {num_muon_regular / 1e6:.2f}M, AdamW params: {num_adamw / 1e6:.2f}M (counts by numel)"
                 )
             logger.info(f"Untrainable parameters names: {untrainable_names}")
-            logger.info(
-                f"using Muon optimizer distributed_mesh_size: {model.fsdp_mesh.size()}, "
-                f"distributed_mesh: {model.fsdp_mesh}"
-            )
 
         optimizer = Muon(
             param_groups,
-            distributed_mesh=model.language_model.fsdp_mesh,  # TODO: 暂不支持 EP>1; maybe rm device_mesh dependency?
             lr=self.lr,
             mu=self.momentum,
             betas=self.betas,

--- a/xtuner/v1/optim/muon.py
+++ b/xtuner/v1/optim/muon.py
@@ -1,4 +1,3 @@
-# type: ignore
 # ================================================================
 # Copyright (c) 2026 InternLM. All rights reserved.
 #
@@ -25,66 +24,26 @@
 
 import math
 from collections import defaultdict
-from itertools import chain
-from typing import Callable, Generator, List, Literal, Optional, Tuple, Union
+from itertools import chain, product
+from typing import Callable, Generator, Iterator, Literal, Sequence, cast, overload
 
 import torch
 import torch.distributed as dist
 from torch import Tensor
 from torch.distributed import ProcessGroup
-from torch.distributed.tensor import DeviceMesh, DTensor
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Shard
 from torch.optim.optimizer import Optimizer, ParamsT
 
-
-def _process_groups_equivalent(pg1: ProcessGroup, pg2: ProcessGroup) -> bool:
-    """Check if two ProcessGroup objects represent the same logical group.
-
-    ProcessGroup objects may be different Python objects even if they represent the same underlying group of processes.
-    This function compares their properties to determine logical equivalence.
-    """
-    if pg1 is pg2:
-        return True
-    return (
-        dist.get_world_size(pg1) == dist.get_world_size(pg2)
-        and dist.get_rank(pg1) == dist.get_rank(pg2)
-        and dist.get_backend(pg1) == dist.get_backend(pg2)
-    )
+from xtuner.v1.utils.dtensor import group_tensors_by_device_mesh_and_placements
 
 
-def to_local(tensor: Union[Tensor, List[Tensor]]) -> Union[Tensor, List[Tensor]]:
-    """Convert a single DTensor or list of DTensors to local tensors.
-
-    This is a no-op for regular tensors.
-    """
-    if isinstance(tensor, Tensor):
-        return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+def maybe_to_local(tensor: list[Tensor]) -> list[Tensor]:
     return [t.to_local() if isinstance(t, DTensor) else t for t in tensor]
 
 
-def dtensor_from_local(tensor: Union[Tensor, List[Tensor]], ref: Tensor) -> Union[DTensor, List[DTensor]]:  # type: ignore
-    """Convert a single local Tensor or list of local Tensors to DTensor.
-
-    The reference tensor's device mesh and placements are used to create the DTensor. if the reference tensor is not a
-    DTensor, we return the input unmodified.
-    """
-    if not isinstance(ref, DTensor):
-        assert isinstance(ref, Tensor)
-        return tensor
-
-    device_mesh = ref.device_mesh
-    placements = ref.placements
-
-    # If we have a single tensor
-    if isinstance(tensor, Tensor):
-        assert not isinstance(tensor, DTensor)
-        return DTensor.from_local(tensor, device_mesh=device_mesh, placements=placements)
-
-    # We have a list of tensors
-    assert not isinstance(tensor[0], DTensor)
-    return [DTensor.from_local(t, device_mesh=device_mesh, placements=placements) for t in tensor]
-
-
-def create_param_batches(params: List[Tensor], batch_size: int) -> Generator[List[Tensor], None, None]:
+def create_param_batches(params: Sequence[Tensor], batch_size: int) -> Generator[list[Tensor], None, None]:
     """Batch parameters into groups of size `batch_size`.
 
     Tensors in each batch will have identical shape, sharding, and dtype.
@@ -102,7 +61,7 @@ def create_param_batches(params: List[Tensor], batch_size: int) -> Generator[Lis
             yield batch
 
 
-def pad_batch(batch: List[Tensor], batch_size: int) -> List[Tensor]:
+def pad_batch(batch: list[Tensor], batch_size: int) -> list[Tensor]:
     """Insert dummy tensors so the batch has exactly `batch_size` elements."""
     assert len(batch) > 0
     assert len(batch) <= batch_size
@@ -136,14 +95,14 @@ class AsyncTask:
 class AsyncRuntime:
     """Event loop for running multiple async tasks concurrently."""
 
-    def __init__(self, task_gen: Generator["AsyncTask", None, None], max_concurrent_tasks: int):
+    def __init__(self, task_gen: Iterator["AsyncTask"], max_concurrent_tasks: int):
         # Initialize runtime with a generator that produces AsyncTask objects
         if max_concurrent_tasks <= 0:
             raise ValueError(f"{max_concurrent_tasks=} cannot be <= 0")
         self._task_gen = task_gen
         self._max_concurrent_tasks = max_concurrent_tasks
 
-    def _get_next_task(self) -> Optional["AsyncTask"]:
+    def _get_next_task(self) -> "AsyncTask | None":
         try:
             task = next(self._task_gen)
             return task
@@ -153,7 +112,7 @@ class AsyncRuntime:
     def run(self):
         # Run the event loop until all tasks are completed
         have_new_tasks = True
-        previous_tasks: List["AsyncTask"] = []
+        previous_tasks: list["AsyncTask"] = []
 
         while have_new_tasks or previous_tasks:
             # See if we can add another task
@@ -224,10 +183,10 @@ def adamw_update(
 
 
 def adamw_update_foreach(  # type: ignore
-    X: List[Tensor],  # Model weights (modified in place)
-    G: List[Tensor],  # Gradient
-    M: List[Tensor],  # Momentum buffer (modified in place)
-    V: List[Tensor],  # Variance buffer (modified in place)
+    X: list[Tensor],  # Model weights (modified in place)
+    G: list[Tensor],  # Gradient
+    M: list[Tensor],  # Momentum buffer (modified in place)
+    V: list[Tensor],  # Variance buffer (modified in place)
     lr: Tensor,  # Learning rate (scalar tensor)
     beta1: Tensor,  # Beta 1 (scalar tensor)
     beta2: Tensor,  # Beta 2 (scalar tensor)
@@ -251,8 +210,8 @@ def adamw_update_foreach(  # type: ignore
 
     # V = beta2 * V + (1 - beta2) * G * G
     G_square = torch._foreach_mul(G, G)
-    G_square = [g.to(dtype=V_dtype) for g in G_square]
-    torch._foreach_lerp_(V, G_square, [1 - beta2] * batch_size)
+    G_square_v = [g.to(dtype=V_dtype) for g in G_square]
+    torch._foreach_lerp_(V, G_square_v, [1 - beta2] * batch_size)
 
     # Bias correction
     bias_correction1 = 1 - beta1**step
@@ -284,30 +243,31 @@ def adamw_update_foreach(  # type: ignore
 
 
 class Muon(Optimizer):
-    """Distributed Muon optimizer for PyTorch FSDP2. Also compatible with DDP.
+    """Distributed Muon optimizer for PyTorch FSDP2.
+
+    All parameters must be DTensors. The optimizer extracts device mesh and process group
+    information directly from DTensor metadata.
 
     Args:
-        params: Parameters for the optimizer. Can be a list of parameters or a list of
-            parameter groups. Each parameter group can specify 'num_experts' to enable
+        params (ParamsT): Parameters for the optimizer. Can be a list of parameters or a list
+            of parameter groups. Each parameter group can specify 'num_experts' to enable
             per-expert orthogonalization for MoE models.
-        distributed_mesh: DeviceMesh or ProcessGroup for distributed training.
-            Use DeviceMesh for FSDP2 and ProcessGroup for DistributedDataParallel.
-        lr: Base learning rate. For Muon, this will be scaled based on the matrix dimensions.
+        lr (float): Base learning rate. For Muon, this will be scaled based on the matrix dimensions.
             For element-wise update rules, this is the actual learning rate and no additional scaling is done.
-        mu: Momentum factor for Muon algorithm.
-        betas: Tuple of (beta1, beta2) for AdamW algorithms.
-        weight_decay: Weight decay factor.
-        epsilon: Small value to avoid division by zero.
-        nesterov: Whether to use Nesterov momentum.
-        adjust_lr: How to adjust the learning rate for Muon updates ("spectral_norm", "rms_norm", or "none").
+        mu (float): Momentum factor for Muon algorithm.
+        betas (tuple[float, float]): tuple of (beta1, beta2) for AdamW algorithms.
+        weight_decay (float): Weight decay factor.
+        epsilon (float): Small value to avoid division by zero.
+        nesterov (bool): Whether to use Nesterov momentum.
+        adjust_lr (str): How to adjust the learning rate for Muon updates ("spectral_norm", "rms_norm", or "none").
             "spectral_norm": Adjust based on spectral norm, for learning rate transfer across model scale.
             "rms_norm": Adjust based on RMS norm, for learning rate compatibility with Adam/AdamW.
             "none": Do not adjust the learning rate.
-        flatten: Whether to flatten 3D+ tensors to 2D for Muon updates.
+        flatten (bool): Whether to flatten 3D+ tensors to 2D for Muon updates.
             True: Tensors with 3+ dimensions are flattened to 2D. Use this for convolutional layers.
             False: Tensors are not flattened. 3D+ tensors are treated as batches of 2D matrices.
-        use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
-        newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
+        use_triton (bool): Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
+        newton_schulz_func (Callable | None): Use a custom Newton-Schulz function for orthogonalization.
             Signature is `func(input: Tensor, epsilon: float, num_experts: int) -> Tensor`.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/
@@ -317,17 +277,16 @@ class Muon(Optimizer):
     def __init__(
         self,
         params: ParamsT,
-        distributed_mesh: Optional[Union[DeviceMesh, ProcessGroup]] = None,
         lr: float = 0.01,
         mu: float = 0.95,
-        betas: Tuple[float, float] = (0.9, 0.95),
+        betas: tuple[float, float] = (0.9, 0.95),
         weight_decay: float = 0.01,
         epsilon: float = 1e-8,
         nesterov: bool = False,
         adjust_lr: Literal["rms_norm", "spectral_norm", "none"] = "rms_norm",
         flatten: bool = False,
         use_triton: bool = False,
-        newton_schulz_func: Optional[Callable] = None,
+        newton_schulz_func: Callable | None = None,
     ):
         # Check hyperparameters
         if lr < 0.0:
@@ -356,28 +315,27 @@ class Muon(Optimizer):
         )
         super().__init__(params, defaults)
 
-        # Distributed configuration
-        if isinstance(distributed_mesh, DeviceMesh):
-            if distributed_mesh.ndim != 1:
-                raise ValueError(
-                    f"Only 1D DeviceMesh is supported, but got {distributed_mesh.ndim}D. For HSDP, provide the 1D sharded sub-mesh."
-                )
-            self._device_rank = distributed_mesh.get_local_rank()
-            self._world_size = distributed_mesh.size()
-            self._process_group = distributed_mesh.get_group()
-        elif isinstance(distributed_mesh, ProcessGroup):
-            self._device_rank = dist.get_rank(distributed_mesh)
-            self._world_size = dist.get_world_size(distributed_mesh)
-            self._process_group = distributed_mesh
-        elif distributed_mesh is None:
-            self._device_rank = 0
-            self._world_size = 1
-            self._process_group = None
-        else:
-            raise TypeError(
-                f"Invalid distributed_mesh type: {type(distributed_mesh)}. Expected DeviceMesh or ProcessGroup."
-            )
-        self._distributed_mesh = distributed_mesh
+        # Pre-compute lr adjustment ratios for each Muon parameter based on global shape.
+        # This must happen at init time because DTensor.shape here is guaranteed to be
+        # the global (unsharded) shape, whereas inside the async task the shape may
+        # reflect a local shard after distributed communication.
+        for group in self.param_groups:
+            if group["algorithm"] != "muon":
+                continue
+            adj = group["adjust_lr"]
+            ne = group.get("num_experts", 1)
+            for p in group["params"]:
+                state = self.state[p]
+                if adj == "none":
+                    state["lr_ratio"] = 1.0
+                elif adj == "spectral_norm":
+                    fan_out = p.shape[-2] // ne
+                    fan_in = p.shape[-1]
+                    state["lr_ratio"] = math.sqrt(fan_out / fan_in)
+                elif adj == "rms_norm":
+                    A = p.shape[-2] // ne
+                    B = p.shape[-1]
+                    state["lr_ratio"] = 0.2 * math.sqrt(max(A, B))
 
         # Newton-Schulz configuration
         if newton_schulz_func is not None:
@@ -391,8 +349,27 @@ class Muon(Optimizer):
         else:
             self._newton_schulz_func = zeropower_via_newtonschulz5
 
+        # Ensure every parameter has a state entry so that state_dict()
+        # includes all params.  Without this, params that never receive a
+        # gradient (e.g. frozen biases) would be missing from the saved
+        # state, causing KeyError on resume.
+        for group in self.param_groups:
+            for p in group["params"]:
+                _ = self.state[p]
+
+        # Pre-create sub-group process groups for MoE sub-group all-gather optimization.
+        # This must happen in __init__ so that all ranks call dist.new_group collectively.
+        self._subgroup_cache: dict[tuple[int, int, int], tuple[ProcessGroup, int, int]] = {}
+        self._init_moe_subgroups()
+
+    @overload
+    def step(self, closure: None = None) -> None: ...
+
+    @overload
+    def step(self, closure: Callable[[], float]) -> float: ...
+
     @torch.no_grad()
-    def step(self, closure=None):
+    def step(self, closure: Callable[[], float] | None = None) -> float | None:
         """Perform a single optimization step."""
         loss = None
         if closure is not None:
@@ -429,15 +406,137 @@ class Muon(Optimizer):
         """Get optimizer state for the given parameter tensor, or lazy-
         initialize it if it doesn't exist."""
         state = self.state[param]
-        if not state:
+        if "momentum" not in state:
             state["momentum"] = torch.zeros_like(param)
             if algo == "adamw":
                 state["variance"] = torch.zeros_like(param)
         return state
 
+    @staticmethod
+    def _find_fsdp_mesh_dim(device_mesh: DeviceMesh) -> int | None:
+        # NOTE: When Expert Parallelism (EP) is enabled, the mesh dimension name
+        # is expected to contain "fsdp" (e.g., "default.fsdp").
+        # TODO:@nil0x9 Consider refactoring this to make the FSDP mesh dimension
+        # identification more generic and less reliant on string matching.
+        for dim, name in enumerate(device_mesh.mesh_dim_names or ()):
+            if "fsdp" in name:
+                return dim
+        return None
+
+    def _init_moe_subgroups(self) -> None:
+        """Pre-create sub-group process groups for MoE parameters needing sub-
+        group all-gather.
+
+        When ``fsdp_size % ns_num_experts == 0``, each expert is split across
+        ``fsdp_size // ns_num_experts`` FSDP ranks.  Instead of a padded all-to-all
+        over all FSDP ranks, we can do a small all-gather within the sub-group that
+        shares each expert, dramatically reducing communication volume.
+
+        This method is called once in ``__init__`` so that all ranks participate in
+        the collective ``dist.new_group`` calls together.
+        """
+        for group in self.param_groups:
+            if group["algorithm"] != "muon":
+                continue
+
+            num_experts = group.get("num_experts", 1)
+
+            if num_experts <= 1:
+                continue
+
+            mesh_groups = group_tensors_by_device_mesh_and_placements(group["params"])
+
+            for (device_mesh, placements), _ in mesh_groups.items():
+                shard_placements = [
+                    (i, p) for i, p in enumerate(placements) if p.is_shard() and device_mesh.size(i) > 1
+                ]
+
+                if not shard_placements:
+                    continue
+
+                ns_num_experts = num_experts
+                sharded_mesh_dim: int
+
+                if len(shard_placements) == 1:
+                    sharded_mesh_dim = shard_placements[0][0]
+
+                elif len(shard_placements) == 2:
+                    fsdp_mesh_dim = self._find_fsdp_mesh_dim(device_mesh)
+
+                    if fsdp_mesh_dim is None:
+                        continue
+
+                    sharded_mesh_dim = fsdp_mesh_dim
+                    sharded_tensor_dim = cast(Shard, placements[fsdp_mesh_dim]).dim
+
+                    for i, p in shard_placements:
+                        if i != fsdp_mesh_dim and cast(Shard, p).dim == sharded_tensor_dim:
+                            assert ns_num_experts % device_mesh.size(i) == 0
+                            ns_num_experts = ns_num_experts // device_mesh.size(i)
+                else:
+                    # >2 shard dims will be caught as error in _create_muon_tasks
+                    continue
+
+                fsdp_size = device_mesh.size(sharded_mesh_dim)
+
+                # Case A: each rank holds complete experts → no sub-groups needed
+                if ns_num_experts % fsdp_size == 0:
+                    continue
+
+                # Case B: sub-group all-gather
+                if fsdp_size % ns_num_experts == 0:
+                    subgroup_size = fsdp_size // ns_num_experts
+                    self._create_subgroup_pgs(device_mesh, sharded_mesh_dim, subgroup_size)
+
+    def _create_subgroup_pgs(
+        self,
+        device_mesh: DeviceMesh,
+        sharded_mesh_dim: int,
+        subgroup_size: int,
+    ) -> None:
+        """Create and cache sub-group process groups for a given mesh
+        dimension.
+
+        Every rank in the world must participate in ``dist.new_group`` calls, so
+        this iterates over *all* sub-groups across all non-FSDP dimension
+        combinations and creates them collectively.
+        """
+        cache_key = (id(device_mesh), sharded_mesh_dim, subgroup_size)
+
+        if cache_key in self._subgroup_cache:
+            return
+
+        fsdp_size = device_mesh.size(sharded_mesh_dim)
+        fsdp_local_rank = device_mesh.get_local_rank(sharded_mesh_dim)
+        mesh_tensor = device_mesh.mesh
+        ndim = mesh_tensor.ndim
+
+        other_dims = [d for d in range(ndim) if d != sharded_mesh_dim]
+        other_dim_ranges = [range(mesh_tensor.size(d)) for d in other_dims]
+
+        current_rank = dist.get_rank()
+        my_pg: ProcessGroup | None = None
+
+        for combo in product(*other_dim_ranges):
+            idx: list[int | slice] = [slice(None)] * ndim
+            for d, c in zip(other_dims, combo):
+                idx[d] = c
+            fsdp_ranks = mesh_tensor[tuple(idx)].tolist()
+
+            for base in range(0, fsdp_size, subgroup_size):
+                sg_ranks = fsdp_ranks[base : base + subgroup_size]
+                pg = dist.new_group(sg_ranks)
+                if current_rank in sg_ranks:
+                    my_pg = pg
+
+        assert my_pg is not None, f"Rank {current_rank} not found in any sub-group"
+        subgroup_rank = fsdp_local_rank % subgroup_size
+
+        self._subgroup_cache[cache_key] = (my_pg, subgroup_rank, subgroup_size)
+
     def _create_muon_tasks(
         self,
-        param_groups: List[dict],
+        param_groups: list[dict],
         algo_name: str = "muon",
     ) -> Generator["AsyncTask", None, None]:
         """Helper function to create batches of Muon matrices and generate
@@ -454,71 +553,194 @@ class Muon(Optimizer):
             mu = torch.tensor(group["mu"])
             weight_decay = torch.tensor(group["weight_decay"])
             epsilon = torch.tensor(group["epsilon"])
+
             nesterov = group["nesterov"]
             flatten = group["flatten"]
-            adjust_lr = group["adjust_lr"]
+
             num_experts = group.get("num_experts", 1)
 
-            # Create batches of parameters of size self._world_size
-            for params in create_param_batches(group_params, batch_size=self._world_size):
-                gradients = [p.grad for p in params]
-                states = [self._get_or_initialize_state(p, algo_name) for p in params]
-                momentums = [s["momentum"] for s in states]
+            # Process DTensor parameters grouped by (device_mesh, placements)
+            mesh_groups = group_tensors_by_device_mesh_and_placements(group_params)
 
-                # Get sharding dimension
+            for (device_mesh, placements), mesh_params in mesh_groups.items():
+                # Extract communication primitives from the group's device_mesh
+                # Find the sharded placement and get its mesh and tensor dimensions
+                # Skip any Shard() placements on size-1 mesh dimension = Replicate()
+                shard_placements = [
+                    (i, p) for i, p in enumerate(placements) if p.is_shard() and device_mesh.size(i) > 1
+                ]
+
                 sharded_mesh_dim = None
                 sharded_tensor_dim = None
-                if isinstance(params[0], DTensor):
-                    if not isinstance(self._distributed_mesh, DeviceMesh):
-                        raise RuntimeError("Must create optimizer with DeviceMesh if using DTensor parameters.")
+                ns_num_experts = num_experts
 
-                    # Find the sharded placement and get its mesh and tensor dimensions
-                    # Skip any Shard() placements on size-1 mesh dimension = Replicate()
-                    shard_placements = [
-                        (i, p)
-                        for i, p in enumerate(params[0].placements)
-                        if p.is_shard() and params[0].device_mesh.size(i) > 1
-                    ]
-                    if len(shard_placements) == 1:
-                        sharded_mesh_dim = shard_placements[0][0]
-                        sharded_tensor_dim = shard_placements[0][1].dim
-                    elif len(shard_placements) > 1:
-                        raise NotImplementedError("Muon does not support parameters with multiple sharded dimensions.")
+                if len(shard_placements) == 1:
+                    # Standard case: single shard dim (FSDP only, or FSDP+EP with Replicate on EP)
+                    sharded_mesh_dim = shard_placements[0][0]
+                    sharded_tensor_dim = cast(Shard, shard_placements[0][1]).dim
 
-                    # Check that the sharded mesh dimension matches optimizer's device mesh
-                    if sharded_mesh_dim is not None and not _process_groups_equivalent(
-                        params[0].device_mesh.get_group(sharded_mesh_dim), self._process_group
-                    ):
+                elif len(shard_placements) > 1:
+                    if len(shard_placements) > 2:
+                        raise NotImplementedError(
+                            f"Muon optimizer supports at most 2 active shard dimensions (EP + FSDP), "
+                            f"got {len(shard_placements)}. Tensor parallelism is not yet supported."
+                        )
+                    # Multi-shard case: FSDP + EP for MoE params
+                    # Identify FSDP mesh dim by name and use it for all-to-all
+                    fsdp_mesh_dim = self._find_fsdp_mesh_dim(device_mesh)
+
+                    if fsdp_mesh_dim is None:
                         raise RuntimeError(
-                            f"Got DTensor sharded over mesh dimension {sharded_mesh_dim} different from the optimizer's device mesh. "
-                            f"param device mesh: {params[0].device_mesh}, optimizer's device mesh: {self._distributed_mesh}. "
-                            f"param group: {params[0].device_mesh.get_group(sharded_mesh_dim)}, optimizer's group: {self._process_group}. "
+                            "Could not identify FSDP mesh dimension for multi-shard DTensor. "
+                            "Ensure the DTensor device mesh has a dimension named 'fsdp'."
                         )
 
-                yield AsyncTask(
-                    muon_update_batch_async(
-                        X=pad_batch(params, self._world_size),
-                        G=pad_batch(gradients, self._world_size),
-                        M=pad_batch(momentums, self._world_size),
-                        lr=lr,
-                        momentum=mu,
-                        weight_decay=weight_decay,
-                        epsilon=epsilon,
-                        nesterov=nesterov,
-                        flatten=flatten,
-                        adjust_lr=adjust_lr,
-                        device_rank=self._device_rank,
-                        world_size=self._world_size,
-                        shard_dim=sharded_tensor_dim,
-                        process_group=self._process_group,
-                        newton_schulz_func=self._newton_schulz_func,
-                        num_experts=num_experts,
+                    fsdp_placement = placements[fsdp_mesh_dim]
+                    sharded_mesh_dim = fsdp_mesh_dim
+                    sharded_tensor_dim = cast(Shard, fsdp_placement).dim
+
+                    # Newton-Schulz needs the LOCAL number of experts after EP sharding,
+                    # so each block corresponds to one complete expert.
+                    for i, p in shard_placements:
+                        if i != fsdp_mesh_dim and cast(Shard, p).dim == sharded_tensor_dim:
+                            assert ns_num_experts % device_mesh.size(i) == 0
+                            ns_num_experts = ns_num_experts // device_mesh.size(i)
+
+                # Optimization: if each FSDP rank already holds complete experts,
+                # we can skip all-to-all and orthogonalize locally.
+                skip_communication = False
+                use_subgroup_allgather = False
+                subgroup_process_group: ProcessGroup | None = None
+                subgroup_size = 1
+                subgroup_rank = 0
+
+                if sharded_mesh_dim is not None and ns_num_experts > 1:
+                    fsdp_size = device_mesh.size(sharded_mesh_dim)
+
+                    if ns_num_experts % fsdp_size == 0:
+                        # Case A: each rank holds complete experts → zero communication
+                        ns_num_experts = ns_num_experts // fsdp_size
+                        sharded_mesh_dim = None
+                        sharded_tensor_dim = None
+                        skip_communication = True
+
+                    elif fsdp_size % ns_num_experts == 0 and len(mesh_params) < fsdp_size:
+                        # Case B: each expert spans a sub-group of ranks → sub-group all-gather
+                        # Guard: only when params can't fill a batch, otherwise batched all-to-all
+                        # is more efficient (fewer kernel launches, better bandwidth utilization).
+                        sg_size = fsdp_size // ns_num_experts
+                        ns_num_experts = 1  # After all-gather each rank has 1 complete expert
+                        use_subgroup_allgather = True
+                        cache_key = (id(device_mesh), sharded_mesh_dim, sg_size)
+                        subgroup_process_group, subgroup_rank, subgroup_size = self._subgroup_cache[cache_key]
+
+                # Derive process_group, world_size, device_rank from the group's device_mesh
+                if skip_communication or use_subgroup_allgather:
+                    # Each rank orthogonalizes its local experts independently, no all-to-all needed.
+                    group_process_group = None
+                    group_world_size = 1
+                    group_device_rank = 0
+
+                elif sharded_mesh_dim is not None:
+                    group_process_group = device_mesh.get_group(sharded_mesh_dim)
+                    group_world_size = device_mesh.size(sharded_mesh_dim)
+                    group_device_rank = device_mesh.get_local_rank(sharded_mesh_dim)
+
+                else:
+                    # Not sharded on any active mesh dim; fall back to FSDP mesh dim
+                    fsdp_dim = self._find_fsdp_mesh_dim(device_mesh)
+
+                    if fsdp_dim is not None:
+                        group_process_group = device_mesh.get_group(fsdp_dim)
+                        group_world_size = device_mesh.size(fsdp_dim)
+                        group_device_rank = device_mesh.get_local_rank(fsdp_dim)
+
+                    else:
+                        group_process_group = None
+                        group_world_size = 1
+                        group_device_rank = 0
+
+                # Create batches within this mesh group
+                for params in create_param_batches(mesh_params, batch_size=group_world_size):
+                    gradients: list[Tensor] = [g for p in params if (g := p.grad) is not None]
+                    assert len(gradients) == len(params), "Some gradients became None after filtering"
+
+                    states = [self._get_or_initialize_state(p, algo_name) for p in params]
+
+                    momentums = [s["momentum"] for s in states]
+                    lr_ratios = [s["lr_ratio"] for s in states]
+                    assert len(set(lr_ratios)) == 1, f"Found different lr_ratios: {set(lr_ratios)}"
+
+                    # AGRS (All-Gather + Reduce-Scatter) only works with even
+                    # sharding — all ranks must contribute the same number of
+                    # elements.  Uneven sharding falls back to padded all-to-all
+                    # which has dedicated uneven-shard handling.
+                    is_evenly_sharded = (
+                        sharded_tensor_dim is None or params[0].size(sharded_tensor_dim) % group_world_size == 0
                     )
-                )
+
+                    is_remainder = (
+                        len(params) < group_world_size
+                        and sharded_tensor_dim is not None
+                        and group_process_group is not None
+                        and is_evenly_sharded
+                    )
+
+                    if is_remainder:
+                        # AG+RS path for partial batches: no zero-padding needed
+                        yield AsyncTask(
+                            muon_update_batch_async(
+                                X=params,
+                                G=gradients,
+                                M=momentums,
+                                lr=lr,
+                                lr_ratio=lr_ratios[0],
+                                momentum=mu,
+                                weight_decay=weight_decay,
+                                epsilon=epsilon,
+                                nesterov=nesterov,
+                                flatten=flatten,
+                                device_rank=group_device_rank,
+                                world_size=group_world_size,
+                                shard_dim=sharded_tensor_dim,
+                                process_group=group_process_group,
+                                newton_schulz_func=self._newton_schulz_func,
+                                num_experts=ns_num_experts,
+                                subgroup_process_group=subgroup_process_group,
+                                subgroup_size=subgroup_size,
+                                subgroup_rank=subgroup_rank,
+                                use_agrs=True,
+                            )
+                        )
+
+                    else:
+                        yield AsyncTask(
+                            muon_update_batch_async(
+                                X=pad_batch(params, group_world_size),
+                                G=pad_batch(gradients, group_world_size),
+                                M=pad_batch(momentums, group_world_size),
+                                lr=lr,
+                                lr_ratio=lr_ratios[0],
+                                momentum=mu,
+                                weight_decay=weight_decay,
+                                epsilon=epsilon,
+                                nesterov=nesterov,
+                                flatten=flatten,
+                                device_rank=group_device_rank,
+                                world_size=group_world_size,
+                                shard_dim=sharded_tensor_dim,
+                                process_group=group_process_group,
+                                newton_schulz_func=self._newton_schulz_func,
+                                num_experts=ns_num_experts,
+                                subgroup_process_group=subgroup_process_group,
+                                subgroup_size=subgroup_size,
+                                subgroup_rank=subgroup_rank,
+                            )
+                        )
 
     def _create_adamw_tasks(
         self,
-        param_groups: List[dict],
+        param_groups: list[dict],
         algo_name: str = "adamw",
     ) -> Generator["AsyncTask", None, None]:
         """Helper function to generate AsyncTask objects for AdamW updates."""
@@ -527,10 +749,13 @@ class Muon(Optimizer):
 
             # Get parameters and optimizer states
             params = [p for p in group["params"] if p.grad is not None]
+
             if not params:
                 continue
+
             gradients = [p.grad for p in params]
             states = [self._get_or_initialize_state(p, algo_name) for p in params]
+
             momentums = [s["momentum"] for s in states]
             variances = [s["variance"] for s in states]
 
@@ -538,15 +763,16 @@ class Muon(Optimizer):
             beta1 = torch.tensor(group["beta1"])
             beta2 = torch.tensor(group["beta2"])
             weight_decay = torch.tensor(group["weight_decay"])
-            epsilon = torch.tensor(group["epsilon"])
-            step = torch.tensor(group["step"])
+            epsilon = group["epsilon"]  # Keep as float
+
+            step = group["step"]  # Keep as int
 
             yield AsyncTask(
                 adamw_update_foreach_async(
-                    X=to_local(params),
-                    G=to_local(gradients),
-                    M=to_local(momentums),
-                    V=to_local(variances),
+                    X=maybe_to_local(params),
+                    G=maybe_to_local(gradients),
+                    M=maybe_to_local(momentums),
+                    V=maybe_to_local(variances),
                     lr=lr,
                     beta1=beta1,
                     beta2=beta2,
@@ -558,236 +784,396 @@ class Muon(Optimizer):
 
 
 def muon_update_batch_async(
-    X: List[Tensor],  # Model weights (modified in place)
-    G: List[Tensor],  # Gradient
-    M: List[Tensor],  # Momentum buffer (modified in place)
+    X: list[Tensor],  # Model weights (modified in place)
+    G: list[Tensor],  # Gradient
+    M: list[Tensor],  # Momentum buffer (modified in place)
     lr: Tensor,  # Learning rate (scalar tensor)
+    lr_ratio: float,  # Pre-computed lr adjustment ratio
     momentum: Tensor,  # Momentum factor (scalar tensor)
     weight_decay: Tensor,  # Weight decay (scalar tensor)
     epsilon: Tensor,  # Epsilon (scalar tensor)
     nesterov: bool,  # Whether to use Nesterov momentum
     flatten: bool,  # Whether to flatten 3D+ tensors to 2D
-    adjust_lr: Optional[str],  # How to adjust learning rate
     device_rank: int,  # Rank of the current device
     world_size: int,  # Total number of devices to parallelize over
-    shard_dim: Optional[int] = None,  # Shard dimension for DTensor (if applicable)
-    process_group: Optional[ProcessGroup] = None,
-    newton_schulz_func: Optional[Callable] = None,
+    newton_schulz_func: Callable,  # Newton-Schulz function for orthogonalization
+    shard_dim: int | None = None,  # Shard dimension for DTensor (if applicable)
+    process_group: ProcessGroup | None = None,
     num_experts: int = 1,  # Number of experts for MoE models
+    subgroup_process_group: ProcessGroup | None = None,  # Sub-group PG for MoE all-gather
+    subgroup_size: int = 1,  # Number of ranks in the sub-group
+    subgroup_rank: int = 0,  # This rank's position within the sub-group
+    use_agrs: bool = False,  # Use All-Gather + Reduce-Scatter for partial batches
 ) -> Generator[None, None, None]:
     """Batched version of Muon update.
 
     Batch size should be equal to number of GPUs. All tensors in a batch should have identical shape, sharding, and
     dtype. Identical hyperparameters are used for all tensors in the batch.
+
+    When ``use_agrs`` is True the batch may be smaller than ``world_size``
+    (a "partial" or "remainder" batch).  Instead of padding and using
+    all-to-all, the function uses All-Gather to reconstruct full parameters,
+    selectively runs Newton-Schulz on a subset, then Reduce-Scatters the
+    results back.  This eliminates zero-padding overhead for partial batches.
     """
 
     assert len(X) == len(G)
     assert len(X) == len(M)
-    assert len(X) == world_size
+    if use_agrs:
+        assert len(X) < world_size, f"AGRS path expects partial batch, got {len(X)} == {world_size}"
+    else:
+        assert len(X) == world_size
 
     # Update momentum and compute the inputs for orthogonalization
     U = muon_update_pre_orthogonalize(
-        G=to_local(G),
-        M=to_local(M),
+        G=maybe_to_local(G),
+        M=maybe_to_local(M),
         momentum=momentum,
         nesterov=nesterov,
     )
 
     # Get one whole matrix for each device to orthogonalize
     if shard_dim is not None:
-        # Use all-to-all to transform from a batch of shards to a single whole matrix
-        # https://www.essential.ai/blog/infra
-        assert process_group is not None, "process_group must be provided for sharded DTensors"
         assert isinstance(X[0], DTensor), "X should contain DTensors"
         assert not isinstance(U[0], DTensor), "U should contain local shards"
 
-        global_shard_dim_size = X[0].size(shard_dim)
+        if use_agrs:
+            # === All-Gather + Selective Newton-Schulz + Reduce-Scatter path ===
+            # Used for partial (remainder) batches where len(batch) < world_size,
+            # avoiding the need to pad with zeros_like tensors.
+            R = len(U)  # Number of real parameters in this partial batch
+            W = world_size
+            assert process_group is not None, "process_group must be provided for AGRS path"
 
-        if global_shard_dim_size >= world_size and global_shard_dim_size % world_size == 0:
-            # Standard path: use all-to-all for evenly sharded tensors
-            # Pack the list of shards into a single contiguous tensor
-            # U is currently [Shard_for_Rank0, Shard_for_Rank1, ...]
-            # Stack creates shape: (World_Size, *Shard_Shape)
-            U_packed = torch.stack(U)
+            # Phase 1: All-Gather — each rank contributes R local shards,
+            # producing W*R shards across all ranks.
+            U_stacked = torch.stack(U)  # (R, *shard_shape)
+            ag_output = torch.empty((W * R,) + U[0].shape, dtype=U[0].dtype, device=U[0].device)
 
-            # Allocate buffer to receive parts of the "Single Matrix"
-            # Shape: (World_Size, *Shard_Shape)
-            single_matrix_parts = torch.empty_like(U_packed)
+            work = dist.all_gather_into_tensor(ag_output, U_stacked.contiguous(), group=process_group, async_op=True)
+            yield  # Yield point 1: overlap with other async work
+            work.wait()  # type: ignore[union-attr]
 
-            # Perform optimized All-to-All
-            # This sends one large contiguous buffer instead of many small ones
-            work = dist.all_to_all_single(single_matrix_parts, U_packed, group=process_group, async_op=True)
-            yield
-            work.wait()
+            # Reconstruct R full parameters from gathered shards.
+            # ag_output layout: [rank0_param0, rank0_param1, ..., rank1_param0, ...]
+            # Reshape to (W, R, *shard_shape), then merge shard_dim to get full params.
+            ag_reshaped = ag_output.view(W, R, *U[0].shape)
 
-            # Reconstruct the full matrix
-            # single_matrix_parts has shape (World_Size, D0, D1...)
             if shard_dim == 0:
-                # Optimization: If sharded on dim 0, we can simply flatten the batch dim
-                # to reconstruct the full matrix. This is a Zero-Copy View.
-                single_matrix = single_matrix_parts.flatten(0, 1)
-            else:
-                # General case (e.g., Col-wise sharding): We must concatenate along shard_dim.
-                # This requires a memory copy.
-                single_matrix = torch.cat(single_matrix_parts.unbind(0), dim=shard_dim)
+                # (W, R, shard_size, ...) → (R, W, shard_size, ...) → (R, W*shard_size, ...)
+                full_params = ag_reshaped.permute(1, 0, *range(2, ag_reshaped.ndim)).flatten(1, 2)
 
-            # 5. Perform Newton-Schulz Orthogonalization
-            single_matrix = muon_update_newton_schulz(
-                single_matrix,
+            else:
+                # General case: move W dim next to the shard_dim chunk, then flatten.
+                # ag_reshaped dims: [W=0, R=1, d0=2, d1=3, ...]
+                # Target: [R=1, d0=2, ..., W=0 next to shard chunk, ..., dN]
+                perm = list(range(ag_reshaped.ndim))
+                perm.remove(0)  # remove W
+                perm.insert(shard_dim + 1, 0)  # put W next to shard chunk (offset +1 for R dim)
+                full_params = ag_reshaped.permute(perm).flatten(shard_dim + 1, shard_dim + 2)
+            # full_params shape: (R, *full_param_shape)
+
+            # Phase 2: Selective Newton-Schulz — each rank orthogonalizes a subset.
+            # Rank r processes parameters where i % W == r, others get zeros.
+            ns_results = []
+            for i in range(R):
+                if i % W == device_rank:
+                    ns_results.append(
+                        muon_update_newton_schulz(
+                            full_params[i],
+                            newton_schulz_func=newton_schulz_func,
+                            flatten=flatten,
+                            epsilon=epsilon,
+                            num_experts=num_experts,
+                        )
+                    )
+                else:
+                    ns_results.append(torch.zeros_like(full_params[i]))
+
+            # Phase 3: Reduce-Scatter — sum partial NS results across ranks,
+            # each rank gets back its local shard of each parameter.
+            ns_stacked = torch.stack(ns_results)  # (R, *full_shape)
+            full_dim = ns_stacked.shape[shard_dim + 1]  # +1 because dim 0 is R
+            shard_size = full_dim // W
+
+            # Split the full dimension into (W, shard_size) for reduce-scatter
+            new_shape = list(ns_stacked.shape)
+            new_shape[shard_dim + 1 : shard_dim + 2] = [W, shard_size]
+            rs_input = ns_stacked.view(new_shape)
+
+            # Move the W dimension to front for reduce_scatter_tensor
+            w_pos = shard_dim + 1
+            perm = [w_pos] + list(range(0, w_pos)) + list(range(w_pos + 1, rs_input.ndim))
+            rs_input = rs_input.permute(perm).contiguous()
+
+            # Flatten trailing dims: (W, R*shard_numel) for reduce_scatter
+            rs_flat_in = rs_input.reshape(W, -1)
+            rs_flat_out = torch.empty(rs_flat_in.shape[1], dtype=rs_flat_in.dtype, device=rs_flat_in.device)
+
+            work = dist.reduce_scatter_tensor(
+                rs_flat_out,
+                rs_flat_in,
+                op=dist.ReduceOp.SUM,
+                group=process_group,
+                async_op=True,
+            )
+            yield  # Yield point 2: overlap with other async work
+            work.wait()  # type: ignore[union-attr]
+
+            # Unpack back to list of R local shards
+            U = list(rs_flat_out.view(R, *U_stacked.shape[1:]).unbind(0))
+
+        elif subgroup_process_group is not None:
+            # Sub-group all-gather path: reconstruct a complete expert from a small
+            # group of FSDP ranks that together hold all shards of one expert, then
+            # orthogonalize locally and slice back.  No global all-to-all needed.
+            assert world_size == 1, "Sub-group all-gather expects world_size=1 (no batch padding)"
+            local_shard = U[0]
+
+            # All-gather within sub-group to reconstruct full expert
+            gathered = torch.empty(
+                (subgroup_size,) + local_shard.shape,
+                dtype=local_shard.dtype,
+                device=local_shard.device,
+            )
+
+            work = dist.all_gather_into_tensor(
+                gathered, local_shard.contiguous(), group=subgroup_process_group, async_op=True
+            )
+            yield
+            work.wait()  # type: ignore[union-attr]
+
+            # Reconstruct full expert along shard_dim
+            if shard_dim == 0:
+                full_expert = gathered.flatten(0, 1)
+            else:
+                full_expert = torch.cat(gathered.unbind(0), dim=shard_dim)
+
+            # Orthogonalize (num_experts=1: we reconstructed exactly one expert)
+            full_expert = muon_update_newton_schulz(
+                full_expert,
                 newton_schulz_func=newton_schulz_func,
                 flatten=flatten,
                 epsilon=epsilon,
                 num_experts=num_experts,
             )
 
-            # Prepare to scatter results back
-            if shard_dim == 0:
-                # Optimization: View back to (World_Size, Shard_Size, ...)
-                # This is a Zero-Copy View.
-                single_matrix_shards_packed = single_matrix.view(world_size, -1, *single_matrix.shape[1:])
-            else:
-                # General case: Split back into chunks and stack them.
-                # We use stack to ensure the output is contiguous (World_Size, ...) for NCCL
-                single_matrix_shards_packed = torch.stack(single_matrix.chunk(world_size, dim=shard_dim))
-
-            # Ensure contiguity is preserved (crucial for NCCL)
-            if not single_matrix_shards_packed.is_contiguous():
-                single_matrix_shards_packed = single_matrix_shards_packed.contiguous()
-
-            # Allocate buffer for receiving updated gradients
-            U_packed_back = torch.empty_like(single_matrix_shards_packed)
-
-            # Perform optimized All-to-All (Scatter back)
-            work = dist.all_to_all_single(
-                U_packed_back, single_matrix_shards_packed, group=process_group, async_op=True
-            )
-            yield
-            work.wait()
-
-            # Unpack back to list form for the post-processing function
-            # unbind(0) is a view operation (slicing)
-            U = list(U_packed_back.unbind(0))
+            # Slice back to local shard — no reverse communication needed
+            shard_size = full_expert.size(shard_dim) // subgroup_size
+            U[0] = full_expert.narrow(shard_dim, subgroup_rank * shard_size, shard_size)
 
         else:
-            # Uneven sharding path: use all-to-all with padding to handle uneven shards.
-            # Each rank still only orthogonalizes one matrix (no redundant computation).
+            # All-to-all paths: use all-to-all to transform from a batch of shards
+            # to a single whole matrix per rank.
+            # https://www.essential.ai/blog/infra
+            assert process_group is not None, "process_group must be provided for sharded DTensors"
 
-            # Calculate padded shard size (ceil division) so all ranks have same-sized tensors
-            padded_shard_size = (global_shard_dim_size + world_size - 1) // world_size
+            global_shard_dim_size = X[0].size(shard_dim)
 
-            # Compute true local sizes for each rank using DTensor's sharding logic
-            local_sizes = []
-            for r in range(world_size):
-                start = r * padded_shard_size
-                end = min((r + 1) * padded_shard_size, global_shard_dim_size)
-                local_sizes.append(max(0, end - start))
+            if global_shard_dim_size >= world_size and global_shard_dim_size % world_size == 0:
+                # Standard path: use all-to-all for evenly sharded tensors
+                # Pack the list of shards into a single contiguous tensor
+                # U is currently [Shard_for_Rank0, Shard_for_Rank1, ...]
+                # Stack creates shape: (World_Size, *Shard_Shape)
+                U_packed = torch.stack(U)
 
-            # Pad all local shards to the same size for uniform all-to-all
-            U_padded = []
-            for u in U:
-                current_size = u.size(shard_dim)
-                if current_size < padded_shard_size:
-                    pad_size = padded_shard_size - current_size
-                    pad_shape = list(u.shape)
-                    pad_shape[shard_dim] = pad_size
-                    padding = torch.zeros(pad_shape, dtype=u.dtype, device=u.device)
-                    u_padded = torch.cat([u, padding], dim=shard_dim)
+                # Allocate buffer to receive parts of the "Single Matrix"
+                # Shape: (World_Size, *Shard_Shape)
+                single_matrix_parts = torch.empty_like(U_packed)
+
+                # Perform optimized All-to-All
+                # This sends one large contiguous buffer instead of many small ones
+                work = dist.all_to_all_single(single_matrix_parts, U_packed, group=process_group, async_op=True)
+                yield
+                work.wait()  # type: ignore[union-attr]
+
+                # Reconstruct the full matrix
+                # single_matrix_parts has shape (World_Size, D0, D1...)
+                if shard_dim == 0:
+                    # Optimization: If sharded on dim 0, we can simply flatten the batch dim
+                    # to reconstruct the full matrix. This is a Zero-Copy View.
+                    single_matrix = single_matrix_parts.flatten(0, 1)
                 else:
-                    u_padded = u
-                U_padded.append(u_padded)
+                    # General case (e.g., Col-wise sharding): We must concatenate along shard_dim.
+                    # This requires a memory copy.
+                    single_matrix = torch.cat(single_matrix_parts.unbind(0), dim=shard_dim)
 
-            # Stack into single tensor: (world_size, padded_shard_size, ...)
-            U_packed = torch.stack(U_padded)
-            single_matrix_parts = torch.empty_like(U_packed)
-
-            # All-to-all: each rank sends its shard of each matrix, receives all shards of one matrix
-            work = dist.all_to_all_single(single_matrix_parts, U_packed, group=process_group, async_op=True)
-            yield
-            work.wait()
-
-            # Reconstruct the full matrix by unpadding and concatenating
-            if shard_dim == 0:
-                # Flatten then unpad: total padded size = world_size * padded_shard_size
-                single_matrix = single_matrix_parts.flatten(0, 1).narrow(0, 0, global_shard_dim_size)
-            else:
-                # General case: unpad each shard then concatenate
-                shards = []
-                for r in range(world_size):
-                    true_size = local_sizes[r]
-                    if true_size > 0:
-                        shards.append(single_matrix_parts[r].narrow(shard_dim, 0, true_size))
-                single_matrix = torch.cat(shards, dim=shard_dim)
-
-            # Orthogonalize
-            single_matrix = muon_update_newton_schulz(
-                single_matrix,
-                newton_schulz_func=newton_schulz_func,
-                flatten=flatten,
-                epsilon=epsilon,
-                num_experts=num_experts,
-            )
-
-            # Split back into padded shards for all-to-all scatter
-            if shard_dim == 0:
-                # Pad back to world_size * padded_shard_size, then view
-                pad_total = world_size * padded_shard_size - global_shard_dim_size
-                if pad_total > 0:
-                    pad_shape = list(single_matrix.shape)
-                    pad_shape[0] = pad_total
-                    padding = torch.zeros(pad_shape, dtype=single_matrix.dtype, device=single_matrix.device)
-                    single_matrix_padded = torch.cat([single_matrix, padding], dim=0)
-                else:
-                    single_matrix_padded = single_matrix
-                single_matrix_shards_packed = single_matrix_padded.view(
-                    world_size, padded_shard_size, *single_matrix.shape[1:]
+                # 5. Perform Newton-Schulz Orthogonalization
+                single_matrix = muon_update_newton_schulz(
+                    single_matrix,
+                    newton_schulz_func=newton_schulz_func,
+                    flatten=flatten,
+                    epsilon=epsilon,
+                    num_experts=num_experts,
                 )
+
+                # Prepare to scatter results back
+                if shard_dim == 0:
+                    # Optimization: View back to (World_Size, Shard_Size, ...)
+                    # This is a Zero-Copy View.
+                    single_matrix_shards_packed = single_matrix.view(world_size, -1, *single_matrix.shape[1:])
+                else:
+                    # General case: Split back into chunks and stack them.
+                    # We use stack to ensure the output is contiguous (World_Size, ...) for NCCL
+                    single_matrix_shards_packed = torch.stack(single_matrix.chunk(world_size, dim=shard_dim))
+
+                # Ensure contiguity is preserved (crucial for NCCL)
+                if not single_matrix_shards_packed.is_contiguous():
+                    single_matrix_shards_packed = single_matrix_shards_packed.contiguous()
+
+                # Allocate buffer for receiving updated gradients
+                U_packed_back = torch.empty_like(single_matrix_shards_packed)
+
+                # Perform optimized All-to-All (Scatter back)
+                work = dist.all_to_all_single(
+                    U_packed_back, single_matrix_shards_packed, group=process_group, async_op=True
+                )
+                yield
+                work.wait()  # type: ignore[union-attr]
+
+                # Unpack back to list form for the post-processing function
+                # unbind(0) is a view operation (slicing)
+                U = list(U_packed_back.unbind(0))
+
             else:
-                # General case: split and pad each shard
-                shards_padded = []
-                offset = 0
+                # Uneven sharding path: use all-to-all with padding to handle uneven shards.
+                # Each rank still only orthogonalizes one matrix (no redundant computation).
+
+                # Calculate padded shard size (ceil division) so all ranks have same-sized tensors
+                padded_shard_size = (global_shard_dim_size + world_size - 1) // world_size
+
+                # Compute true local sizes for each rank using DTensor's sharding logic
+                local_sizes = []
                 for r in range(world_size):
-                    true_size = local_sizes[r]
-                    if true_size > 0:
-                        shard = single_matrix.narrow(shard_dim, offset, true_size)
-                        offset += true_size
-                        # Pad to padded_shard_size if needed
-                        if true_size < padded_shard_size:
-                            pad_shape = list(shard.shape)
-                            pad_shape[shard_dim] = padded_shard_size - true_size
-                            padding = torch.zeros(pad_shape, dtype=shard.dtype, device=shard.device)
-                            shard = torch.cat([shard, padding], dim=shard_dim)
+                    start = r * padded_shard_size
+                    end = min((r + 1) * padded_shard_size, global_shard_dim_size)
+                    local_sizes.append(max(0, end - start))
+
+                # Pad all local shards to the same size for uniform all-to-all
+                U_padded = []
+                for u in U:
+                    current_size = u.size(shard_dim)
+
+                    if current_size < padded_shard_size:
+                        pad_size = padded_shard_size - current_size
+                        pad_shape = list(u.shape)
+                        pad_shape[shard_dim] = pad_size
+                        padding = torch.zeros(pad_shape, dtype=u.dtype, device=u.device)
+                        u_padded = torch.cat([u, padding], dim=shard_dim)
+
                     else:
-                        # Create zero-padded shard
-                        shape = list(single_matrix.shape)
-                        shape[shard_dim] = padded_shard_size
-                        shard = torch.zeros(shape, dtype=single_matrix.dtype, device=single_matrix.device)
-                    shards_padded.append(shard)
-                single_matrix_shards_packed = torch.stack(shards_padded)
+                        u_padded = u
 
-            if not single_matrix_shards_packed.is_contiguous():
-                single_matrix_shards_packed = single_matrix_shards_packed.contiguous()
+                    U_padded.append(u_padded)
 
-            U_packed_back = torch.empty_like(single_matrix_shards_packed)
+                # Stack into single tensor: (world_size, padded_shard_size, ...)
+                U_packed = torch.stack(U_padded)
+                single_matrix_parts = torch.empty_like(U_packed)
 
-            # All-to-all scatter back
-            work = dist.all_to_all_single(
-                U_packed_back, single_matrix_shards_packed, group=process_group, async_op=True
-            )
-            yield
-            work.wait()
+                # All-to-all: each rank sends its shard of each matrix, receives all shards of one matrix
+                work = dist.all_to_all_single(single_matrix_parts, U_packed, group=process_group, async_op=True)
+                yield
+                work.wait()  # type: ignore[union-attr]
 
-            # Unpad and unpack to list form
-            my_size = local_sizes[device_rank]
-            U = []
-            for i in range(world_size):
-                shard = U_packed_back[i]
-                if my_size > 0 and my_size < padded_shard_size:
-                    shard = shard.narrow(shard_dim, 0, my_size)
-                elif my_size == 0:
-                    shape = list(shard.shape)
-                    shape[shard_dim] = 0
-                    shard = torch.empty(shape, dtype=shard.dtype, device=shard.device)
-                U.append(shard)
+                # Reconstruct the full matrix by unpadding and concatenating
+                if shard_dim == 0:
+                    # Flatten then unpad: total padded size = world_size * padded_shard_size
+                    single_matrix = single_matrix_parts.flatten(0, 1).narrow(0, 0, global_shard_dim_size)
+
+                else:
+                    # General case: unpad each shard then concatenate
+                    shards = []
+                    for r in range(world_size):
+                        true_size = local_sizes[r]
+
+                        if true_size > 0:
+                            shards.append(single_matrix_parts[r].narrow(shard_dim, 0, true_size))
+
+                    single_matrix = torch.cat(shards, dim=shard_dim)
+
+                # Orthogonalize
+                single_matrix = muon_update_newton_schulz(
+                    single_matrix,
+                    newton_schulz_func=newton_schulz_func,
+                    flatten=flatten,
+                    epsilon=epsilon,
+                    num_experts=num_experts,
+                )
+
+                # Split back into padded shards for all-to-all scatter
+                if shard_dim == 0:
+                    # Pad back to world_size * padded_shard_size, then view
+                    pad_total = world_size * padded_shard_size - global_shard_dim_size
+
+                    if pad_total > 0:
+                        pad_shape = list(single_matrix.shape)
+                        pad_shape[0] = pad_total
+                        padding = torch.zeros(pad_shape, dtype=single_matrix.dtype, device=single_matrix.device)
+                        single_matrix_padded = torch.cat([single_matrix, padding], dim=0)
+
+                    else:
+                        single_matrix_padded = single_matrix
+
+                    single_matrix_shards_packed = single_matrix_padded.view(
+                        world_size, padded_shard_size, *single_matrix.shape[1:]
+                    )
+
+                else:
+                    # General case: split and pad each shard
+                    shards_padded = []
+                    offset = 0
+
+                    for r in range(world_size):
+                        true_size = local_sizes[r]
+
+                        if true_size > 0:
+                            shard = single_matrix.narrow(shard_dim, offset, true_size)
+                            offset += true_size
+
+                            # Pad to padded_shard_size if needed
+                            if true_size < padded_shard_size:
+                                pad_shape = list(shard.shape)
+                                pad_shape[shard_dim] = padded_shard_size - true_size
+                                padding = torch.zeros(pad_shape, dtype=shard.dtype, device=shard.device)
+                                shard = torch.cat([shard, padding], dim=shard_dim)
+
+                        else:
+                            # Create zero-padded shard
+                            shape = list(single_matrix.shape)
+                            shape[shard_dim] = padded_shard_size
+                            shard = torch.zeros(shape, dtype=single_matrix.dtype, device=single_matrix.device)
+
+                        shards_padded.append(shard)
+
+                    single_matrix_shards_packed = torch.stack(shards_padded)
+
+                if not single_matrix_shards_packed.is_contiguous():
+                    single_matrix_shards_packed = single_matrix_shards_packed.contiguous()
+
+                U_packed_back = torch.empty_like(single_matrix_shards_packed)
+
+                # All-to-all scatter back
+                work = dist.all_to_all_single(
+                    U_packed_back, single_matrix_shards_packed, group=process_group, async_op=True
+                )
+                yield
+                work.wait()  # type: ignore[union-attr]
+
+                # Unpad and unpack to list form
+                my_size = local_sizes[device_rank]
+                U = []
+                for i in range(world_size):
+                    shard = U_packed_back[i]
+
+                    if my_size > 0 and my_size < padded_shard_size:
+                        shard = shard.narrow(shard_dim, 0, my_size)
+
+                    elif my_size == 0:
+                        shape = list(shard.shape)
+                        shape[shard_dim] = 0
+                        shard = torch.empty(shape, dtype=shard.dtype, device=shard.device)
+
+                    U.append(shard)
 
     else:
         # Matrices are not sharded, so we can directly orthogonalize
@@ -815,7 +1201,7 @@ def muon_update_batch_async(
             # Use efficient all_gather
             work = dist.all_gather_into_tensor(gathered_U, input_tensor, group=process_group, async_op=True)
             yield
-            work.wait()
+            work.wait()  # type: ignore[union-attr]
 
             # Unbind to list for compatibility
             U = list(gathered_U.unbind(0))
@@ -825,20 +1211,12 @@ def muon_update_batch_async(
             assert world_size == 1
             U = [single_matrix]
 
-    # Compute scaled learning rate
-    # Do this before to_local(X) because we use the full tensor shape, not the shard shape
-    if adjust_lr == "none":
-        adjusted_lr = lr
-    elif adjust_lr == "spectral_norm":
-        adjusted_lr = adjust_lr_spectral_norm(lr, X[0].shape, num_experts=num_experts)
-    elif adjust_lr == "rms_norm":
-        adjusted_lr = adjust_lr_rms_norm(lr, X[0].shape, num_experts=num_experts)
-    else:
-        raise ValueError(f"Unknown adjust_lr value: {adjust_lr}")
+    # Compute adjusted learning rate
+    adjusted_lr = lr * lr_ratio
 
     # Update model parameters with orthogonalized output
     muon_update_post_orthogonalize(
-        X=to_local(X),
+        X=maybe_to_local(X),
         U=U,
         base_lr=lr,
         adjusted_lr=adjusted_lr,
@@ -847,10 +1225,10 @@ def muon_update_batch_async(
 
 
 def adamw_update_foreach_async(
-    X: List[Tensor],  # Model weights (modified in place)
-    G: List[Tensor],  # Gradient
-    M: List[Tensor],  # Momentum buffer (modified in place)
-    V: List[Tensor],  # Variance buffer (modified in place)
+    X: list[Tensor],  # Model weights (modified in place)
+    G: list[Tensor],  # Gradient
+    M: list[Tensor],  # Momentum buffer (modified in place)
+    V: list[Tensor],  # Variance buffer (modified in place)
     lr: Tensor,  # Learning rate (scalar tensor)
     beta1: Tensor,  # Beta 1 (scalar tensor)
     beta2: Tensor,  # Beta 2 (scalar tensor)
@@ -864,11 +1242,11 @@ def adamw_update_foreach_async(
 
 
 def muon_update_pre_orthogonalize(
-    G: List[Tensor],
-    M: List[Tensor],
+    G: list[Tensor],
+    M: list[Tensor],
     momentum: Tensor,
     nesterov: bool,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Update momentum with gradient and compute the input to
     orthogonalization."""
     dtype = M[0].dtype
@@ -878,6 +1256,7 @@ def muon_update_pre_orthogonalize(
     torch._foreach_mul_(M, momentum)
     torch._foreach_add_(M, G)
 
+    U: Sequence[Tensor]
     if nesterov:
         U = torch._foreach_mul(M, momentum)
         torch._foreach_add_(U, G)
@@ -891,8 +1270,8 @@ def muon_update_pre_orthogonalize(
 
 
 def muon_update_post_orthogonalize(
-    X: List[Tensor],
-    U: List[Tensor],
+    X: list[Tensor],
+    U: list[Tensor],
     base_lr: Tensor,
     adjusted_lr: Tensor,
     weight_decay: Tensor,
@@ -902,7 +1281,7 @@ def muon_update_post_orthogonalize(
     torch._foreach_mul_(X, 1 - base_lr * weight_decay)
 
     # Weight update
-    U = torch._foreach_mul(U, adjusted_lr)
+    torch._foreach_mul_(U, adjusted_lr)
     torch._foreach_sub_(X, U)
 
 
@@ -924,25 +1303,6 @@ def muon_update_newton_schulz(
         X = X.flatten(end_dim=-3)
 
     return newton_schulz_func(X, epsilon=epsilon, num_experts=num_experts).reshape(original_shape)
-
-
-def adjust_lr_rms_norm(lr, param_shape, num_experts=1):
-    # Adjust learning rate for constant element-wise RMS norm
-    # https://arxiv.org/abs/2502.16982
-    A = param_shape[-2] // num_experts
-    B = param_shape[-1]
-    adjusted_ratio = 0.2 * math.sqrt(max(A, B))
-    adjusted_lr = lr * adjusted_ratio
-    return adjusted_lr
-
-
-def adjust_lr_spectral_norm(lr, param_shape, num_experts=1):
-    # Adjust from spectral norm 1 to RMS operator norm 1
-    # https://arxiv.org/abs/2310.17813
-    fan_out = param_shape[-2] // num_experts
-    fan_in = param_shape[-1]
-    adjusted_lr = lr * math.sqrt(fan_out / fan_in)
-    return adjusted_lr
 
 
 def zeropower_via_newtonschulz5(G: Tensor, epsilon: float = 1e-7, num_experts: int = 1):

--- a/xtuner/v1/utils/__init__.py
+++ b/xtuner/v1/utils/__init__.py
@@ -2,7 +2,7 @@ from .compile import maybe_compile
 from .config import Config
 from .device import get_device, get_torch_device_module
 from .dist_utils import is_local_rank0
-from .dtensor import is_evenly_distributed
+from .dtensor import cal_total_norm, group_tensors_by_device_mesh_and_placements, is_evenly_distributed
 from .enum_helper import StrEnum
 from .exception_helper import ParallelConfigException
 from .init_weight import default_init_weights, init_params
@@ -63,4 +63,6 @@ __all__ = [
     "profile_time",
     "clean_param_name",
     "trim_memory",
+    "group_tensors_by_device_mesh_and_placements",
+    "cal_total_norm",
 ]

--- a/xtuner/v1/utils/dtensor.py
+++ b/xtuner/v1/utils/dtensor.py
@@ -1,7 +1,96 @@
 from typing import cast
 
+import torch
+import torch.distributed as dist
+from torch.distributed._tensor import Replicate, Shard
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
-from torch.distributed.tensor.placement_types import Shard
+from torch.distributed.tensor.placement_types import Placement
+from torch.utils._foreach_utils import (
+    _device_has_foreach_support,
+    _has_foreach_support,
+)
+
+
+def group_tensors_by_device_mesh_and_placements(
+    tensors: list[DTensor],
+) -> dict[tuple[DeviceMesh, tuple[Placement, ...]], list[DTensor]]:
+    """Group DTensors by their device_mesh and placements.
+
+    Args:
+        tensors (list[DTensor]): List of DTensors to group.
+
+    Returns:
+        dict[tuple[DeviceMesh, tuple[Placement, ...]], list[DTensor]]:
+            A dictionary mapping (device_mesh, placements) to a list of DTensors.
+    """
+    grouped_tensors: dict[tuple[DeviceMesh, tuple[Placement, ...]], list[DTensor]] = {}
+    for tensor in tensors:
+        assert isinstance(tensor, DTensor)
+        key = (tensor.device_mesh, tensor.placements)
+        if key in grouped_tensors:
+            grouped_tensors[key].append(tensor)
+        else:
+            grouped_tensors[key] = [tensor]
+    return grouped_tensors
+
+
+def cal_total_norm(
+    tensors: list[DTensor], norm_type: float = 2.0, foreach: bool | None = None, dtype: torch.dtype = torch.float32
+) -> torch.Tensor:
+    """Compute the total norm of a list of DTensors.
+
+    All tensors must share the same device_mesh and placements. Supports L2 norm with
+    distributed all-reduce across sharded mesh dimensions.
+
+    Args:
+        tensors (list[DTensor]): List of DTensors to compute the norm of.
+        norm_type (float): Type of the norm. Only 2.0 is supported.
+        foreach (bool | None): Whether to use the foreach API. None for auto-detection.
+        dtype (torch.dtype): Dtype for norm computation.
+
+    Returns:
+        torch.Tensor: The total norm as a scalar tensor.
+    """
+    norm_type = float(norm_type)
+    if len(tensors) == 0:
+        return torch.tensor(0.0)
+
+    device_mesh: DeviceMesh = tensors[
+        0
+    ].device_mesh  # For eg: DeviceMesh('cuda', [0, 1], mesh_dim_names=('default.fsdp',))
+    placements = tensors[0].placements  # For eg: (Shard(dim=0),)
+    device = tensors[0].device  # For eg: device(type='cuda', index=0)
+    norms: tuple[DTensor, ...]
+    if (foreach is None and _has_foreach_support(tensors, device)) or (  # type: ignore
+        foreach and _device_has_foreach_support(device)
+    ):
+        norms = torch._foreach_norm(tensors, norm_type, dtype=dtype)  # type: ignore
+        # element of norms is dtensor with placement of _NormPartial
+        # For example: norms[0] = DTensor(local_tensor=0.04525977373123169,
+        #                                 device_mesh=DeviceMesh('cuda', [0, 1], mesh_dim_names=('default.fsdp',)),
+        #                                 placements=(_NormPartial(reduce_op='sum', norm_type=2.0),))
+    elif foreach:
+        raise RuntimeError(f"foreach=True was passed, but can't use the foreach API on {device.type} tensors")
+    else:
+        norms = tuple(torch.linalg.vector_norm(g, norm_type, dtype=dtype) for g in tensors)
+
+    local_norm = torch.linalg.vector_norm(torch.stack([norm.to_local() for norm in norms]), norm_type, dtype=dtype)
+    if norm_type == 2:
+        local_norm_squared = local_norm**2
+        for i, placement in enumerate(placements):
+            if isinstance(placement, Shard):
+                # When using ep + fsdp, the placement corresponding to fsdp mesh is _StridedShard
+                # isinstance(_StridedShard, Shard) is True
+                dist.all_reduce(local_norm_squared, group=device_mesh.get_group(i))
+            elif isinstance(placement, Replicate):
+                pass
+            else:
+                raise ValueError(f"Unsupported placement type {placement} in clip_grad_norm")
+        global_norm = local_norm_squared**0.5
+    else:
+        raise NotImplementedError
+    return global_norm
 
 
 def is_evenly_distributed(dtensor: DTensor) -> bool:

--- a/xtuner/v1/utils/grad_norm.py
+++ b/xtuner/v1/utils/grad_norm.py
@@ -1,70 +1,9 @@
-from typing import Dict, List, Optional, Tuple
+from typing import List
 
 import torch
-import torch.distributed as dist
-from torch.distributed._tensor import DTensor, Replicate, Shard
-from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor.placement_types import Placement
-from torch.utils._foreach_utils import (
-    _device_has_foreach_support,
-    _has_foreach_support,
-)
+from torch.distributed.tensor import DTensor
 
-
-def group_tensors_by_device_mesh_and_placements(tensors: List[DTensor]):
-    grouped_tensors: Dict[Tuple[DeviceMesh, Tuple[Placement, ...]], List[DTensor]] = {}
-    for tensor in tensors:
-        assert isinstance(tensor, DTensor)
-        key = (tensor.device_mesh, tensor.placements)
-        if key in grouped_tensors:
-            grouped_tensors[key].append(tensor)
-        else:
-            grouped_tensors[key] = [tensor]
-    return grouped_tensors
-
-
-def cal_total_norm(
-    tensors: List[DTensor], norm_type: float = 2.0, foreach: Optional[bool] = None, dtype=torch.float32
-):
-    norm_type = float(norm_type)
-    if len(tensors) == 0:
-        return torch.tensor(0.0)
-
-    device_mesh: DeviceMesh = tensors[
-        0
-    ].device_mesh  # For eg: DeviceMesh('cuda', [0, 1], mesh_dim_names=('default.fsdp',))
-    placements = tensors[0].placements  # For eg: (Shard(dim=0),)
-    device = tensors[0].device  # For eg: device(type='cuda', index=0)
-    norms: Tuple[DTensor, ...]
-    if (foreach is None and _has_foreach_support(tensors, device)) or (  # type: ignore
-        foreach and _device_has_foreach_support(device)
-    ):
-        norms = torch._foreach_norm(tensors, norm_type, dtype=dtype)  # type: ignore
-        # element of norms is dtensor with placement of _NormPartial
-        # For example: norms[0] = DTensor(local_tensor=0.04525977373123169,
-        #                                 device_mesh=DeviceMesh('cuda', [0, 1], mesh_dim_names=('default.fsdp',)),
-        #                                 placements=(_NormPartial(reduce_op='sum', norm_type=2.0),))
-    elif foreach:
-        raise RuntimeError(f"foreach=True was passed, but can't use the foreach API on {device.type} tensors")
-    else:
-        norms = tuple(torch.linalg.vector_norm(g, norm_type, dtype=dtype) for g in tensors)
-
-    local_norm = torch.linalg.vector_norm(torch.stack([norm.to_local() for norm in norms]), norm_type, dtype=dtype)
-    if norm_type == 2:
-        local_norm_squared = local_norm**2
-        for i, placement in enumerate(placements):
-            if isinstance(placement, Shard):
-                # When using ep + fsdp, the placement corresponding to fsdp mesh is _StridedShard
-                # isinstance(_StridedShard, Shard) is True
-                dist.all_reduce(local_norm_squared, group=device_mesh.get_group(i))
-            elif isinstance(placement, Replicate):
-                pass
-            else:
-                raise ValueError(f"Unsupported placement type {placement} in clip_grad_norm")
-        global_norm = local_norm_squared**0.5
-    else:
-        raise NotImplementedError
-    return global_norm
+from .dtensor import cal_total_norm, group_tensors_by_device_mesh_and_placements
 
 
 def cal_grad_norm(grads: List[DTensor], dtype=torch.float32):

--- a/xtuner/v1/utils/internal_metrics.py
+++ b/xtuner/v1/utils/internal_metrics.py
@@ -18,7 +18,7 @@ from xtuner.v1.module.attention.gated_deltanet import FusedRMSNormGated
 from xtuner.v1.module.decoder_layer.dense_decoder_layer import DenseDecoderLayer
 from xtuner.v1.module.decoder_layer.moe_decoder_layer import MoEDecoderLayer
 from xtuner.v1.utils.device import get_device
-from xtuner.v1.utils.grad_norm import cal_total_norm, group_tensors_by_device_mesh_and_placements
+from xtuner.v1.utils.dtensor import cal_total_norm, group_tensors_by_device_mesh_and_placements
 
 
 DEVICE = get_device()


### PR DESCRIPTION
# Summary
Highlight:
- Support Muon training when EP > 1
- reduce latency and memory footprint caused by excessive padding for all2all.

Details:
- Remove distributed_mesh parameter; extract device mesh and process group directly from DTensor metadata to support heterogeneous meshes (ViT and LM have different meshes).
- Pre-compute adjust_lr ratios in `__init__` based on global (unsharded) shape, avoiding incorrect shape references inside async tasks after communication.
- Add MoE expert-parallel support: per-expert Newton-Schulz orthogonalization, requires n_experts % ep_size == 0 on the EP dimension. On the FSDP dimension, skip communication when n_experts % fsdp_size == 0 (each rank holds complete experts), use sub-group all-gather when fsdp_size % n_experts == 0, otherwise fall back to batched all-to-all.
- Add AGRS (All-Gather + Reduce-Scatter) path for remainder batches to avoid zero-padding overhead, with even-sharding guard to prevent deadlock.
- Refactor shared utilities (group_tensors_by_device_mesh_and_placements,  cal_total_norm) from grad_norm.py to dtensor.py.
- Remove `# type: ignore` from file head, fix lint, add full type annotations.

## Communication Path Table

| Path | Condition | Communication | Computation | Code Location |
|------|-----------|---------------|-------------|---------------|
| **No communication** | MoE, `n_experts % fsdp_size == 0` (each rank holds complete experts) | None | Local NS per expert | `skip_communication = True` |
| **Sub-group all-gather** | MoE, `fsdp_size % n_experts == 0`, batch < fsdp_size | Small all-gather within sub-group | Local NS on reconstructed expert, then slice back | `subgroup_process_group` path |
| **All-to-all (even)** | Batch fills `world_size`, `global_dim % world_size == 0` | Forward a2a + backward a2a | Each rank orthogonalizes 1 full matrix | Even sharding branch |
| **All-to-all (uneven)** | Batch fills `world_size`, `global_dim % world_size != 0` | Padded forward a2a + padded backward a2a | Each rank orthogonalizes 1 full matrix (after unpad) | Uneven sharding branch |
| **AGRS** | Batch < `world_size`, evenly sharded (`dim % world_size == 0`) | All-gather + reduce-scatter | Selective NS: rank `r` computes params where `i % W == r` | `use_agrs = True` |
| **Padded all-to-all** | Batch < `world_size`, unevenly sharded (`dim % world_size != 0`) | Pad batch with `zeros_like` to `world_size`, then even/uneven a2a | Padded zeros go through NS (wasted computation) | Fallback when `is_evenly_sharded = False` |

## Constraints

- EP dimension: `n_experts % ep_size == 0` is **required** (assertion).
- FSDP dimension: no hard constraint; the three MoE paths (no-comm, sub-group, fall-through to a2a) are optimizations, not requirements.




# End Results
Experiments are run on a model of arch Qwen3.5. #GPU=128
## Regression Test

Loss aligns almost perfectly when `XTUNER_DETERMINISTIC` is turned on.
<img width="2055" height="900" alt="image" src="https://github.com/user-attachments/assets/e1ed4ffa-0de3-4438-8d0f-ab115d1a28ec" />


## Step Latency
Profile was collected at step 10 (rank0). Latencies might vary run-to-run.
| VERSION | EP_SIZE | latency |
|------|--------|--------|
|Base|1|  783ms|
|Base|8| Not Supported|
|This PR|1| 236ms|
|This PR|8|232ms|

The original implementation wastes a lot of time creating and transmitting padding tensors. This is wasteful when num_layers < world_size. The following graph showcases this behavior:
<img width="1780" height="524" alt="image" src="https://github.com/user-attachments/assets/91538c6b-19c4-425c-9bda-9d1d9fb3f038" />

This is especially the case when the world_size grows. Typically the world_size might be somewhere between 64 and 2048. But the number of layers (which determines how many params of the same shape are batched and all2all'ed) is typically smaller than 100, meaning that for large-scale training, the memory footprint and latency caused by padding tensors grows linearly with world size. In my experiment, I encountered OOM when training a 397B MoE model (60 layers, 128GPU, see below) for this exact reason.

The following is the timeline when running the same experiment using code in this PR:
<img width="1779" height="501" alt="image" src="https://github.com/user-attachments/assets/bcb6e0c3-8b12-4d20-916c-3089ce5734f8" />


## 397B Model
| VERSION | EP_SIZE | latency |
|------|--------|--------|
|Base|1|  OOM|
|Base|8| Not Supported|
|This PR|1| 491ms|
|This PR|8|1019ms|

# Limitation
**Padding fallback**. When the number of experts satisfies neither n_experts % fsdp_size == 0 nor fsdp_size % n_experts == 0, the code falls back to creating large padding tensors and running all-to-all to distribute
  expert parameters across ranks. This incurs significant memory and latency overhead. In practice, however, such model configurations are uncommon.

**Dispatch efficiency**. The current parameter dispatch follows a two-stage pattern: tensors are first grouped by device mesh and sharding placement, then routed within each group. This grouping-before-dispatching approach can introduce waste. A more general global parameter-to-device dispatcher **could** eliminate this overhead and is left for future work.

