### PR TITLE
support debug_train and debug_rollout

### DIFF
--- a/examples/v1/config/rl_disagg_multi.py
+++ b/examples/v1/config/rl_disagg_multi.py
@@ -349,5 +349,4 @@ trainer = RLDisaggregatedTrainerConfig(
     evaluate_step=evaluate_step,
     work_dir=work_dir,
     seed=int(os.environ.get("SEED", "123")),
-    debug_rollout=os.environ.get("DEBUG_ROLLOUT", "0") == "1",
 )

--- a/examples/v1/config/rl_disagg_single.py
+++ b/examples/v1/config/rl_disagg_single.py
@@ -272,5 +272,4 @@ trainer = RLDisaggregatedTrainerConfig(
     evaluate_step=evaluate_step,
     work_dir=work_dir,
     seed=int(os.environ.get("SEED", "123")),
-    debug_rollout=os.environ.get("DEBUG_ROLLOUT", "0") == "1",
 )

--- a/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
+++ b/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
@@ -31,12 +31,16 @@ meta_data_path = os.environ["DATA_PATH"]
 eval_data_path = os.environ.get("EVAL_DATA_PATH", "")
 eval_media_root = os.environ.get("EVAL_MEDIA_ROOT", "")
 
+debug_rollout_dir = os.environ.get("DEBUG_ROLLOUT_DIR", "")
+debug_train = os.environ.get("DEBUG_TRAIN", False)
+debug_rollout = os.environ.get("DEBUG_ROLLOUT", False)
+
 enable_evaluate = eval_data_path is not None and eval_data_path != ""
 
 # basic settings
 experimental_name = "grpo_mix_data"
 total_epochs = 15
-global_batch_size = 256
+global_batch_size = 16
 prompt_repeat_k = 8
 rollout_tp_size = 2
 rollout_ep_size = 1
@@ -256,4 +260,7 @@ trainer = RLColocateTrainerConfig(
     evaluate_step=1,
     work_dir=work_dir,
     hf_interval=hf_interval,
+    debug_rollout_dir=debug_rollout_dir,
+    debug_train=debug_train,
+    debug_rollout=debug_rollout,
 )

--- a/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
+++ b/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
@@ -40,7 +40,7 @@ enable_evaluate = eval_data_path is not None and eval_data_path != ""
 # basic settings
 experimental_name = "grpo_mix_data"
 total_epochs = 15
-global_batch_size = 16
+global_batch_size = 256
 prompt_repeat_k = 8
 rollout_tp_size = 2
 rollout_ep_size = 1

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -5,10 +5,13 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from xtuner.v1.data_proto.rl_data import Status
+import ray
+import torch
+
+from xtuner.v1.data_proto.rl_data import RolloutState, Status
 from xtuner.v1.rl.agent_loop_manager import AsyncProduceStrategyConfig, ProduceBatchResult
 from xtuner.v1.rl.agent_loop_manager.agent_loop_manager import AgentLoopManager, _TaskRunner
-from xtuner.v1.rl.replay_buffer import AsyncReplayBufferConfig
+from xtuner.v1.rl.replay_buffer import AsyncReplayBufferConfig, SerializedRayObjectRef
 from xtuner.v1.train.rl_trainer import RLColocateTrainer
 
 
@@ -83,6 +86,8 @@ class TestRLColocateTrainer(unittest.TestCase):
         trainer.train_batch_size = 1
         trainer._sync_weights_interval = sync_weights_interval
         trainer._debug_rollout = False
+        trainer._debug_rollout_dir = None
+        trainer._debug_train = False
         trainer._enable_evaluate = False
         trainer._enable_initial_evaluate = False
         trainer._evaluate_step = 1
@@ -207,6 +212,112 @@ class TestRLColocateTrainer(unittest.TestCase):
             [1, 2, 3],
         )
         self.assertEqual(trainer._cur_step, 3)
