### PR TITLE
support skip eval and fix tokenize_fn

### DIFF
--- a/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
+++ b/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
@@ -28,6 +28,10 @@ def _as_list(value):
 work_dir = os.environ["WORK_DIR"]
 model_path = os.environ["MODEL_PATH"]
 meta_data_path = os.environ["DATA_PATH"]
+eval_data_path = os.environ.get("EVAL_DATA_PATH", "")
+eval_media_root = os.environ.get("EVAL_MEDIA_ROOT", "")
+
+enable_evaluate = eval_data_path is not None and eval_data_path != ""
 
 # basic settings
 experimental_name = "grpo_mix_data"
@@ -86,7 +90,6 @@ with open(meta_data_path, "r", encoding="utf-8") as f:
     ds_collections = json.load(f)
 
 train_dataset_cfg = []
-eval_dataset_cfg = []
 for name, data in ds_collections.items():
     annotations = _as_list(data["annotation"])
     for annotation in annotations:
@@ -104,27 +107,39 @@ for name, data in ds_collections.items():
                     max_length=max_prompt_length,
                     system_message=data.get("system_message", None),
                     chat_template="qwen3.5-vl",
+                    add_generation_prompt=True,
+                    enable_thinking=True,
                 ),
             }
         )
-        eval_dataset_cfg.append(
-            {
-                "dataset": DatasetConfig(
-                    name=name,
-                    anno_path=annotation,
-                    media_root=data.get("media_root", ""),
-                    sample_ratio=data.get("sample_ratio", 1.0),
-                    class_name="VLMJsonlDataset",
-                ),
-                "tokenize_fn": RLQwen3VLTokenizeFnConfig(
-                    processor_path=model_path,
-                    max_length=max_prompt_length,
-                    system_message=data.get("system_message", None),
-                    chat_template="qwen3.5-vl",
-                    ignore_multimodal_info=True,
-                ),
-            }
-        )
+
+if enable_evaluate:
+    eval_dataset_cfg = [
+        {
+            "dataset": DatasetConfig(
+                name=f"{experimental_name}_eval",
+                anno_path=eval_data_path,
+                media_root=eval_media_root,
+                sample_ratio=1.0,
+                class_name="VLMJsonlDataset",
+            ),
+            "tokenize_fn": RLQwen3VLTokenizeFnConfig(
+                processor_path=model_path,
+                max_length=max_prompt_length,
+                chat_template="qwen3.5-vl",
+                add_generation_prompt=True,
+                enable_thinking=True,
+                ignore_multimodal_info=True,
+            ),
+        }
+    ]
+    eval_dataloader_cfg = DataloaderConfig(
+        dataset_config_list=eval_dataset_cfg,
+        num_workers=8,
+        collator="fake_collator",
+        pack_level="none",
+        pack_max_length=pack_max_length,
+    )
 
 dataloader_cfg = DataloaderConfig(
     dataset_config_list=train_dataset_cfg,
@@ -133,13 +148,7 @@ dataloader_cfg = DataloaderConfig(
     pack_level="none",
     pack_max_length=pack_max_length,
 )
-eval_dataloader_cfg = DataloaderConfig(
-    dataset_config_list=eval_dataset_cfg,
-    num_workers=8,
-    collator="fake_collator",
-    pack_level="none",
-    pack_max_length=pack_max_length,
-)
+
 
 # 4. judger
 tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
@@ -210,18 +219,23 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
     ),
 )
 
