### PR TITLE
[Enhance] use fp32 acc for liger fused ce loss

### DIFF
--- a/xtuner/v1/loss/ce_loss.py
+++ b/xtuner/v1/loss/ce_loss.py
@@ -114,7 +114,10 @@ class LMHeadLossContext(BaseLossContext):
                 LigerFusedLinearCrossEntropyLoss,
             )
 
-            self.liger_loss_fct = LigerFusedLinearCrossEntropyLoss(reduction="sum")
+            self.liger_loss_fct = LigerFusedLinearCrossEntropyLoss(
+                reduction="sum",
+                accum_dtype=torch.float32,
+            )
         else:
             self.liger_loss_fct = None
 


### PR DESCRIPTION
This PR is to replace the default liger CE loss accumulator dtype to fp32. There is a known issue in fused CE loss implementation that, in mixed-precision training, when grad accumulator is maintained in low precision, training becomes unstable in late training stage.

The official liger-kernel implementation introduced an extra arg `accum_dtype` to `LigerFusedLinearCrossEntropyLoss` probably in light of this issue. But they keep the default behavior to be "following input dtype":
<img width="2340" height="476" alt="image" src="https://github.com/user-attachments/assets/7774e63e-7d0c-4516-a025-5da5b750459c" />

Therefore when we don't designate `accum_dtype` in `LigerFusedLinearCrossEntropyLoss`, this accumulator will follow the dtype of weight, which in most cases is of dtype `bfloat16`. This is likely gonna cause instability in training.

See also:
- https://github.com/linkedin/Liger-Kernel/pull/830
- https://github.com/linkedin/Liger-Kernel/issues/512
- https://github.com/apple/ml-cross-entropy/issues/14#issuecomment-2564374400