+
+    def test_debug_rollout_saves_raw_batch_and_skips_training(self):
+        rollout_state = RolloutState(
+            message=[{"role": "user", "content": "hello"}],
+            response="ok",
+            response_ids=[1, 2],
+            reward={"score": 1.0},
+            status=Status.COMPLETED,
+        )
+
+        async def _produce_batch(batch_size, train_step, *, model_step):
+            return ProduceBatchResult(rollout_states=[[rollout_state]])
+
+        trainer = self._make_trainer(SimpleNamespace(produce_batch=_produce_batch))
+        trainer._debug_rollout = True
+        trainer._debug_rollout_dir = Path(self.temp_dir.name) / "debug_rollout"
+
+        with (
+            patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
+        ):
+            trainer.fit()
+
+        saved_path = trainer._debug_rollout_dir / "debug_rollout_1.pt"
+        self.assertTrue(saved_path.exists())
+        saved_batch = torch.load(saved_path, map_location="cpu", weights_only=False)
+        self.assertEqual(saved_batch[0][0].response, "ok")
+        trainer.train_controller.fit.assert_not_called()
+        trainer._sync_weights_and_save.assert_not_called()
+
+    def test_debug_train_loads_batches_and_skips_weight_sync(self):
+        trainer = self._make_trainer(MagicMock(), total_train_steps=2)
+        trainer._debug_train = True
+        trainer._load_debug_rollout_batch = MagicMock(
+            side_effect=[
+                [[SimpleNamespace(uid=1, message_uid=1)]],
+                [[SimpleNamespace(uid=2, message_uid=2)]],
+            ]
+        )
+        trainer._train_one_batch = MagicMock(
+            return_value={
+                "data_info": {"batch_size": 1},
+                "workers_log_item": [
+                    {
+                        "rollout_is_metrics": {},
+                        "mismatch_metrics": {},
+                        "rollout_entropy": 0.0,
+                        "train_entropy": 0.0,
+                        "train_metrics": [],
+                        "sft_train_metrics": {},
+                    }
+                ],
+            }
+        )
+
+        trainer.fit()
+
+        self.assertEqual([call.args[0] for call in trainer._load_debug_rollout_batch.call_args_list], [1, 2])
+        self.assertEqual(trainer._train_one_batch.call_count, 2)
+        trainer._sync_weights_and_save.assert_not_called()
+        self.assertEqual(trainer._cur_step, 2)
+
+    def test_debug_rollout_save_resolves_object_refs_and_load_puts_them_back(self):
+        if not ray.is_initialized():
+            try:
+                ray.init(local_mode=True, ignore_reinit_error=True, include_dashboard=False)
+            except Exception as exc:
+                self.skipTest(f"Ray init failed in this test environment: {exc}")
+        try:
+            pixel_values = torch.ones(1, 2)
+            routed_experts = [1, 2, 3]
+            rollout_state = RolloutState(
+                message=[{"role": "user", "content": "hello"}],
+                mm_info={"pixel_values": ray.put(pixel_values)},
+                routed_experts=ray.put(routed_experts),
+                response="ok",
+                response_ids=[1],
+                reward={"score": 1.0},
+                status=Status.COMPLETED,
+            )
+            trainer = self._make_trainer(MagicMock())
+            trainer._debug_rollout_dir = Path(self.temp_dir.name) / "debug_refs"
+            trainer._save_debug_rollout_batch([[rollout_state]], train_step=1)
+
+            saved_batch = torch.load(
+                trainer._debug_rollout_dir / "debug_rollout_1.pt",
+                map_location="cpu",
+                weights_only=False,
+            )
+            saved_pixel_values = saved_batch[0][0].mm_info["pixel_values"]
+            saved_routed_experts = saved_batch[0][0].routed_experts
+            self.assertFalse(isinstance(saved_pixel_values, ray.ObjectRef))
+            self.assertFalse(isinstance(saved_routed_experts, ray.ObjectRef))
+            self.assertIsInstance(saved_pixel_values, SerializedRayObjectRef)
+            self.assertIsInstance(saved_routed_experts, SerializedRayObjectRef)
+            self.assertTrue(torch.equal(saved_pixel_values.value, pixel_values))
+            self.assertEqual(saved_routed_experts.value, routed_experts)
+
+            trainer._debug_train_files = {1: trainer._debug_rollout_dir / "debug_rollout_1.pt"}
+            loaded_batch = trainer._load_debug_rollout_batch(train_step=1)
+            self.assertIsInstance(loaded_batch[0][0].mm_info["pixel_values"], ray.ObjectRef)
+            self.assertIsInstance(loaded_batch[0][0].routed_experts, ray.ObjectRef)
+            self.assertTrue(torch.equal(ray.get(loaded_batch[0][0].mm_info["pixel_values"]), pixel_values))
+            self.assertEqual(ray.get(loaded_batch[0][0].routed_experts), routed_experts)
+        finally:
+            ray.shutdown()
 
     def test_sync_weights_and_save_can_skip_weight_update_and_restore_rollout(self):
         trainer = RLColocateTrainer.__new__(RLColocateTrainer)

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import re
 from pathlib import Path
 from shutil import rmtree
 from typing import Any, List, cast
