### PR TITLE
[Fix] Fix position_ids device inconsistency for ascend npu

### DIFF
--- a/xtuner/v1/data_proto/sequence_context.py
+++ b/xtuner/v1/data_proto/sequence_context.py
@@ -121,7 +121,7 @@ class SequenceContext:
 
         if position_ids is None:
             _position_ids = [torch.arange(k - q, k) for q, k in zip(seq_lens_q, seq_lens_k)]
-            position_ids = torch.cat(_position_ids).unsqueeze(0).to(self.cu_seq_lens_k.device)  # type: ignore[assignment]
+            position_ids = torch.cat(_position_ids).unsqueeze(0).to(self.device)  # type: ignore[assignment]
 
             if self.sequence_parallel_mesh is not None:
                 position_ids = split_for_sequence_parallel(position_ids, dim=1, sp_mesh=self.sequence_parallel_mesh)  # type: ignore

--- a/xtuner/v1/datasets/collator.py
+++ b/xtuner/v1/datasets/collator.py
@@ -288,7 +288,9 @@ def qwen3_vl_sft_collator(
         else:
             image_grid_thw = None
 
-        seq_ctx.position_ids = position_ids  # type: ignore
+        if position_ids is not None:
+            seq_ctx.position_ids = position_ids  # type: ignore
+
         seq_ctx.pixel_values = pixel_values  # type: ignore
         seq_ctx.image_grid_thw = image_grid_thw
         seq_ctx.num_img_tokens = num_img_tokens


### PR DESCRIPTION
# Issue
This PR is to solve a device inconsistency issue that is triggered under the following conditions:
1. trained on ascend npu;
2. 3d rope is disabled;
3. SequenceContext object is copied (e.g., in `Qwen3VLForConditionalGeneration.foward`).

The following exception would arise from the above setting:
```txt
 freqs = (inv_freq_expanded.float().to(x.device) @ position_ids_expanded.float()).transpose(
[rank0]:              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[rank0]: RuntimeError: Expected all tensors to be on the same device, but found at least two devices, npu:0 and cpu! 
```

# Root Cause
For Ascend NPU device, `SequenceContext.to` method exempt cu_seq_len from being moved to the target device. 
https://github.com/InternLM/xtuner/blob/73f656327bfdc745081ae49d37011e6307e0d228/xtuner/v1/data_proto/sequence_context.py#L477-L479

Now in `__init__`:
https://github.com/InternLM/xtuner/blob/73f656327bfdc745081ae49d37011e6307e0d228/xtuner/v1/data_proto/sequence_context.py#L124

When `position_ids` is None, the freshly created `position_ids` tensor would be moved to `cu_seq_lens_k.device`, which is always on device `cpu`. This is problematic when one copies a `SequenceContext` object without invoking `to` method afterwards.

A known path to this issue is when one trains a Qwen3VL model with 3d rope turned off. In this case, position_ids would be reset to None in collator:
https://github.com/InternLM/xtuner/blob/73f656327bfdc745081ae49d37011e6307e0d228/xtuner/v1/datasets/collator.py#L291

and then during model forward `seq_ctx` would be copied with `position_ids` being None.
https://github.com/InternLM/xtuner/blob/73f656327bfdc745081ae49d37011e6307e0d228/xtuner/v1/model/compose/qwen3_vl/modeling_qwen3_vl.py#L207-L212

# Solution
1. avoid overwriting position_ids to None in `qwen3_vl_sft_collator` when 3d rope is off.
2. Keep position_ids's device consistent with `self` instead of `self.cu_seq_lens_k`.