-eval_agent_loop_config = SingleTurnAgentLoopConfig(
-    hf_checkpoint=model_path,
-    sample_params=evaluation_sample_params,
-)
-eval_agent_loop_manager_cfg = AgentLoopManagerConfig(
-    tasks=TaskSpecConfig(
-        task_name="eval_task",
-        agent_loop_config=eval_agent_loop_config,
-        judger_config=judger_config,
-        sampler_config=SamplerConfig(dataloader_cfg=eval_dataloader_cfg, prompt_repeat_k=1),
-    ),
-)
+if enable_evaluate:
+    eval_agent_loop_config = SingleTurnAgentLoopConfig(
+        hf_checkpoint=model_path,
+        sample_params=evaluation_sample_params,
+    )
+    eval_agent_loop_manager_cfg = AgentLoopManagerConfig(
+        tasks=TaskSpecConfig(
+            task_name="eval_task",
+            agent_loop_config=eval_agent_loop_config,
+            judger_config=judger_config,
+            sampler_config=SamplerConfig(dataloader_cfg=eval_dataloader_cfg, prompt_repeat_k=1),
+        ),
+    )
+    enable_evaluate=True
+else:
+    eval_agent_loop_manager_cfg = None
+    enable_evaluate=False
 
 # 7. trainer
 trainer = RLColocateTrainerConfig(
@@ -237,7 +251,7 @@ trainer = RLColocateTrainerConfig(
     total_epochs=total_epochs,
     train_batch_size=global_batch_size,
     advantage_estimator_config=GRPOAdvantageConfig(eps=1e-8),
-    enable_evaluate=False,
+    enable_evaluate=enable_evaluate,
     enable_initial_evaluate=False,
     evaluate_step=1,
     work_dir=work_dir,

--- a/lagent
+++ b/lagent
@@ -1,0 +1,1 @@
+../../gateway/lagent/

--- a/lagent
+++ b/lagent
@@ -1,1 +1,0 @@
-../../gateway/lagent/

--- a/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_tokenize_fn.py
@@ -421,6 +421,7 @@ class Qwen3VLTokenizeFunction(BaseMLLMTokenizeFunction):
         )
 
     def calc_num_tokens_pure_text_get_item(self, data_item) -> CacheItem:
+        # It is expected that Qwen35ChatMessages is slightly slower than ChatMessages in the same data and same output.
         if self.chat_template_name == "qwen3.5-vl":
             messages = Qwen35ChatMessages(messages=data_item["messages"], tools=data_item.get("tools"))
         else:

--- a/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 from xtuner.v1.data_proto.rl_data import RolloutState
 
 from ...data_proto.rl_data import MultimodalInfo
+from ..data_item import CacheItem
 from ..mllm_tokenize_fn.qwen3_vl_tokenize_fn import Qwen3VLTokenizeFnConfig, Qwen3VLTokenizeFunction, QwenVL3DataItem
 
 
@@ -59,7 +60,7 @@ class RLQwen3VLTokenizeFunction(Qwen3VLTokenizeFunction):
         self.data_judger_mapping = data_judger_mapping
         super().__init__(*args, **kwargs)
 
-    def __call__(self, item: dict, media_root: str = "", **kwargs) -> RolloutState:
+    def __call__(self, item: dict, media_root: str = "", **kwargs) -> RolloutState | CacheItem:
         extra_info = item.get("extra_info", {})
         if isinstance(item["prompt"], dict):
             assert "messages" in item["prompt"], "When prompt is a dict, it must contain 'messages' key"
@@ -78,8 +79,8 @@ class RLQwen3VLTokenizeFunction(Qwen3VLTokenizeFunction):
         data = super().__call__({"messages": messages, "tools": tools}, media_root=media_root)
 
         if self.state == "cache":
-            return RolloutState(
-                message=messages,
+            # If return RolloutState, the cache speed will be slow because of serialization problem
+            return CacheItem(
                 num_tokens=data["num_tokens"],
                 proxy_attn_flops=data.get("proxy_attn_flops", float(data["num_tokens"])),
             )

--- a/xtuner/v1/datasets/rl_tokenize_fn/text_tokenize_fn.py
+++ b/xtuner/v1/datasets/rl_tokenize_fn/text_tokenize_fn.py
@@ -5,6 +5,7 @@ from transformers import PreTrainedTokenizer
 from xtuner.v1.data_proto.rl_data import RolloutState
 from xtuner.v1.utils import get_logger
 
+from ..data_item import CacheItem
 from ..utils import CachableTokenizeFunction
 
 
@@ -26,7 +27,7 @@ class RLTextTokenizeFn(CachableTokenizeFunction[RolloutState]):
         self.data_judger_mapping = data_judger_mapping
         self.system_prompt = system_prompt
 
-    def __call__(self, item: dict, **kwargs) -> RolloutState:
+    def __call__(self, item: dict, **kwargs) -> RolloutState | CacheItem:
         """example:
         item = {
                 "data_source": data_source,
@@ -79,16 +80,22 @@ class RLTextTokenizeFn(CachableTokenizeFunction[RolloutState]):
             else:
                 mapped_judger_name_and_weight = {data_source: 1.0}
 
-        rollout_state = RolloutState(
-            prompt_ids=prompt_token_ids,
-            message=message,
-            reward_model=item.get("reward_model", {}),
-            num_tokens=num_tokens,
-            proxy_attn_flops=float(num_tokens),
-            data_source=mapped_judger_name_and_weight,
-            extra_fields=extra_info,
-        )
-        return rollout_state
+        if self.state == "cache":
+            # If return RolloutState, the cache speed will be slow because of serialization problem
+            return CacheItem(
+                num_tokens=num_tokens,
+                proxy_attn_flops=float(num_tokens),
+            )
+        else:
+            return RolloutState(
+                prompt_ids=prompt_token_ids,
+                message=message,
+                reward_model=item.get("reward_model", {}),
+                num_tokens=num_tokens,
+                proxy_attn_flops=float(num_tokens),
+                data_source=mapped_judger_name_and_weight,
+                extra_fields=extra_info,
+            )
 
     def hash(self) -> str:
         return "RLTextTokenizeFn"

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -187,8 +187,8 @@ class BaseRLTrainerConfig(BaseModel):
     tokenizer_path: str | Path
     replay_buffer_config: SyncReplayBufferConfig | AsyncReplayBufferConfig = SyncReplayBufferConfig()
     agent_loop_manager_cfg: AgentLoopManagerConfig
-    eval_agent_loop_manager_cfg: AgentLoopManagerConfig
-    evaluator_config: EvaluatorConfig
+    eval_agent_loop_manager_cfg: AgentLoopManagerConfig | None = None
+    evaluator_config: EvaluatorConfig | None = None
     load_from: str | Path
     total_train_steps: int | None = None
     total_epochs: int | None = None
@@ -332,7 +332,7 @@ class BaseRLTrainer:
 
     def _init_runtime_flags(self, cfg: BaseRLTrainerConfig) -> None:
         self._enable_evaluate = cfg.enable_evaluate
-        self._enable_initial_evaluate = cfg.enable_initial_evaluate
+        self._enable_initial_evaluate = cfg.enable_initial_evaluate and cfg.enable_evaluate
         self._evaluate_step = cfg.evaluate_step
         self._debug_rollout = cfg.debug_rollout
 
@@ -352,16 +352,19 @@ class BaseRLTrainer:
             sync_weights_interval=cfg.sync_weights_interval,
         )
 
-        self.eval_agent_loop_manager = cfg.eval_agent_loop_manager_cfg.build(
-            rollout_controller=self.rollout_controller,
-            tokenizer=self.tokenizer,
-            replay_buffer=replay_buffer,
-            logger=self.logger,
-            sync_weights_interval=cfg.sync_weights_interval,
-        )
+        if self._enable_evaluate:
+            assert cfg.eval_agent_loop_manager_cfg is not None
+            self.eval_agent_loop_manager = cfg.eval_agent_loop_manager_cfg.build(
+                rollout_controller=self.rollout_controller,
+                tokenizer=self.tokenizer,
+                replay_buffer=replay_buffer,
+                logger=self.logger,
+                sync_weights_interval=cfg.sync_weights_interval,
+            )
 
-        total_eval_samples = len(self.eval_agent_loop_manager.data_sampler)
-        self.evaluator = cfg.evaluator_config.build(total_eval_samples=total_eval_samples)
+            total_eval_samples = len(self.eval_agent_loop_manager.data_sampler)
+            assert cfg.evaluator_config is not None
+            self.evaluator = cfg.evaluator_config.build(total_eval_samples=total_eval_samples)
         self._resolve_total_train_steps(cfg)
 
     def _resolve_total_train_steps(self, cfg: BaseRLTrainerConfig) -> None:


### PR DESCRIPTION
- 支持跳过 eval 过程训练
- 修复 qwen3_5 RL 配置中存在的 eval 配置和 chat_template 错误问题
- 缓解在 cache 情况下由于 rolloutstate 导致的速度慢问题

在 dapo_math 上测试发现，build_dataset 速度比主分支慢，分析下来原因为：
- rolloutstate 在 cache 阶段序列化会慢一点(不是主要原因)
- 新实现的 `Qwen35ChatMessages` tokenize 过程比 `ChatMessages` 慢(主要原因)。这是无法避免的问题

在 dapo_math 数据集上，main 分支使用 `ChatMessages` 耗时是 72s，在新分支上+`Qwen35ChatMessages` 需要 92s，如果修复rolloutstate 在 cache 阶段序列化问题，可以稍微减轻到 85s。