@@ -26,7 +27,12 @@ from xtuner.v1.rl.agent_loop_manager import (
 from xtuner.v1.rl.agent_loop_manager.producer import default_should_continue_fn
 from xtuner.v1.rl.evaluator import EvaluatorConfig
 from xtuner.v1.rl.gateway.config import GatewayConfig
-from xtuner.v1.rl.replay_buffer import AsyncReplayBufferConfig, SyncReplayBufferConfig
+from xtuner.v1.rl.replay_buffer import (
+    AsyncReplayBufferConfig,
+    SyncReplayBufferConfig,
+    _restore_nested_objectrefs,
+    _snapshot_nested_objectrefs,
+)
 from xtuner.v1.rl.rollout.controller import RolloutControllerProxy
 from xtuner.v1.rl.rollout.worker import RolloutConfig
 from xtuner.v1.rl.trainer.controller import TrainingController
@@ -69,6 +75,13 @@ def bind_train_rollout(
     info_dict = ray.get(rollout_controller.get_rollout_metadata.remote())  # type: ignore[attr-defined]
     train_controller.update_rollout_info(info_dict)
     return
+
+
+def _parse_debug_rollout_step(path: Path) -> int:
+    match = re.fullmatch(r"debug_rollout_(\d+)\.pt", path.name)
+    if match is None:
+        raise ValueError(f"Unexpected debug rollout file name: {path}")
+    return int(match.group(1))
 
 
 class TrainInfo(TypedDict, total=False):
@@ -210,12 +223,20 @@ class BaseRLTrainerConfig(BaseModel):
     log_dir: Path | str | None = None
     seed: int = 66
     debug_rollout: bool = False
+    debug_rollout_dir: Path | str | None = None
+    debug_train: bool = False
     skip_checkpoint_validation: bool = False
     exp_tracker: Literal["tensorboard", "jsonl"] = "tensorboard"
 
     @model_validator(mode="after")
     def _validate_sync_intervals(self):
-        if self.total_train_steps is None and self.total_epochs is None:
+        if self.debug_rollout and self.debug_train:
+            raise ValueError("debug_rollout and debug_train cannot be enabled at the same time.")
+        if self.debug_rollout and self.debug_rollout_dir is None:
+            raise ValueError("debug_rollout_dir must be provided when debug_rollout=True.")
+        if self.debug_train and self.debug_rollout_dir is None:
+            raise ValueError("debug_rollout_dir must be provided when debug_train=True.")
+        if not self.debug_train and self.total_train_steps is None and self.total_epochs is None:
             raise ValueError("Either total_train_steps or total_epochs must be provided.")
         if self.total_train_steps is not None and self.total_train_steps <= 0:
             raise ValueError(f"total_train_steps must be positive, got {self.total_train_steps}.")
@@ -254,6 +275,7 @@ class BaseRLTrainer:
 
     train_controller: TrainingController
     rollout_controller: RolloutControllerProxy
+    _debug_train_files: dict[int, Path]
 
     def _init_common(self, cfg: BaseRLTrainerConfig, *, meta_path: str, logger_tag: str) -> None:
         check_fa3()
@@ -334,6 +356,9 @@ class BaseRLTrainer:
         self._enable_initial_evaluate = cfg.enable_initial_evaluate and cfg.enable_evaluate
         self._evaluate_step = cfg.evaluate_step
         self._debug_rollout = cfg.debug_rollout
+        self._debug_rollout_dir = Path(cfg.debug_rollout_dir) if cfg.debug_rollout_dir is not None else None
+        self._debug_train = cfg.debug_train
+        self._debug_train_files: dict[int, Path] = {}
 
     def _maybe_start_gateway(self, cfg: BaseRLTrainerConfig) -> None:
         if cfg.gateway_config is None or not cfg.gateway_config.auto_start:
@@ -568,6 +593,38 @@ class BaseRLTrainer:
         self._save_trajectories(eval_batch, eval_trajectory_path)
         self.logger.info(f"Train step {train_step} eval trajectories saved to {eval_trajectory_path}")
         return eval_metrics
+
+    def _save_debug_rollout_batch(self, train_batch: list[list[RolloutState]], train_step: int) -> None:
+        assert self._debug_rollout_dir is not None
+        self._debug_rollout_dir.mkdir(parents=True, exist_ok=True)
+        save_path = self._debug_rollout_dir / f"debug_rollout_{train_step}.pt"
+        serializable_batch = [
+            [cast(RolloutState, _snapshot_nested_objectrefs(rollout_state)) for rollout_state in group]
+            for group in train_batch
+        ]
+        torch.save(serializable_batch, save_path)
+        self.logger.info(f"Debug rollout batch for step {train_step} saved to {save_path}")
+
+    def _list_debug_rollout_files(self, debug_rollout_dir: Path) -> dict[int, Path]:
+        debug_files = {
+            _parse_debug_rollout_step(path): path
+            for path in sorted(debug_rollout_dir.glob("debug_rollout_*.pt"), key=_parse_debug_rollout_step)
+        }
+        if not debug_files:
+            raise FileNotFoundError(f"No debug rollout files found in {debug_rollout_dir}")
+        return debug_files
+
+    def _load_debug_rollout_batch(self, train_step: int) -> list[list[RolloutState]]:
+        debug_file = self._debug_train_files.get(train_step)
+        if debug_file is None:
+            raise FileNotFoundError(f"No debug rollout file found for train step {train_step}")
+        train_batch = torch.load(debug_file, map_location="cpu", weights_only=False)
+        train_batch = [
+            [cast(RolloutState, _restore_nested_objectrefs(rollout_state)) for rollout_state in group]
+            for group in train_batch
+        ]
+        self.logger.info(f"Loaded debug rollout batch for step {train_step} from {debug_file}")
+        return cast(list[list[RolloutState]], train_batch)
 
     # TODO: simplify with Packer.pack_pad_dispatch()
     def _prepare_train_data(
@@ -875,11 +932,37 @@ class RLColocateTrainer(BaseRLTrainer):
         self._init_common(cfg, meta_path=self._META_PATH, logger_tag="RLTrainer")
 
         self._pg = AutoAcceleratorWorkers.build_placement_group(cfg.resources)
+
+        if self._debug_rollout:
+            if self._rollout_config.skip_load_weights:
+                self.logger.info(
+                    "debug_rollout cannot be used with rollout_config.skip_load_weights=True. force set skip_load_weights to False"
+                )
+                self._rollout_config.skip_load_weights = False
+            self.rollout_controller = self._rollout_config.build(self._pg)
+            self._maybe_start_gateway(cfg)
+            replay_buffer = cfg.replay_buffer_config.build()
+            self._build_agent_loop_components(cfg, replay_buffer)
+            self.logger.warning("Debug rollout mode is enabled. Only rollout workers will be started.")
+            return
+
         self.train_controller = self._train_worker_cfg.build(self._pg)
 
         checkpoint_path = self._load_checkpoint_cfg.checkpoint_path
         if checkpoint_path is not None:
             checkpoint_path = self._resume_train_controller_and_state(checkpoint_path)
+
+        if self._debug_train:
+            assert self._debug_rollout_dir is not None
+            self.tokenizer = AutoTokenizer.from_pretrained(cfg.tokenizer_path, trust_remote_code=True)
+            self._debug_train_files = self._list_debug_rollout_files(self._debug_rollout_dir)
+            if cfg.total_train_steps is None:
+                self._total_train_steps = max(self._debug_train_files)
+            self.logger.warning(
+                "Debug train mode is enabled. Only training workers will be started and rollout weights will not be synchronized."
+            )
+            return
+
         # Free trainer-side GPU memory before bringing up colocated rollout workers.
         # Backends like sglang may size KV cache against their own target utilization
         # instead of the trainer's transient footprint, which can cause init-time OOM.
@@ -897,9 +980,6 @@ class RLColocateTrainer(BaseRLTrainer):
         if self._rollout_config.skip_load_weights:
             self._sync_weights_from_train_workers()
 
-        if self._debug_rollout:
-            self.logger.warning("Debug rollout mode is enabled, rollout will not be offloaded.")
-
     def _sync_weights_from_train_workers(self) -> None:
         self.logger.info("Rollout workers skip load weights, update weights from train workers.")
         ray.get(self.rollout_controller.offload.remote())
@@ -914,6 +994,10 @@ class RLColocateTrainer(BaseRLTrainer):
         self.logger.info("Start RL training")
         if self._cur_step >= self._total_train_steps:
             self.logger.info(f"Train steps {self._total_train_steps} reached, stop training")
+            return
+
+        if self._debug_train:
+            self._fit_debug_train()
             return
 
         if self._enable_initial_evaluate and not self._debug_rollout:
@@ -964,8 +1048,30 @@ class RLColocateTrainer(BaseRLTrainer):
                         with timer("evaluation", step_timer_dict):
                             eval_log_info.update(asyncio_run(self._run_evaluation(train_step)))
                 else:
+                    self._save_debug_rollout_batch(train_batch, train_step)
                     train_log_info = {}
                     eval_log_info = {}
+
+            self._log_step(train_step, step_timer_dict, produce_result, train_log_info, eval_log_info)
+            self._cur_step = train_step
+
+    def _fit_debug_train(self) -> None:
+        init_train_step = self._cur_step + 1
+        for train_step in range(init_train_step, self._total_train_steps + 1):
+            self.logger.info(f"Debug train step {train_step}/{self._total_train_steps} start")
+            step_timer_dict: dict[str, float] = {}
+            with timer("step", step_timer_dict):
+                with timer("load_debug_rollout", step_timer_dict):
+                    train_batch = self._load_debug_rollout_batch(train_step)
+                train_log_info = self._train_one_batch(
+                    train_batch,
+                    train_step,
+                    step_timer_dict,
+                    offload_rollout_before_train=False,
+                    onload_train_before_train=False,
+                )
+                eval_log_info: dict[str, float] = {}
+                produce_result = ProduceBatchResult(rollout_states=train_batch)
 
             self._log_step(train_step, step_timer_dict, produce_result, train_log_info, eval_log_info)
             self._cur_step = train_step
@@ -1028,11 +1134,6 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
 
         if self._load_checkpoint_cfg.checkpoint_path is not None:
             self._resume_from_checkpoint(self._load_checkpoint_cfg.checkpoint_path)
-
-        if self._debug_rollout:
-            self.logger.warning(
-                "Debug rollout mode is enabled. Disaggregated training keeps rollout workers resident."
-            )
 
     def _build_disaggregated_placement_groups(
         self,

--- a/xtuner/v1/utils/track_rl_mem.py
+++ b/xtuner/v1/utils/track_rl_mem.py
@@ -137,10 +137,9 @@ def _format_memory_info_for_console(memory_info: dict) -> str:
     lines = [
         f"[RL_MEM] time={formatted.get('time', '')}",
         f"[RL_MEM] node_id={formatted.get('node_id', '')}",
-        f"[RL_MEM] rollout_gpu_by_device_gb={formatted.get('rollout_gpu_by_device_gb', [])}",
     ]
     for actor_name, actor_info in formatted.items():
-        if actor_name in {"time", "node_id", "rollout_gpu_by_device_gb"}:
+        if actor_name in {"time", "node_id"}:
             continue
         if not isinstance(actor_info, dict):
             continue
@@ -177,14 +176,6 @@ def monitor_actor_memory(work_dir: str, interval: int = 60):
 
     print(f"当前节点 GPU 数量: {local_gpus}")
     tb_writer_list = [TensorboardWriter(log_dir=f"{work_dir}/tb/{rank}") for rank in range(max(local_gpus, 1))]
-    rollout_related_actor_names = {
-        "LMDeployWorker",
-        "SGLangWorker",
-        "vLLMWorker",
-        "LMDeployServerProcess",
-        "RayWorkerWrapper",
-        "RayEngineWorker",
-    }
 
     count = 0
     try:
@@ -193,7 +184,6 @@ def monitor_actor_memory(work_dir: str, interval: int = 60):
             memory_info = {}
             pid_to_gpu_memory_gb, pid_to_gpu_memory_by_device_gb = _collect_local_gpu_memory_by_pid_gb()
             unmatched_actor_pid_samples: list[tuple[int, int | None]] = []
-            rollout_gpu_by_device_gb = [0.0 for _ in range(local_gpus)]
 
             # Only collect actors on this node. Ray actor metadata is cluster-wide,
             # while psutil and NVML can only query local processes and GPUs.
@@ -240,10 +230,6 @@ def monitor_actor_memory(work_dir: str, interval: int = 60):
                     except (psutil.NoSuchProcess, psutil.AccessDenied):
                         pass
 
-                if actor_name in rollout_related_actor_names:
-                    for device_idx, device_mem_gb in enumerate(gpu_memory_by_device):
-                        rollout_gpu_by_device_gb[device_idx] += device_mem_gb
-
                 memory_gb = _round_gb(memory_gb)  # type: ignore
                 gpu_memory_gb = _round_gb(gpu_memory_gb)  # type: ignore
 
@@ -258,17 +244,13 @@ def monitor_actor_memory(work_dir: str, interval: int = 60):
                         "gpu_mem_gb": [gpu_memory_gb],
                     }
 
-            rollout_gpu_by_device_gb = [_round_gb(v) for v in rollout_gpu_by_device_gb]
-            memory_info["rollout_gpu_by_device_gb"] = rollout_gpu_by_device_gb  # type: ignore
-
             # 写入文件
             json.dump(memory_info, f, ensure_ascii=False)
             f.write("\n")
             f.flush()
 
             if pid_to_gpu_memory_gb and all(
-                actor_name in ["time", "node_id", "rollout_gpu_by_device_gb"]
-                or max(memory_mb_info.get("gpu_mem_gb", [0.0])) <= 0.0  # type: ignore
+                actor_name in ["time", "node_id"] or max(memory_mb_info.get("gpu_mem_gb", [0.0])) <= 0.0  # type: ignore
                 for actor_name, memory_mb_info in memory_info.items()
             ):
                 sample_gpu_pids = list(pid_to_gpu_memory_gb.items())[:10]
@@ -277,15 +259,8 @@ def monitor_actor_memory(work_dir: str, interval: int = 60):
                     f"sample_gpu_pid_mem={sample_gpu_pids}, sample_actor_pid_ngid={unmatched_actor_pid_samples}"
                 )
 
-            for device_idx, device_gpu_gb in enumerate(rollout_gpu_by_device_gb):
-                tb_writer_list[0].add_scalar(
-                    tag=f"rollout/gpu_device_{device_idx}_gb",
-                    scalar_value=_round_gb(device_gpu_gb),
-                    global_step=count,
-                )
-
             for actor_name, memory_mb_info in memory_info.items():
-                if actor_name in ["time", "node_id", "rollout_gpu_by_device_gb"]:
+                if actor_name in ["time", "node_id"]:
                     continue
                 memory_mb: list[float] = memory_mb_info["mem_gb"]  # type: ignore
                 gpu_memory_mb: list[float] = memory_mb_info["gpu_mem_gb"]  # type: ignore


### PR DESCRIPTION
- 支持指定 debug_rollout_dir 和 debug_rollout 和 debug_train 来快速 debug
- 由于分离式非共卡方案不成熟，因此分离式非共卡方案没有支持 debug 功能
- 内存监控移除 rollout 相关的 gpu 显存监控，实测发现因为 lmdeploy 内部特点，通过 ray.actor 监控的 gpu pid 是不稳定的

```python
trainer = RLColocateTrainerConfig(
    ...
    debug_rollout_dir=debug_rollout_dir,
    debug_train=debug_train,
    debug_rollout=debug_rollout,
)
```
