### PR TITLE
fix(ci): update lmdeploy commit in Dockerfile and fix some ci image version problems

### DIFF
--- a/.github/workflows/docker-inner.yml
+++ b/.github/workflows/docker-inner.yml
@@ -51,18 +51,18 @@ jobs:
             IMAGE_TAG="pt$(echo ${TORCH_VERSION} | awk -F. '{print $1$2}')_${DATE_TODAY}_${COMMIT_SHA}"
             echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
           fi
-          echo "DOCKER_TAG=${{ secrets.IMAGE_REGISTRY }}/${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "DOCKER_TAG=${{ secrets.CI_GPU_IMAGE_REGISTRY }}/${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_ENV
           echo "SHORT_DOCKER_TAG=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_ENV
       - name: Build image
         run: |
           cat ${{vars.EXTRA_DOCKERFILE}} >> ${{ github.workspace }}/Dockerfile
           echo "IMAGE_NAME: ${IMAGE_NAME}, IMAGE_TAG: ${IMAGE_TAG}"
-          export IMAGE_NAME=${{ secrets.IMAGE_REGISTRY }}/${IMAGE_NAME}
+          export IMAGE_NAME=${{ secrets.CI_GPU_IMAGE_REGISTRY }}/${IMAGE_NAME}
           bash ${{ github.workspace }}/image_build.sh
           echo "Built image with tag: ${SHORT_DOCKER_TAG}"
       - name: Push to cluster
         if: ${{ !inputs.build_only }}
         run: |
           echo "pushing $SHORT_DOCKER_TAG ..."
-          docker login ${{ secrets.IMAGE_REGISTRY }} -p ${{ secrets.CLUSTER_DOCKERHUB_TOKEN }} -u ${{ secrets.CLUSTER_DOCKERHUB_USERNAME }}
+          docker login ${{ secrets.CI_GPU_IMAGE_REGISTRY }} -p ${{ secrets.CLUSTER_DOCKERHUB_TOKEN }} -u ${{ secrets.CLUSTER_DOCKERHUB_USERNAME }}
           docker push $DOCKER_TAG

--- a/.github/workflows/docker-inner.yml
+++ b/.github/workflows/docker-inner.yml
@@ -10,9 +10,9 @@ on:
         default: auto
       torch_version:
         required: true
-        description: 'Set docker torch version. Default is "2.8.0"'
+        description: 'Set docker torch version. Default is "2.9.1"'
         type: string
-        default: '2.8.0'
+        default: '2.9.1'
       image_repo_short:
         required: true
         description: 'Set target repository for pushing the docker image. Default is "xtuner"'
@@ -33,10 +33,10 @@ jobs:
   publish_docker_image:
     runs-on: [docker-inner]
     env:
-      IMAGE_NAME: registry.h.pjlab.org.cn/ailab-llmrazor/${{ inputs.image_repo_short || 'xtuner' }}
+      IMAGE_NAME: ailab-llmrazor/${{ inputs.image_repo_short || 'xtuner' }}
       IMAGE_TAG: ${{ inputs.image_tag || 'auto' }}
-      TORCH_VERSION: ${{ inputs.torch_version || '2.8.0' }}
-      SCHEDULE_TAG: 'pt28_latest'
+      TORCH_VERSION: ${{ inputs.torch_version || '2.9.1' }}
+      SCHEDULE_TAG: 'pt29_latest'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -51,16 +51,18 @@ jobs:
             IMAGE_TAG="pt$(echo ${TORCH_VERSION} | awk -F. '{print $1$2}')_${DATE_TODAY}_${COMMIT_SHA}"
             echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
           fi
-          echo "DOCKER_TAG=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "DOCKER_TAG=${{ secrets.IMAGE_REGISTRY }}/${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "SHORT_DOCKER_TAG=${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_ENV
       - name: Build image
         run: |
           cat ${{vars.EXTRA_DOCKERFILE}} >> ${{ github.workspace }}/Dockerfile
           echo "IMAGE_NAME: ${IMAGE_NAME}, IMAGE_TAG: ${IMAGE_TAG}"
+          export IMAGE_NAME=${{ secrets.IMAGE_REGISTRY }}/${IMAGE_NAME}
           bash ${{ github.workspace }}/image_build.sh
-          echo "Built image with tag: ${DOCKER_TAG}"
+          echo "Built image with tag: ${SHORT_DOCKER_TAG}"
       - name: Push to cluster
         if: ${{ !inputs.build_only }}
         run: |
-          echo "$DOCKER_TAG"
-          docker login registry.h.pjlab.org.cn -p ${{ secrets.CLUSTER_DOCKERHUB_TOKEN }} -u ${{ secrets.CLUSTER_DOCKERHUB_USERNAME }}
+          echo "pushing $SHORT_DOCKER_TAG ..."
+          docker login ${{ secrets.IMAGE_REGISTRY }} -p ${{ secrets.CLUSTER_DOCKERHUB_TOKEN }} -u ${{ secrets.CLUSTER_DOCKERHUB_USERNAME }}
           docker push $DOCKER_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -265,18 +265,16 @@ ARG LMDEPLOY_URL
 ENV XTUNER_LMDEPLOY_ENVS_DIR=/envs/lmdeploy
 
 # RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
-ARG LMDEPLOY_WHEELS=https://github.com/InternLM/lmdeploy/releases/download/v${LMDEPLOY_VERSION}/lmdeploy-${LMDEPLOY_VERSION}+cu128-cp312-cp312-manylinux2014_x86_64.whl
 RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
     --mount=type=secret,id=NO_PROXY,env=no_proxy \
     pip install fastapi fire openai outlines \
         pyzmq aiohttp cloudpickle prometheus_client protobuf numpy pillow einops tiktoken sentencepiece \
         partial_json_parser 'ray[default]<3' shortuuid uvicorn pybase64 \
+        tilelang \
         'pydantic>2' openai_harmony dlblas --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-cache-dir -i ${DEFAULT_PYPI_URL} && \
     pip install xgrammar==0.1.32 timm!=1.0.23 --no-cache-dir -i ${DEFAULT_PYPI_URL} --no-deps && \
     if [ -n "${LMDEPLOY_VERSION}" ]; then \
-        # pip install lmdeploy==${LMDEPLOY_VERSION} --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
-        echo pip install ${LMDEPLOY_WHEELS} --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
-        pip install ${LMDEPLOY_WHEELS} --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
+        pip install lmdeploy==${LMDEPLOY_VERSION} --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
     else \
         git clone $(echo ${LMDEPLOY_URL} | cut -d '@' -f 1) && \
         cd ${CODESPACE}/lmdeploy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -210,59 +210,9 @@ ARG DEFAULT_PYPI_URL
 # RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 RUN pip install pystack py-spy --no-cache-dir -i ${DEFAULT_PYPI_URL}
 
-# install sglang and its runtime requirements
-ENV XTUNER_SGLANG_ENVS_DIR=/envs/sglang
-
-# RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
-RUN \
-   pip install --target ${XTUNER_SGLANG_ENVS_DIR} \
-   sglang==0.5.9 sgl-kernel==0.3.21 \
-   apache-tvm-ffi==0.1.9 \
-   anthropic==0.86.0 \
-   build==1.4.0 \
-   cuda-python==12.9.0 \
-   decord2==3.2.0 \
-   flashinfer_python==0.6.3 \
-   flashinfer_cubin==0.6.3 \
-   gguf==0.18.0 \
-   modelscope==1.35.3 \
-   nvidia-cutlass-dsl==4.4.2 \
-   openai-harmony==0.0.4 \
-   openai==2.6.1 \
-   outlines==0.1.11 \
-   quack-kernels==0.2.4 \
-   timm==1.0.16 \
-   torchao==0.9.0 \
-   torchaudio==2.9.1 \
-   torchcodec==0.8.0 \
-   xgrammar==0.1.32 \
-   smg-grpc-proto==0.4.5 \
-   grpcio==1.78.1 \
-   grpcio-reflection==1.78.1 \
-   grpcio-health-checking==1.80.0 \
-   pycryptodomex==3.23.0 \
-   lxml==6.0.2 \
-   cuda-bindings==12.9.6 \
-   cuda-pathfinder==1.5.0 \
-   nvidia-cudnn-frontend==1.21.0 \
-   lark==1.3.1 \
-   pycountry==26.2.16 \
-   airportsdata==20260315 \
-   outlines_core==0.1.26 \
-   torch-c-dlpack-ext==0.1.5 \
-   pyproject_hooks==1.2.0 \
-   huggingface_hub==0.36.2 \
-   torch_memory_saver==0.0.9 \
-   diskcache==5.6.3 distro==1.9.0 jiter==0.13.0 \
-   llguidance==0.7.11 blobfile==3.0.0 \
-   pybase64 orjson uvloop setproctitle msgspec partial_json_parser \
-   compressed_tensors python-multipart \
-   hf_transfer interegular --no-cache-dir --no-deps -i ${DEFAULT_PYPI_URL}
-
 # install lmdeploy and its missing runtime requirements
 ARG LMDEPLOY_VERSION
 ARG LMDEPLOY_URL
-ENV XTUNER_LMDEPLOY_ENVS_DIR=/envs/lmdeploy
 
 # RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
@@ -271,15 +221,15 @@ RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
         pyzmq aiohttp cloudpickle prometheus_client protobuf numpy pillow einops tiktoken sentencepiece \
         partial_json_parser 'ray[default]<3' shortuuid uvicorn pybase64 \
         tilelang \
-        'pydantic>2' openai_harmony dlblas --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-cache-dir -i ${DEFAULT_PYPI_URL} && \
+        'pydantic>2' openai_harmony dlblas --no-cache-dir -i ${DEFAULT_PYPI_URL} && \
     pip install xgrammar==0.1.32 timm!=1.0.23 --no-cache-dir -i ${DEFAULT_PYPI_URL} --no-deps && \
     if [ -n "${LMDEPLOY_VERSION}" ]; then \
-        pip install lmdeploy==${LMDEPLOY_VERSION} --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
+        pip install lmdeploy==${LMDEPLOY_VERSION} --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
     else \
         git clone $(echo ${LMDEPLOY_URL} | cut -d '@' -f 1) && \
         cd ${CODESPACE}/lmdeploy && \
         git checkout $(echo ${LMDEPLOY_URL} | cut -d '@' -f 2) && \
-        pip install . -v --target ${XTUNER_LMDEPLOY_ENVS_DIR} --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
+        pip install . -v --no-deps --no-cache-dir -i ${DEFAULT_PYPI_URL}; \
     fi
 
 ## install xtuner
@@ -292,9 +242,6 @@ ARG XTUNER_COMMIT
 COPY . ${CODESPACE}/xtuner
 
 WORKDIR ${CODESPACE}/xtuner
-
-# Install custom .pth file for conditional lmdeploy and sglang path injection
-RUN cp -r .dev_scripts/xtuner_rl_path* ${PYTHON_SITE_PACKAGE_PATH}/
 
 # RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 RUN pip install .[all] -v --no-cache-dir -i ${DEFAULT_PYPI_URL}

--- a/Dockerfile
+++ b/Dockerfile
@@ -266,7 +266,7 @@ ENV XTUNER_LMDEPLOY_ENVS_DIR=/envs/lmdeploy
 
 # RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
-    --mount=type=secret,id=NO_PROXY,env=no_proxy \
+    # --mount=type=secret,id=NO_PROXY,env=no_proxy \
     pip install fastapi fire openai outlines \
         pyzmq aiohttp cloudpickle prometheus_client protobuf numpy pillow einops tiktoken sentencepiece \
         partial_json_parser 'ray[default]<3' shortuuid uvicorn pybase64 \

--- a/autotest/config.yaml
+++ b/autotest/config.yaml
@@ -8,7 +8,7 @@ default_config:
             gpus_per_task: 8
             cpus_per_task: 120
             memory_per_task: 512
-            image: ailab-llmrazor/xtuner_tmp:pt29_20260414_c8f6fa1
+            image: ailab-llmrazor/xtuner:pt29_latest
             envs: 
                 - HF_HUB_CACHE=/mnt/shared-storage-user/auto-eval-pipeline/opencompass/models/hf_hub
     eval:

--- a/image_build.sh
+++ b/image_build.sh
@@ -10,9 +10,9 @@ export DEEP_EP_URL=https://github.com/deepseek-ai/DeepEP@9af0e0d0e74f3577af1979c
 export DEEP_GEMM_URL=https://github.com/deepseek-ai/DeepGEMM@c9f8b34dcdacc20aa746b786f983492c51072870 # v2.1.1.post3
 export CAUSAL_CONV1D_URL=https://github.com/Dao-AILab/causal-conv1d@da6dbaa9fd5a919967f14d3fd031da1288ad5025 # v1.6.0
 
-export TORCH_VERSION=${TORCH_VERSION:-"2.9.0"}
-export LMDEPLOY_VERSION="0.12.2"
-# export LMDEPLOY_URL=https://github.com/InternLM/lmdeploy@9a50f1f4eaf1e4fbe45892bc8017a7359237160c
+export TORCH_VERSION=${TORCH_VERSION:-"2.9.1"}
+# export LMDEPLOY_VERSION="0.13.0dev"
+export LMDEPLOY_URL=https://github.com/InternLM/lmdeploy@9df0eff7c38ae69b9d4b9f7ad1441e484d439f92
 export PPA_SOURCE="https://mirrors.aliyun.com"
 export DEFAULT_PYPI_URL=${DEFAULT_PYPI_URL:-"https://mirrors.aliyun.com/pypi/simple"}
 # mirror https://download.pytorch.org/whl
@@ -38,7 +38,7 @@ docker build . \
   --build-arg DEEP_GEMM_URL=$DEEP_GEMM_URL \
   --build-arg XTUNER_URL=$XTUNER_URL \
   --build-arg XTUNER_COMMIT=$XTUNER_COMMIT \
-  --build-arg LMDEPLOY_VERSION=$LMDEPLOY_VERSION \
+  --build-arg LMDEPLOY_URL=$LMDEPLOY_URL \
   --progress=plain \
   --label "BASE_IMAGE=$BASE_IMAGE" \
   --label "XTUNER_URL=${XTUNER_URL/@/\/tree\/}" \
@@ -49,4 +49,5 @@ docker build . \
   --label "CAUSAL_CONV1D_URL=${CAUSAL_CONV1D_URL/@/\/tree\/}" \
   --label "DEEP_EP_URL=${DEEP_EP_URL/@/\/tree\/}" \
   --label "DEEP_GEMM_URL=${DEEP_GEMM_URL/@/\/tree\/}" \
-  --label "LMDEPLOY_VERSION=$LMDEPLOY_VERSION"
+  --label "LMDEPLOY_URL=$LMDEPLOY_URL"
+  # --label "LMDEPLOY_VERSION=$LMDEPLOY_VERSION"

--- a/image_build.sh
+++ b/image_build.sh
@@ -49,5 +49,5 @@ docker build . \
   --label "CAUSAL_CONV1D_URL=${CAUSAL_CONV1D_URL/@/\/tree\/}" \
   --label "DEEP_EP_URL=${DEEP_EP_URL/@/\/tree\/}" \
   --label "DEEP_GEMM_URL=${DEEP_GEMM_URL/@/\/tree\/}" \
-  --label "LMDEPLOY_URL=$LMDEPLOY_URL"
+  --label "LMDEPLOY_URL=${LMDEPLOY_URL/@/\/tree\/}"
   # --label "LMDEPLOY_VERSION=$LMDEPLOY_VERSION"

--- a/image_build.sh
+++ b/image_build.sh
@@ -12,7 +12,7 @@ export CAUSAL_CONV1D_URL=https://github.com/Dao-AILab/causal-conv1d@da6dbaa9fd5a
 
 export TORCH_VERSION=${TORCH_VERSION:-"2.9.1"}
 # export LMDEPLOY_VERSION="0.13.0dev"
-export LMDEPLOY_URL=https://github.com/InternLM/lmdeploy@9df0eff7c38ae69b9d4b9f7ad1441e484d439f92
+export LMDEPLOY_URL=https://github.com/InternLM/lmdeploy@efe3b88607756a7ad9411b89627b5ac6ebaa540e
 export PPA_SOURCE="https://mirrors.aliyun.com"
 export DEFAULT_PYPI_URL=${DEFAULT_PYPI_URL:-"https://mirrors.aliyun.com/pypi/simple"}
 # mirror https://download.pytorch.org/whl


### PR DESCRIPTION
This pull request updates the Docker build and deployment workflow to use newer dependencies and improves the way Docker images are tagged and pushed. The main changes involve upgrading the default PyTorch version, adjusting LMDeploy installation, updating image registry handling, and refining image tagging conventions.

Dependency and version upgrades:

* Updated the default PyTorch version to 2.9.1 in the workflow, image build script, and Dockerfile, replacing the previous 2.8.0/2.9.0 defaults.
* Changed LMDeploy installation in the Dockerfile to use the official pip package for a specified version or build from a custom URL, and switched from using `LMDEPLOY_VERSION` to `LMDEPLOY_URL` as the main build argument. 

Docker image registry and tagging improvements:

* Removed the hardcoded registry prefix from `IMAGE_NAME` and now prepend the registry from secrets during the push step, improving flexibility and security. 
* Refined tagging: introduced `SHORT_DOCKER_TAG` for clarity and updated `SCHEDULE_TAG` to reflect the new PyTorch version. 

Configuration and image usage updates:

* Updated the default Docker image used in `autotest/config.yaml` to `ailab-llmrazor/xtuner:pt29_latest`, ensuring tests use the latest image built with the new workflow.

Dependency management:

* Added the `tilelang` package to the Dockerfile's installation list, ensuring it is available in the build environment.