### PR TITLE
[Bug] forbid extra fields in BaseAdvantageConfig

### DIFF
--- a/xtuner/v1/rl/config/advantage.py
+++ b/xtuner/v1/rl/config/advantage.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 from cyclopts import Group, Parameter
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from xtuner.v1.rl.advantage.base import AdvantageEstimator
 
@@ -11,6 +11,8 @@ advantage_group = Group("Advantage Estimation", sort_key=2, help="Advantage esti
 
 class BaseAdvantageConfig(BaseModel):
     """Intermediate base for discriminated union."""
+
+    model_config = ConfigDict(extra="forbid")
 
     def build(self) -> AdvantageEstimator:
         raise NotImplementedError("Subclasses must implement this method.")


### PR DESCRIPTION
## Motivation

`BaseAdvantageConfig` is the intermediate base class for all advantage estimation configs (used in Pydantic discriminated union). Without `extra="forbid"`, misspelled or unexpected fields are silently ignored by Pydantic, making configuration errors hard to spot.

## Modification

Add `model_config = ConfigDict(extra="forbid")` to `BaseAdvantageConfig` so that any extra/unknown fields raise a validation error immediately.

## Checklist

- [x] Pre-commit hooks passed