### PR TITLE
[Draft] Eliminate centralized generation

### DIFF
--- a/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
+++ b/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
@@ -42,7 +42,7 @@ enable_evaluate = eval_data_path is not None and eval_data_path != ""
 # basic settings
 experimental_name = "grpo_mix_data"
 total_epochs = 15
-global_batch_size = 64
+global_batch_size = 256
 prompt_repeat_k = 8
 rollout_tp_size = 2
 rollout_ep_size = 1

--- a/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
+++ b/examples/v1/config/rl_qwen3p5_vl_35B_grpo_mixdata.py
@@ -15,6 +15,7 @@ from xtuner.v1.rl.evaluator import EvaluatorConfig
 from xtuner.v1.rl.judger import DapoMathJudgerConfig
 from xtuner.v1.rl.loss import GRPOLossConfig
 from xtuner.v1.rl.replay_buffer import SyncReplayBufferConfig
+from xtuner.v1.rl.rollout import RolloutEndpointConfig
 from xtuner.v1.rl.rollout.worker import RolloutConfig
 from xtuner.v1.rl.trainer import RolloutImportanceSampling, WorkerConfig
 from xtuner.v1.rl.utils import AcceleratorResourcesConfig, get_eos_token
@@ -34,13 +35,14 @@ eval_media_root = os.environ.get("EVAL_MEDIA_ROOT", "")
 debug_rollout_dir = os.environ.get("DEBUG_ROLLOUT_DIR", "")
 debug_train = os.environ.get("DEBUG_TRAIN", False)
 debug_rollout = os.environ.get("DEBUG_ROLLOUT", False)
+rollout_endpoint_mode = os.environ.get("ROLLOUT_ENDPOINT_MODE", "1")
 
 enable_evaluate = eval_data_path is not None and eval_data_path != ""
 
 # basic settings
 experimental_name = "grpo_mix_data"
 total_epochs = 15
-global_batch_size = 256
+global_batch_size = 64
 prompt_repeat_k = 8
 rollout_tp_size = 2
 rollout_ep_size = 1
@@ -71,6 +73,27 @@ rollout_config = RolloutConfig(
     context_length=max_response_length + max_prompt_length,
     enable_return_routed_experts=True,
     rollout_max_batch_size_per_instance=512,
+)
+
+rollout_endpoint_kind_map = {
+    "1": "worker_local",
+    "2": "worker_http",
+    "3": "worker_extern",
+}
+if rollout_endpoint_mode not in rollout_endpoint_kind_map:
+    raise ValueError("ROLLOUT_ENDPOINT_MODE must be one of: 1, 2, 3.")
+
+# Mode 1 (worker_local): AgentLoop holds a WorkerLocalRouter object and calls worker Ray actors directly.
+# Mode 2 (worker_http): trainer starts WorkerHttpRouter after rollout workers are ready, and AgentLoop gets its
+# runtime URL from rollout_controller metadata.
+# Mode 3 (worker_extern): AgentLoop uses WORKER_EXTERN_ROUTER_URL, while WorkerExternRouter periodically
+# registers/removes rollout worker URLs to/from that external router.
+rollout_endpoint_config = RolloutEndpointConfig(
+    kind=rollout_endpoint_kind_map[rollout_endpoint_mode],
+    base_url=os.environ.get("WORKER_EXTERN_ROUTER_URL") if rollout_endpoint_mode == "3" else None,
+    worker_http_router_host=os.environ.get("WORKER_HTTP_ROUTER_HOST", "0.0.0.0"),
+    worker_http_router_port=int(os.environ.get("WORKER_HTTP_ROUTER_PORT", "8081")),
+    worker_extern_router_worker_api_key=os.environ.get("ROLLOUT_WORKER_API_KEY") or None,
 )
 
 # sampling params
@@ -263,4 +286,5 @@ trainer = RLColocateTrainerConfig(
     debug_rollout_dir=debug_rollout_dir,
     debug_train=debug_train,
     debug_rollout=debug_rollout,
+    rollout_endpoint_config=rollout_endpoint_config,
 )

--- a/tests/rl/test_agent_loop.py
+++ b/tests/rl/test_agent_loop.py
@@ -15,7 +15,7 @@ from xtuner.v1.rl.agent_loop_manager import (
     TaskSpecConfig,
 )
 from xtuner.v1.data_proto.rl_data import RolloutState, Status, SampleParams
-from xtuner.v1.rl.rollout import RolloutController
+from xtuner.v1.rl.rollout import RolloutController, RolloutEndpointConfig
 from xtuner.v1.rl.judger.gsm8k import GSM8KJudgerConfig
 from xtuner.v1.rl.replay_buffer import SyncReplayBufferConfig
 from xtuner.v1.datasets.config import DataloaderConfig, DatasetConfig
@@ -96,7 +96,7 @@ class TestAgentLoop(unittest.IsolatedAsyncioTestCase):
         rollout_controller = ray.remote(RolloutController).remote(rollout_config, pg)
         # 3. 创建 AgentLoop
         agent_loop = agent_loop_cfg.build(
-            rollout_controller=rollout_controller,
+            rollout_endpoint=RolloutEndpointConfig().build(rollout_controller),
             judger=judger_config.build(),
         )
         # 4. 构造输入数据
@@ -143,7 +143,7 @@ class TestAgentLoop(unittest.IsolatedAsyncioTestCase):
         pg = AutoAcceleratorWorkers.build_placement_group(self.resources_cfg)
         rollout_controller = ray.remote(RolloutController).remote(rollout_config, pg)
         agent_loop = agent_loop_cfg.build(
-            rollout_controller=rollout_controller,
+            rollout_endpoint=RolloutEndpointConfig().build(rollout_controller),
             judger=judger_config.build(),
         )
 
@@ -215,7 +215,7 @@ class TestAgentLoop(unittest.IsolatedAsyncioTestCase):
         replay_buffer_cfg = SyncReplayBufferConfig()
         replay_buffer = replay_buffer_cfg.build()
         agent_loop_manager = agent_loop_manager_cfg.build(
-            rollout_controller=rollout_controller,
+            rollout_endpoint=RolloutEndpointConfig().build(rollout_controller),
             tokenizer=self.tokenizer,
             replay_buffer=replay_buffer,
         )

--- a/tests/rl/test_agent_loop_utils.py
+++ b/tests/rl/test_agent_loop_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status, refresh_seq_staleness
 from xtuner.v1.rl.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
 from xtuner.v1.rl.agent_loop.utils import PartialRolloutHandler
+from xtuner.v1.rl.rollout import RolloutEndpoint
 
 
 def _make_rollout_state(
@@ -70,14 +71,20 @@ class TestAgentLoopUtils(unittest.TestCase):
 
 class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
     def _build_agent_loop(self):
-        rollout_ctl = MagicMock()
-        rollout_ctl.generate.remote = AsyncMock()
+        worker_local_router = MagicMock()
+        worker_local_router.rollout_controller = MagicMock()
+        worker_local_router.generate = AsyncMock()
+        rollout_endpoint = RolloutEndpoint(
+            kind="worker_local",
+            worker_local_router=worker_local_router,
+            rollout_controller=worker_local_router.rollout_controller,
+        )
         with (
             patch("xtuner.v1.rl.agent_loop.agent_loop.load_tokenizer", return_value=MagicMock()),
             patch("xtuner.v1.rl.agent_loop.agent_loop.load_processor", return_value=MagicMock()),
         ):
             return SingleTurnAgentLoop(
-                rollout_ctl=rollout_ctl,
+                rollout_endpoint=rollout_endpoint,
                 sample_params=SampleParams(max_tokens=8),
                 hf_checkpoint="dummy",
                 judger=None,
@@ -88,7 +95,7 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
         agent_loop = self._build_agent_loop()
         rollout_state = _make_rollout_state(response_ids=[], status=Status.ABORTED)
         generated_state = _make_rollout_state(response_ids=[30, 31], seq_staleness=7, status=Status.ABORTED)
-        agent_loop.rollout_ctl.generate.remote.return_value = generated_state
+        agent_loop.rollout_endpoint.require_worker_local_router().generate.return_value = generated_state
 
         result = await agent_loop.generate_sample(
             rollout_state,
@@ -101,7 +108,7 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
         agent_loop = self._build_agent_loop()
         rollout_state = _make_rollout_state(response_ids=[], status=Status.ABORTED)
         generated_state = _make_rollout_state(response_ids=[30, 31], status=Status.ABORTED)
-        agent_loop.rollout_ctl.generate.remote.return_value = generated_state
+        agent_loop.rollout_endpoint.require_worker_local_router().generate.return_value = generated_state
 
         result = await agent_loop.generate_sample(rollout_state)
 
@@ -112,7 +119,7 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
         agent_loop = self._build_agent_loop()
         rollout_state = _make_rollout_state(response_ids=[], status=Status.ABORTED)
         generated_state = _make_rollout_state(response_ids=[30, 31], status=Status.ABORTED)
-        agent_loop.rollout_ctl.generate.remote.return_value = generated_state
+        agent_loop.rollout_endpoint.require_worker_local_router().generate.return_value = generated_state
 
         result = await agent_loop.generate_sample(rollout_state)
 

--- a/tests/rl/test_async_rollout.py
+++ b/tests/rl/test_async_rollout.py
@@ -19,7 +19,7 @@ from xtuner.v1.rl.agent_loop_manager import (
     TaskSpecConfig,
 )
 from xtuner.v1.rl.replay_buffer import AsyncReplayBufferConfig
-from xtuner.v1.rl.rollout import RolloutController
+from xtuner.v1.rl.rollout import RolloutController, RolloutEndpointConfig
 from xtuner.v1.rl.rollout.worker import RolloutConfig
 from xtuner.v1.rl.utils import AcceleratorResourcesConfig, AutoAcceleratorWorkers
 
@@ -117,7 +117,7 @@ def _build_agent_loop_manager(
         ],
     )
     manager = manager_cfg.build(
-        rollout_controller=rollout_ctl,
+        rollout_endpoint=RolloutEndpointConfig().build(rollout_ctl),
         tokenizer=tokenizer,
         replay_buffer=replay_buffer,
         logger=None,

--- a/tests/rl/test_multi_task_agent_loop_manager.py
+++ b/tests/rl/test_multi_task_agent_loop_manager.py
@@ -14,6 +14,7 @@ from xtuner.v1.rl.agent_loop_manager.agent_loop_manager import (
     _TaskRunner,
 )
 from xtuner.v1.rl.agent_loop_manager.producer import GROUP_GENERATE_TIME_KEY, ProduceBatchStatus
+from xtuner.v1.rl.rollout import RolloutEndpoint
 from xtuner.v1.rl.utils import calculate_seq_staleness
 
 
@@ -234,13 +235,16 @@ class _SequencedCompletedReplayBuffer(_FakeReplayBuffer):
 
 
 def _fake_agent_loop():
-    rollout_ctl = MagicMock()
-    rollout_ctl.continue_generation.remote = AsyncMock()
-    rollout_ctl.pause_generation.remote = AsyncMock()
-    rollout_ctl.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
     agent_loop = MagicMock()
-    agent_loop.rollout_ctl = rollout_ctl
     return agent_loop
+
+
+def _fake_rollout_endpoint():
+    rollout_controller = MagicMock()
+    rollout_controller.continue_generation.remote = AsyncMock()
+    rollout_controller.pause_generation.remote = AsyncMock()
+    rollout_controller.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
+    return RolloutEndpoint(kind="worker_extern", base_url="http://rollout-router", rollout_controller=rollout_controller)
 
 
 class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
@@ -282,6 +286,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         )
 
         multi_task_manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_b",
@@ -346,6 +351,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         sampler = _FakeSampler()
         replay_buffer = _FakeReplayBuffer({}, {})
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -396,6 +402,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         strategy = _FakeProduceStrategy()
         strategy.pending_task_count_value = 1
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -430,6 +437,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
                 return {"task_a": 0, "task_b": global_batch_size}
 
         multi_task_manager = _CustomBatchManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -472,6 +480,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         )
 
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -507,6 +516,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
 
     async def test_produce_batch_requires_non_empty_rollout_states(self):
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -526,6 +536,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
     async def test_pause_produce_from_async_produce_loop_sets_status_and_pause_time(self):
         strategy = _FakeProduceStrategy(cleanup_pause_time_s=2.5)
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -553,6 +564,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
     async def test_pause_produce_validates_progress_selection_before_state_change(self):
         strategy = _FakeProduceStrategy(cleanup_pause_time_s=2.5)
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -579,6 +591,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_batch_returns_expired_batch_when_manager_is_expired(self):
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -606,6 +619,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
             leftover_counts={("task_a", Status.COMPLETED): 1},
         )
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -643,6 +657,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
             },
         )
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -667,6 +682,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
 
     async def test_produce_batch_to_buffer_aggregates_status_with_update_abort_priority(self):
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -715,6 +731,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
             statuses=[ProduceBatchStatus.NORMAL, ProduceBatchStatus.EXPIRED_BATCH, ProduceBatchStatus.NORMAL],
         )
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",
@@ -746,6 +763,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
 
     async def test_shutdown_sets_finish_signals(self):
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="task_a",

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -62,9 +62,9 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
 
     def _build_agent_loop(self, sleep_by_id: dict[int, float] | None = None):
         mock_agent_loop = MagicMock()
-        mock_agent_loop.rollout_ctl.continue_generation.remote = AsyncMock(return_value=None)
-        mock_agent_loop.rollout_ctl.pause_generation.remote = AsyncMock(return_value=None)
-        mock_agent_loop.rollout_ctl.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
+        mock_agent_loop.rollout_controller.continue_generation.remote = AsyncMock(return_value=None)
+        mock_agent_loop.rollout_controller.pause_generation.remote = AsyncMock(return_value=None)
+        mock_agent_loop.rollout_controller.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
 
         sleep_by_id = sleep_by_id or {}
 
@@ -98,6 +98,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             update_event = asyncio.Event()
         return ProduceContext(
             agent_loop=agent_loop,
+            rollout_controller=getattr(agent_loop, "rollout_controller", MagicMock()),
             sampler=sampler,
             replay_buffer=self.replay_buffer,
             task_batch_size=batch_size,
@@ -310,7 +311,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         # 异步的其他功能如 partial_rollout, tail_batch不在这里进行验证
         mock_agent_loop = MagicMock()
         mock_agent_loop.pause = AsyncMock()
-        mock_agent_loop.rollout_ctl.continue_generation.remote = AsyncMock(return_value=None)
+        mock_agent_loop.rollout_controller.continue_generation.remote = AsyncMock(return_value=None)
         task_name = "test_task"
         call_count = 0
         async def mock_gen(rs, **kwargs):

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -12,6 +12,7 @@ from xtuner.v1.data_proto.rl_data import RolloutState, Status
 from xtuner.v1.rl.agent_loop_manager import AsyncProduceStrategyConfig, ProduceBatchResult
 from xtuner.v1.rl.agent_loop_manager.agent_loop_manager import AgentLoopManager, _TaskRunner
 from xtuner.v1.rl.replay_buffer import AsyncReplayBufferConfig, SerializedRayObjectRef
+from xtuner.v1.rl.rollout import RolloutEndpoint
 from xtuner.v1.train.rl_trainer import RLColocateTrainer
 
 
@@ -49,12 +50,7 @@ class _FakeSampler:
 
 
 def _build_fake_agent_loop():
-    rollout_ctl = MagicMock()
-    rollout_ctl.continue_generation.remote = AsyncMock(return_value=None)
-    rollout_ctl.pause_generation.remote = AsyncMock(return_value=None)
-    rollout_ctl.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
     agent_loop = MagicMock()
-    agent_loop.rollout_ctl = rollout_ctl
 
     async def generate_group(rollout_states, **kwargs):
         model_step = kwargs.get("model_step", kwargs.get("train_step", 0))
@@ -68,6 +64,14 @@ def _build_fake_agent_loop():
 
     agent_loop.generate_group = generate_group
     return agent_loop
+
+
+def _fake_rollout_endpoint():
+    rollout_controller = MagicMock()
+    rollout_controller.continue_generation.remote = AsyncMock(return_value=None)
+    rollout_controller.pause_generation.remote = AsyncMock(return_value=None)
+    rollout_controller.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
+    return RolloutEndpoint(kind="worker_extern", base_url="http://rollout-router", rollout_controller=rollout_controller)
 
 
 class TestRLColocateTrainer(unittest.TestCase):
@@ -134,6 +138,7 @@ class TestRLColocateTrainer(unittest.TestCase):
     def test_fit_accepts_async_strategy_manager_on_colocate_path(self):
         replay_buffer = AsyncReplayBufferConfig().build()
         manager = AgentLoopManager(
+            rollout_endpoint=_fake_rollout_endpoint(),
             task_runners=[
                 _TaskRunner(
                     task_name="train_task",

--- a/xtuner/v1/rl/agent_loop/__init__.py
+++ b/xtuner/v1/rl/agent_loop/__init__.py
@@ -6,7 +6,6 @@ from .agent_loop import (
     RayAgentLoop,
     RayAgentLoopProxy,
     RouterAgentLoop,
-    get_agent_loop_rollout_ctl,
 )
 from .single_turn_agent_loop import SingleTurnAgentLoop, SingleTurnAgentLoopConfig
 
@@ -21,5 +20,4 @@ __all__ = [
     "RayAgentLoop",
     "RayAgentLoopProxy",
     "SingleTurnAgentLoop",
-    "get_agent_loop_rollout_ctl",
 ]

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -10,7 +10,7 @@ from ray.util.placement_group import PlacementGroup
 
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams
 from xtuner.v1.rl.judger import Judger
-from xtuner.v1.rl.rollout import RolloutController
+from xtuner.v1.rl.rollout import RolloutEndpoint
 from xtuner.v1.rl.utils import CPUActorLauncher, create_task
 from xtuner.v1.utils import get_logger, ray_method
 from xtuner.v1.utils.processing_utils import load_processor, load_tokenizer
@@ -35,21 +35,26 @@ class AgentLoopConfig(ABC, BaseModel):
             logger.warning("num_cpus and cpu_memory are ignored when AgentLoop runs in local mode.")
         return self
 
-    def build(self, rollout_controller, judger: Judger | None = None, logger=None) -> AgentLoopSpec:
+    def build(
+        self,
+        rollout_endpoint: RolloutEndpoint,
+        judger: Judger | None = None,
+        logger=None,
+    ) -> AgentLoopSpec:
         if self.num_ray_actors == 0:
             return self.build_local(
-                rollout_controller=rollout_controller,
+                rollout_endpoint=rollout_endpoint,
                 judger=judger,
                 logger=logger,
             )
         if self.num_ray_actors > 1:
             return self._build_router(
-                rollout_controller=rollout_controller,
+                rollout_endpoint=rollout_endpoint,
                 judger=judger,
                 logger=logger,
             )
         return self._build_ray_actor(
-            rollout_controller=rollout_controller,
+            rollout_endpoint=rollout_endpoint,
             judger=judger,
             logger=logger,
         )
@@ -57,14 +62,14 @@ class AgentLoopConfig(ABC, BaseModel):
     @abstractmethod
     def build_local(
         self,
-        rollout_controller,
+        rollout_endpoint: RolloutEndpoint,
         judger: Judger | None = None,
         logger=None,
     ) -> AgentLoop: ...
 
     def _build_ray_actor(
         self,
-        rollout_controller: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
         logger=None,
@@ -74,7 +79,7 @@ class AgentLoopConfig(ABC, BaseModel):
             CPUActorLauncher.build_actor(
                 AgentLoopActor,
                 self,
-                rollout_controller,
+                rollout_endpoint,
                 judger,
                 logger,
                 pg=pg,
@@ -87,7 +92,7 @@ class AgentLoopConfig(ABC, BaseModel):
 
     def _build_ray_actors(
         self,
-        rollout_controller: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         num_actors: int,
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
@@ -99,7 +104,7 @@ class AgentLoopConfig(ABC, BaseModel):
             CPUActorLauncher.build_actors(
                 AgentLoopActor,
                 self,
-                rollout_controller,
+                rollout_endpoint,
                 judger,
                 logger,
                 pg=pg,
@@ -113,7 +118,7 @@ class AgentLoopConfig(ABC, BaseModel):
 
     def _build_router(
         self,
-        rollout_controller: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
         logger=None,
@@ -121,27 +126,26 @@ class AgentLoopConfig(ABC, BaseModel):
     ) -> RouterAgentLoop:
         return RouterAgentLoop(
             workers=self._build_ray_actors(
-                rollout_controller=rollout_controller,
+                rollout_endpoint=rollout_endpoint,
                 num_actors=self.num_ray_actors,
                 pg=pg,
                 judger=judger,
                 logger=logger,
                 start_bundle_idx=start_bundle_idx,
             ),
-            rollout_ctl=rollout_controller,
         )
 
 
 class AgentLoop(ABC):
     def __init__(
         self,
-        rollout_ctl: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         sample_params: SampleParams,
         hf_checkpoint: str,
         judger: Judger | None = None,
         logger=None,
     ) -> None:
-        self.rollout_ctl = rollout_ctl
+        self.rollout_endpoint = rollout_endpoint
         self.hf_checkpoint = hf_checkpoint
         self.tokenizer = load_tokenizer(hf_checkpoint, trust_remote_code=True)
         self.processor = load_processor(hf_checkpoint, trust_remote_code=True)
@@ -155,6 +159,21 @@ class AgentLoop(ABC):
     @abstractmethod
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState: ...
 
+    async def rollout_generate(self, rollout_state: RolloutState) -> RolloutState:
+        if self.rollout_endpoint.kind == "worker_local":
+            return await self.rollout_endpoint.require_worker_local_router().generate(rollout_state)
+        return await self.rollout_generate_from_url(
+            rollout_state=rollout_state,
+            base_url=self.rollout_endpoint.require_base_url(),
+        )
+    
+    # 这个地方还需要思考，rollout_state 如何发送给 worker 的 url？ 应该还有一层 gateway，因为要做 token 记录+session 隔离
+    async def rollout_generate_from_url(self, rollout_state: RolloutState, base_url: str) -> RolloutState:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement URL rollout generation for endpoint "
+            f"{self.rollout_endpoint.kind!r} at {base_url!r}."
+        )
+
     async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
         pending_tasks = []
         for state in rollout_state:
@@ -167,9 +186,8 @@ class AgentLoop(ABC):
 
 
 class RouterAgentLoop:
-    def __init__(self, workers: list[RayAgentLoopProxy], rollout_ctl: RolloutController):
+    def __init__(self, workers: list[RayAgentLoopProxy]):
         self.workers = workers
-        self.rollout_ctl = rollout_ctl
         self._worker_loads = dict.fromkeys(workers, 0)
         self._rr_index = 0
         self._lock = asyncio.Lock()
@@ -205,27 +223,17 @@ class RouterAgentLoop:
         return {str(worker): load for worker, load in self._worker_loads.items()}
 
 
-async def get_agent_loop_rollout_ctl(agent_loop: AgentLoopSpec) -> RolloutController:
-    rollout_ctl = getattr(agent_loop, "rollout_ctl", None)
-    if rollout_ctl is not None:
-        return rollout_ctl
-
-    get_rollout_ctl = getattr(agent_loop, "get_rollout_ctl", None)
-    if get_rollout_ctl is None or not hasattr(get_rollout_ctl, "remote"):
-        raise AttributeError(f"Agent loop {type(agent_loop)} does not expose rollout_ctl or get_rollout_ctl().")
-    return await get_rollout_ctl.remote()
-
-
 class AgentLoopActor:
     def __init__(
         self,
         agent_loop_config: AgentLoopConfig,
-        rollout_controller: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         judger: Judger | None = None,
         logger=None,
     ):
+        self.agent_loop_config = agent_loop_config
         self.agent_loop = agent_loop_config.build_local(
-            rollout_controller=rollout_controller,
+            rollout_endpoint=rollout_endpoint,
             judger=judger,
             logger=logger,
         )
@@ -237,10 +245,6 @@ class AgentLoopActor:
     @ray_method
     async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
         return await self.agent_loop.generate_group(rollout_state, **kwargs)
-
-    @ray_method
-    async def get_rollout_ctl(self):
-        return self.agent_loop.rollout_ctl
 
 
 RayAgentLoop = cast(ActorClass[AgentLoopActor], CPUActorLauncher.to_actor_class(AgentLoopActor))

--- a/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
+++ b/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams
 from xtuner.v1.rl.agent_loop import AgentLoop, AgentLoopConfig
 from xtuner.v1.rl.judger import Judger
-from xtuner.v1.rl.rollout import RolloutController
+from xtuner.v1.rl.rollout import RolloutEndpoint
 from xtuner.v1.utils import get_logger
 
 
@@ -18,10 +18,10 @@ logger = get_logger()
 class GSM8KToolAgentLoopConfig(AgentLoopConfig):
     max_turns: int
 
-    def build_local(self, rollout_controller, judger: Judger | None = None, logger=None) -> "GSM8KToolAgentLoop":
+    def build_local(self, rollout_endpoint: RolloutEndpoint, judger: Judger | None = None, logger=None) -> "GSM8KToolAgentLoop":
         return GSM8KToolAgentLoop(
             max_turns=self.max_turns,
-            rollout_ctl=rollout_controller,
+            rollout_endpoint=rollout_endpoint,
             hf_checkpoint=self.hf_checkpoint,
             sample_params=self.sample_params,
             judger=judger,
@@ -39,13 +39,13 @@ class GSM8KToolAgentLoop(AgentLoop):
     def __init__(
         self,
         max_turns: int,
-        rollout_ctl: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         hf_checkpoint: str,
         sample_params: SampleParams,
         judger: Judger | None = None,
     ):
         super().__init__(
-            rollout_ctl=rollout_ctl, hf_checkpoint=hf_checkpoint, sample_params=sample_params, judger=judger
+            rollout_endpoint=rollout_endpoint, hf_checkpoint=hf_checkpoint, sample_params=sample_params, judger=judger
         )
         self.max_turns = max_turns
         self.tool_call_pattern = re.compile(r"\n*<tool_call>(.*?)</tool_call>", re.DOTALL)
@@ -99,7 +99,7 @@ class GSM8KToolAgentLoop(AgentLoop):
             rollout_state.sample_params = copy.deepcopy(base_sample_params)
             rollout_state.sample_params.max_tokens = remaining_max_tokens
 
-            rollout_state = await self.rollout_ctl.generate.remote(rollout_state)  # type: ignore[attr-defined]
+            rollout_state = await self.rollout_generate(rollout_state)
             cur_turn += 1
             response_ids = cast(list[int], rollout_state.response_ids)
             cur_turn_tokens.extend(response_ids)

--- a/xtuner/v1/rl/agent_loop/single_turn_agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/single_turn_agent_loop.py
@@ -2,7 +2,7 @@ import asyncio
 
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.judger import Judger
-from xtuner.v1.rl.rollout import RolloutController
+from xtuner.v1.rl.rollout import RolloutEndpoint
 from xtuner.v1.rl.utils import create_task
 
 from .agent_loop import AgentLoop, AgentLoopConfig
@@ -12,9 +12,9 @@ from .utils import PartialRolloutHandler
 class SingleTurnAgentLoopConfig(AgentLoopConfig):
     enable_batch_judge: bool = False
 
-    def build_local(self, rollout_controller, judger: Judger | None = None, logger=None) -> "SingleTurnAgentLoop":
+    def build_local(self, rollout_endpoint: RolloutEndpoint, judger: Judger | None = None, logger=None) -> "SingleTurnAgentLoop":
         return SingleTurnAgentLoop(
-            rollout_ctl=rollout_controller,
+            rollout_endpoint=rollout_endpoint,
             sample_params=self.sample_params,
             hf_checkpoint=self.hf_checkpoint,
             judger=judger,
@@ -26,14 +26,14 @@ class SingleTurnAgentLoopConfig(AgentLoopConfig):
 class SingleTurnAgentLoop(AgentLoop):
     def __init__(
         self,
-        rollout_ctl: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         sample_params: SampleParams,
         hf_checkpoint: str,
         judger: Judger | None = None,
         logger=None,
         enable_batch_judge: bool = False,
     ):
-        super().__init__(rollout_ctl, sample_params, hf_checkpoint, judger, logger)
+        super().__init__(rollout_endpoint, sample_params, hf_checkpoint, judger, logger)
         self.max_tokens = self.sample_params.max_tokens
         self.partial_rollout_handler = PartialRolloutHandler(max_tokens=self.max_tokens)
         self.enable_batch_judge = enable_batch_judge
@@ -51,7 +51,7 @@ class SingleTurnAgentLoop(AgentLoop):
             rollout_state.tokens = rollout_state.prompt_ids
 
         # 推理引擎generate, 生成的结果会覆盖到 rollout_state.response_ids 上
-        rollout_state = await self.rollout_ctl.generate.remote(rollout_state)  # type: ignore[attr-defined]
+        rollout_state = await self.rollout_generate(rollout_state)
         # rollout state 后处理: 合并 partial rollout 的历史上下文
         rollout_state = self.partial_rollout_handler.postprocess(rollout_state)
         # 非 COMPLETED 状态（如被截断、放弃等）直接早退，不触发打分

--- a/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
@@ -10,10 +10,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from xtuner.v1.data_proto.rl_data import RolloutState, Status
-from xtuner.v1.rl.agent_loop import AgentLoopConfig, AgentLoopSpec, get_agent_loop_rollout_ctl
+from xtuner.v1.rl.agent_loop import AgentLoopConfig, AgentLoopSpec
 from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig, build_judger
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
-from xtuner.v1.rl.rollout import RolloutController, continue_generation, pause_generation
+from xtuner.v1.rl.rollout import RolloutEndpoint, continue_generation, pause_generation
 from xtuner.v1.rl.utils import asyncio_run
 from xtuner.v1.utils import get_logger
 
@@ -182,6 +182,7 @@ def _fill_leftover_counts(result: ProduceBatchResult, status_counts: dict[Status
 
 def _build_produce_context(
     task_runner: _TaskRunner,
+    rollout_controller,
     replay_buffer: ReplayBuffer,
     batch_size: int,
     train_step: int,
@@ -191,6 +192,7 @@ def _build_produce_context(
 ) -> ProduceContext:
     return ProduceContext(
         agent_loop=task_runner.agent_loop,
+        rollout_controller=rollout_controller,
         sampler=task_runner.sampler,
         replay_buffer=replay_buffer,
         task_batch_size=batch_size,
@@ -222,7 +224,7 @@ class AgentLoopManagerConfig(BaseModel):
 
     def build(
         self,
-        rollout_controller: RolloutController,
+        rollout_endpoint: RolloutEndpoint,
         tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast,
         replay_buffer: ReplayBuffer,
         logger=None,
@@ -240,7 +242,7 @@ class AgentLoopManagerConfig(BaseModel):
             seen_task_names.add(task_cfg.task_name)
 
             agent_loop = task_cfg.agent_loop_config.build(
-                rollout_controller=rollout_controller,
+                rollout_endpoint=rollout_endpoint,
                 judger=build_judger(task_cfg.judger_config) if task_cfg.judger_config is not None else None,
                 logger=logger,
             )
@@ -259,6 +261,7 @@ class AgentLoopManagerConfig(BaseModel):
 
         return AgentLoopManager(
             task_runners=task_runners,
+            rollout_endpoint=rollout_endpoint,
             replay_buffer=replay_buffer,
             logger=logger,
         )
@@ -272,6 +275,7 @@ class AgentLoopManager:
     def __init__(
         self,
         task_runners: list[_TaskRunner],
+        rollout_endpoint: RolloutEndpoint,
         replay_buffer: ReplayBuffer,
         logger=None,
     ):
@@ -281,6 +285,8 @@ class AgentLoopManager:
             raise ValueError("At least one task weight must be positive for AgentLoopManager.")
 
         self.task_runners = task_runners
+        self.rollout_endpoint = rollout_endpoint
+        self.rollout_controller = rollout_endpoint.rollout_controller
         self.replay_buffer = replay_buffer
         self.data_sampler = (
             task_runners[0].sampler
@@ -490,6 +496,7 @@ class AgentLoopManager:
                 task.produce_strategy.produce_batch(
                     _build_produce_context(
                         task,
+                        self.rollout_controller,
                         self.replay_buffer,
                         task_batch_sizes[task.task_name],
                         current_future_step,
@@ -538,6 +545,7 @@ class AgentLoopManager:
         for task in self.task_runners:
             ctx = _build_produce_context(
                 task,
+                self.rollout_controller,
                 self.replay_buffer,
                 0,
                 pause_progress.producer_future_step,
@@ -669,9 +677,8 @@ class AgentLoopManager:
         active_tasks = [task for task in self.task_runners if current_sizes[task.task_name] > 0]
         assert active_tasks, "No active tasks found"
 
-        rollout_ctl = await get_agent_loop_rollout_ctl(self.task_runners[0].agent_loop)
         # TODO: put in self.continue_produce()
-        await continue_generation(rollout_ctl)
+        await continue_generation(self.rollout_controller)
         try:
             # 共卡路径不复用非共卡的 paused producer 状态机。
             # 即使 manager 是从 resume() 恢复出来、当前仍处在 UPDATE_WEIGHT_AND_ABORT，
@@ -702,7 +709,7 @@ class AgentLoopManager:
             )
         finally:
             # TODO: put in self.pause_produce()
-            await pause_generation(rollout_ctl)
+            await pause_generation(self.rollout_controller)
 
         self.logger.info(
             f"[AgentLoopManager][{self.name}] produce_batch done "
@@ -730,8 +737,7 @@ class AgentLoopManager:
                 await self._wait_for_status_exit(self._status)
                 continue
 
-            rollout_ctl = await get_agent_loop_rollout_ctl(self.task_runners[0].agent_loop)
-            await continue_generation(rollout_ctl)
+            await continue_generation(self.rollout_controller)
             task_batch_sizes = self._produce_progress.ensure_target_upto(
                 batch_size=batch_size,
                 future_step=self._produce_progress.producer_future_step,

--- a/xtuner/v1/rl/agent_loop_manager/producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/producer.py
@@ -14,7 +14,7 @@ from xtuner.v1.data_proto.rl_data import (
     Status,
     get_group_status,
 )
-from xtuner.v1.rl.agent_loop import AgentLoopSpec, get_agent_loop_rollout_ctl
+from xtuner.v1.rl.agent_loop import AgentLoopSpec
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
 from xtuner.v1.rl.rollout.utils import pause_generation
 from xtuner.v1.rl.utils import calculate_seq_staleness, create_task
@@ -181,6 +181,7 @@ class ProduceContext:
     """
 
     agent_loop: AgentLoopSpec
+    rollout_controller: Any
     sampler: Sampler
     replay_buffer: ReplayBuffer
     task_batch_size: int
@@ -496,8 +497,7 @@ class AsyncProduceStrategy(ProduceStrategy):
         if self._pending_tasks.count() == 0:
             return 0.0
 
-        rollout_ctl = await get_agent_loop_rollout_ctl(ctx.agent_loop)
-        await pause_generation(rollout_ctl)
+        await pause_generation(ctx.rollout_controller)
         cleanup_start_time = time.perf_counter()
         while True:
             elapsed_time = time.perf_counter() - cleanup_start_time
@@ -523,7 +523,7 @@ class AsyncProduceStrategy(ProduceStrategy):
                     )
                 await ctx.put_generated_group(paused_items)
             if self._pending_tasks.count() > 0:
-                await pause_generation(rollout_ctl)
+                await pause_generation(ctx.rollout_controller)
                 await asyncio.sleep(1)
         return time.perf_counter() - pause_start
 

--- a/xtuner/v1/rl/rollout/__init__.py
+++ b/xtuner/v1/rl/rollout/__init__.py
@@ -1,6 +1,22 @@
 import os
 
 from .controller import RolloutController
+from .endpoint import RolloutEndpoint, RolloutEndpointConfig
+from .health_manager import RolloutHealthManager, RolloutWorkerRouteInfo
+from .worker_extern_router import (
+    WorkerExternRouter,
+    WorkerExternRouterConfig,
+)
+from .worker_http_router import (
+    WorkerHttpRouter,
+    WorkerHttpRouterConfig,
+    build_worker_http_router_app,
+    serve_worker_http_router_in_thread,
+)
+from .worker_local_router import (
+    WorkerLocalRouter,
+    WorkerLocalRouterConfig,
+)
 from .worker import RolloutWorker
 
 

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -1,29 +1,23 @@
-import asyncio
 import os
-import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeAlias, TypedDict
-from uuid import uuid4
 
 import ray
 from ray.actor import ActorProxy
 from ray.util.placement_group import PlacementGroup
 
-from transformers import AutoTokenizer
-from xtuner.v1.data_proto.rl_data import RolloutState, Status
 from xtuner.v1.rl.utils import AutoAcceleratorWorkers
-from xtuner.v1.utils import XTUNER_DETERMINISTIC, get_logger
+from xtuner.v1.utils import get_logger
 
-from .parser.factory import build_reasoning_parser, build_tool_call_parser
-from .parser.reasoning_parser import ReasoningParser
-from .parser.tool_parser import ToolCallParser
-from .utils import ROLLOUT_RAY_GET_TIMEOUT, RolloutHealthChecker, SessionRouter
+from .health_manager import RayRolloutHealthManager, RolloutHealthManagerProxy, RolloutWorkerRouteInfo
+from .utils import ROLLOUT_RAY_GET_TIMEOUT
 from .worker import RolloutConfig, RolloutWorker
 
 
 if TYPE_CHECKING:
     from xtuner.v1.rl.gateway.config import GatewayConfig
+    from xtuner.v1.rl.rollout.worker_http_router import WorkerHttpRouterConfig
 
 
 @dataclass
@@ -66,6 +60,9 @@ class RolloutWorkerMetadata(TypedDict):
     # Set after start_gateway() is called; None if the gateway has not been started.
     api_server_url: Optional[str]
 
+    # WorkerHttpRouter URL. Set after start_worker_http_router() is called.
+    worker_http_router_url: Optional[str]
+
 
 # Keep this as a Ray actor because Ray AgentLoop actors need a shared, cross-process handle to the same controller
 # state; passing a normal Python object would serialize a separate copy into each actor.
@@ -97,37 +94,21 @@ class RolloutController:
         self.rank2info: dict[int, WorkerInfo] = {}
         self.engine_rank_mesh_array, self.worker_server_urls_map, self.rank2info = self._init_workers(placement_group)
         self.num_active_workers = len(self.rank2info)
-        self.worker_info_lock = threading.RLock()
         # The timeout for the environment to wait for the rollout controller's response.
         # This should be longer than the controller's internal timeout (`rollout_timeout`)
         # to account for potential queuing delays and other overheads.
         self.timeout_multiplier = 2.0
-        self.router = SessionRouter(self.rank2info, worker_infos_lock=self.worker_info_lock)
-        self.health_checker = RolloutHealthChecker(
-            config=self.config,
-            workers_info=self.rank2info,
-            worker_infos_lock=self.worker_info_lock,
+        self.health_manager: RolloutHealthManagerProxy = RayRolloutHealthManager.options(num_cpus=0).remote(
+            self.config,
+            [
+                RolloutWorkerRouteInfo(rank=rank, actor=info.actor, url=info.url, is_active=info.is_active)
+                for rank, info in self.rank2info.items()
+            ],
         )
-        self.health_checker.start()
-        self._tool_call_parser, self._reasoning_parser = self._build_output_parsers()
         self._gateway_url: str | None = None
+        self._worker_http_router_url: str | None = None
 
     def start_gateway(self, config: "GatewayConfig") -> str | None:
-        """Start the gateway HTTP server in a daemon thread and return its URL.
-
-        The gateway exposes OpenAI-compatible endpoints that forward requests to
-        this controller via :class:`~xtuner.v1.rl.gateway.backend.local_backend.LocalRolloutBackend`.
-        Agent loops (e.g. CamelAgentLoop) discover the URL via :meth:`get_rollout_metadata`.
-
-        Args:
-            config: Gateway configuration.  ``port`` and ``host`` control where
-                the server binds; ``capture_folder`` enables per-request trace files.
-
-        Returns:
-            The base URL of the gateway, e.g. ``"http://1.2.3.4:8080"``, or
-            ``None`` when the configured rollout backend does not support the
-            gateway.
-        """
         if self.config.rollout_backend == "sglang":
             self.logger.error("XTuner gateway is not supported for SGLang rollout backend yet; skip starting gateway.")
             return None
@@ -144,6 +125,25 @@ class RolloutController:
         self._gateway_url = url
         self.logger.info(f"Gateway server started at {url}, capture_folder: {config.capture_folder}")
         return url
+    
+    # TODO: 是否应该绑定到这个类？会有啥风险？
+    def start_worker_http_router(self, config: "WorkerHttpRouterConfig") -> str:
+        from xtuner.v1.rl.rollout.worker_http_router import (
+            build_worker_http_router_app,
+            serve_worker_http_router_in_thread,
+        )
+
+        app = build_worker_http_router_app(
+            health_manager=self.health_manager,
+            rollout_config=self.config,
+            config=config,
+        )
+        serve_worker_http_router_in_thread(app, config)
+        host = ray.util.get_node_ip_address() if config.host in ("", "0.0.0.0") else config.host
+        url = f"http://{host}:{config.port}"
+        self._worker_http_router_url = url
+        self.logger.info(f"Worker HTTP router started at {url}")
+        return url
 
     def get_rollout_metadata(self) -> RolloutWorkerMetadata:
         """Get information about the current rollout setup.
@@ -152,90 +152,31 @@ class RolloutController:
             dict: A dictionary containing the engine mesh list, server URL
                 dictionary, and the rollout configuration.
         """
-        with self.worker_info_lock:
-            worker_server_urls_status = {info.url: info.is_active for info in self.rank2info.values()}
+        health_manager = self.get_health_manager()
+        route_infos = ray.get(health_manager.get_worker_route_infos.remote())
+        worker_server_urls_map = {info.rank: info.url for info in route_infos}
+        worker_server_urls_status = {info.url: info.is_active for info in route_infos}
         rollout_metadata: RolloutWorkerMetadata = {
             "engine_rank_mesh_array": self.engine_rank_mesh_array,
-            "server_url_dict": self.worker_server_urls_map,
+            "server_url_dict": worker_server_urls_map,
             "rollout_config": self.config,
             "worker_server_urls_status": worker_server_urls_status,
-            "api_server_url": self._gateway_url,
+            "api_server_url": self._worker_http_router_url or self._gateway_url,
+            "worker_http_router_url": self._worker_http_router_url,
         }
         return rollout_metadata
 
-    def _build_output_parsers(self) -> tuple[ToolCallParser | None, ReasoningParser | None]:
-        tool_call_parser = None
-        reasoning_parser = None
-
-        if self.config.tool_call_parser != "none":
-            tool_call_parser = build_tool_call_parser(self.config.tool_call_parser)
-
-        if self.config.reasoning_parser != "none":
-            tokenizer_path = self.config.tokenizer_path or self.config.model_path
-            tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
-            reasoning_parser = build_reasoning_parser(self.config.reasoning_parser, tokenizer)
-
-        return tool_call_parser, reasoning_parser
+    def get_health_manager(self) -> RolloutHealthManagerProxy:
+        return self.health_manager
 
     def get_ready_status(self) -> tuple[bool, dict[str, Any]]:
-        with self.worker_info_lock:
-            active_workers = sum(1 for info in self.rank2info.values() if info.is_active)
-            total_workers = len(self.rank2info)
-        return active_workers > 0, {
-            "active_workers": active_workers,
-            "total_workers": total_workers,
-        }
-
-    async def generate(self, rollout_state: RolloutState) -> RolloutState:
-        if XTUNER_DETERMINISTIC:
-            sample_params = rollout_state.sample_params.model_copy(deep=True)
-            sample_params.sampling_seed = self.config.random_seed + (
-                (rollout_state.uid or 0) - (rollout_state.message_uid or 0)
-            )
-            rollout_state.sample_params = sample_params
-
-        session_id = rollout_state.session_uid if rollout_state.session_uid is not None else uuid4().int
-        worker = await self.router.get_worker(session_id)
-        if worker is None:
-            rollout_state.status = Status.FAILED
-            rollout_state.error_msg = "No active rollout worker available."
-            return rollout_state
-
-        response_ref = worker.generate.remote(rollout_state=rollout_state)  # type: ignore[attr-defined]
-        try:
-            response_rollout_state = await asyncio.wait_for(
-                response_ref, timeout=self.config.rollout_timeout * self.timeout_multiplier
-            )
-            self._apply_output_parsers(response_rollout_state)
-            return response_rollout_state
-        except asyncio.TimeoutError:
-            self.logger.error(f"Rollout timeout for worker {worker}. Skipping sample.")
-            rollout_state.status = Status.FAILED
-            rollout_state.error_msg = (
-                f"Rollout request timed out after {self.config.rollout_timeout * self.timeout_multiplier} seconds."
-            )
-            return rollout_state
-
-    def _apply_output_parsers(self, rollout_state: RolloutState) -> None:
-        """Apply tool-call and reasoning parsers to the rollout state in-
-        place."""
-        if self._tool_call_parser is not None:
-            parsed = self._tool_call_parser.parse(rollout_state)
-            rollout_state.tool_calls = parsed.tool_calls
-            rollout_state.response = parsed.remaining_text or None
-        if self._reasoning_parser is not None:
-            parsed_reasoning = self._reasoning_parser.parse(rollout_state)
-            rollout_state.response = parsed_reasoning.remaining_text
-            if parsed_reasoning.reasoning_text:
-                rollout_state.extra_fields["reasoning_text"] = parsed_reasoning.reasoning_text
-            else:
-                rollout_state.extra_fields.pop("reasoning_text", None)
+        return ray.get(self.get_health_manager().get_ready_status.remote())
 
     def pause_generation(self):
-        self.health_checker.pause()
+        ray.get(self.get_health_manager().pause.remote())
 
     def continue_generation(self):
-        self.health_checker.resume()
+        ray.get(self.get_health_manager().resume.remote())
         self._broadcast_to_active_workers("continue_generation")
 
     def offload(self):
@@ -257,42 +198,14 @@ class RolloutController:
         Args:
             block (bool): Whether to block until the operation completes.
         """
-        self.health_checker.stop()
+        ray.get(self.get_health_manager().stop.remote())
         self._broadcast_to_active_workers("shutdown")
-
+    
+    # TODO: 是否要移除？目前不改是为了不改 rl_trainer 调用逻辑，实际上直接调用 health_manager 的 recover_failed_workers 更合理
     def recover_failed_workers(self):
         """Recovers from worker failures by restarting failed workers and
         reinitializing the rollout setup."""
-        self.health_checker.pause()
-        with self.worker_info_lock:
-            failed_workers = [info for info in self.rank2info.values() if not info.is_active]
-        if not failed_workers:
-            self.logger.info("No failed workers detected during recovery.")
-            return
-
-        self.logger.warning(f"Detected {len(failed_workers)} failed workers. Initiating recovery process.")
-        for worker in failed_workers:
-            if self._restart_failed_workers(worker.actor):
-                with self.worker_info_lock:
-                    rank = self._get_rank_by_actor(worker.actor)
-                    if rank is not None:
-                        self.rank2info[rank].is_active = True
-        self.health_checker.resume()
-
-    def _restart_failed_workers(self, worker: RolloutWorker) -> bool:
-        try:
-            dist_init_addr = ray.get(worker.init_dist_port.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            _, url = ray.get(worker.init.remote(dist_init_addr), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            is_healthy = ray.get(worker.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            if is_healthy:
-                self.logger.info(f"Successfully restarted worker {worker} with URL {url}.")
-                return True
-            else:
-                self.logger.error(f"Worker {worker} is still unhealthy after restart.")
-                return False
-        except Exception as e:
-            self.logger.error(f"Failed to restart worker: {e}")
-            return False
+        return ray.get(self.get_health_manager().recover_failed_workers.remote())
 
     def _update_dist_init_addr(self, nodes_per_engine, server_urls_per_engine, dist_init_addrs, tp_size):
         """Update the distributed initialization addresses for workers.
@@ -362,9 +275,7 @@ class RolloutController:
         Returns:
             A list of futures if `block` is False, otherwise a list of results.
         """
-        futures = []
-        with self.worker_info_lock:
-            active_actors = [info.actor for info in self.rank2info.values() if info.is_active]
+        active_actors = ray.get(self.get_health_manager().get_active_actors.remote())
         futures = [getattr(actor, method_name).remote() for actor in active_actors]
         results = ray.get(futures, timeout=ROLLOUT_RAY_GET_TIMEOUT)
         return results
@@ -388,20 +299,6 @@ class RolloutController:
                 "Please set XTUNER_USE_LMDEPLOY or XTUNER_USE_VLLM"
                 " or XTUNER_USE_SGLANG environment variable."
             )
-
-    def _get_rank_by_actor(self, actor: RolloutWorker) -> Optional[int]:
-        """Get rank by actor object.
-
-        Args:
-            actor: The RolloutWorker actor object.
-
-        Returns:
-            The rank of the worker, or None if not found.
-        """
-        for rank, info in self.rank2info.items():
-            if info.actor == actor:
-                return rank
-        return None
 
     def _update_active_workers_and_urls_map(self, active_rollout_workers, worker_server_urls_map):
         """Update the list of active rollout workers and their server URLs.

--- a/xtuner/v1/rl/rollout/endpoint.py
+++ b/xtuner/v1/rl/rollout/endpoint.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import ray
+from pydantic import BaseModel, ConfigDict, Field
+
+from .worker_extern_router import WorkerExternRouterConfig
+from .worker_http_router import WorkerHttpRouterConfig
+from .worker_local_router import WorkerLocalRouter, WorkerLocalRouterConfig
+
+
+RolloutEndpointKind = Literal["worker_local", "worker_http", "worker_extern"]
+
+
+@dataclass
+class RolloutEndpoint:
+    kind: RolloutEndpointKind
+    worker_local_router: WorkerLocalRouter | None = None
+    base_url: str | None = None
+    rollout_controller: Any | None = None
+
+    def require_worker_local_router(self) -> WorkerLocalRouter:
+        if self.worker_local_router is None:
+            raise RuntimeError(f"Rollout endpoint {self.kind!r} does not provide a WorkerLocalRouter.")
+        return self.worker_local_router
+
+    def require_base_url(self) -> str:
+        if self.base_url is None:
+            raise RuntimeError(f"Rollout endpoint {self.kind!r} does not provide a base URL.")
+        return self.base_url
+
+
+# 对外用户配置
+class RolloutEndpointConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    kind: RolloutEndpointKind = "worker_local"
+    worker_local_router_config: WorkerLocalRouterConfig = Field(default_factory=WorkerLocalRouterConfig)
+
+    # URL consumed by AgentLoop for worker_extern. For worker_http this is filled
+    # at runtime by RolloutController after WorkerHttpRouter starts.
+    base_url: str | None = None
+
+    worker_http_router_host: str = "0.0.0.0"
+    worker_http_router_port: int = 8081
+    worker_http_router_title: str = "XTuner Worker Router"
+    worker_http_router_version: str = "0.1.0"
+    worker_http_router_log_level: str = "warning"
+    worker_http_router_request_timeout: float | None = None
+    worker_http_router_stream_timeout: float | None = None
+
+    worker_extern_router_health_path: str = "/health"
+    worker_extern_router_register_path: str = "/admin/rollout_workers"
+    worker_extern_router_remove_path: str = "/admin/rollout_workers/remove"
+    worker_extern_router_register_method: str = "POST"
+    worker_extern_router_remove_method: str = "POST"
+    worker_extern_router_request_timeout: float = 10.0
+    worker_extern_router_poll_interval_seconds: float = 1.0
+    worker_extern_router_api_key: str | None = None
+    worker_extern_router_worker_api_key: str | None = None
+    worker_extern_router_headers: dict[str, str] = Field(default_factory=dict)
+
+    def build(self, rollout_controller) -> RolloutEndpoint:
+        if self.kind == "worker_local":
+            return RolloutEndpoint(
+                kind=self.kind,
+                worker_local_router=self.worker_local_router_config.build(rollout_controller),
+                rollout_controller=rollout_controller,
+            )
+
+        base_url = self.base_url
+        if base_url is None and self.kind == "worker_http":
+            rollout_metadata = ray.get(rollout_controller.get_rollout_metadata.remote())
+            base_url = rollout_metadata.get("worker_http_router_url")
+            if base_url is None:
+                raise ValueError(
+                    "Rollout endpoint 'worker_http' requires WorkerHttpRouter to be started before building "
+                    "AgentLoop, or base_url to be provided as a runtime override."
+                )
+        if base_url is None:
+            raise ValueError(f"Rollout endpoint {self.kind!r} requires base_url.")
+        return RolloutEndpoint(kind=self.kind, base_url=base_url, rollout_controller=rollout_controller)
+
+    def build_worker_http_router_config(self) -> WorkerHttpRouterConfig | None:
+        if self.kind != "worker_http":
+            return None
+        return WorkerHttpRouterConfig(
+            host=self.worker_http_router_host,
+            port=self.worker_http_router_port,
+            title=self.worker_http_router_title,
+            version=self.worker_http_router_version,
+            log_level=self.worker_http_router_log_level,
+            request_timeout=self.worker_http_router_request_timeout,
+            stream_timeout=self.worker_http_router_stream_timeout,
+        )
+
+    def build_worker_extern_router_config(self) -> WorkerExternRouterConfig | None:
+        if self.kind != "worker_extern":
+            return None
+        if self.base_url is None:
+            raise ValueError("Rollout endpoint 'worker_extern' requires base_url.")
+        return WorkerExternRouterConfig(
+            base_url=self.base_url,
+            worker_health_path=self.worker_extern_router_health_path,
+            register_path=self.worker_extern_router_register_path,
+            remove_path=self.worker_extern_router_remove_path,
+            register_method=self.worker_extern_router_register_method,
+            remove_method=self.worker_extern_router_remove_method,
+            request_timeout=self.worker_extern_router_request_timeout,
+            poll_interval_seconds=self.worker_extern_router_poll_interval_seconds,
+            api_key=self.worker_extern_router_api_key,
+            worker_api_key=self.worker_extern_router_worker_api_key,
+            headers=self.worker_extern_router_headers,
+        )

--- a/xtuner/v1/rl/rollout/health_manager.py
+++ b/xtuner/v1/rl/rollout/health_manager.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+import ray
+from ray.actor import ActorProxy
+
+from xtuner.v1.utils import get_logger
+
+from .utils import ROLLOUT_RAY_GET_TIMEOUT, RolloutHealthChecker, SessionRouter
+from .worker import RolloutConfig
+
+
+@dataclass
+class RolloutWorkerRouteInfo:
+    rank: int
+    actor: Any
+    url: str
+    is_active: bool = True
+
+
+class RolloutHealthManager:
+    def __init__(self, config: RolloutConfig, route_infos: list[RolloutWorkerRouteInfo]) -> None:
+        self.config = config
+        self.logger = get_logger(log_dir=config.worker_log_dir, tag="RolloutHealthManager")
+        self.worker_info_lock = threading.RLock()
+        self.rank2info: dict[int, RolloutWorkerRouteInfo] = {info.rank: info for info in route_infos}
+        self.router = SessionRouter(self.rank2info, worker_infos_lock=self.worker_info_lock)
+        self.health_checker = RolloutHealthChecker(
+            config=self.config,
+            workers_info=self.rank2info,
+            worker_infos_lock=self.worker_info_lock,
+        )
+        self.health_checker.start()
+
+    def get_worker_route_infos(self) -> list[RolloutWorkerRouteInfo]:
+        with self.worker_info_lock:
+            return [
+                RolloutWorkerRouteInfo(
+                    rank=rank,
+                    actor=info.actor,
+                    url=info.url,
+                    is_active=info.is_active,
+                )
+                for rank, info in self.rank2info.items()
+            ]
+
+    def get_worker_server_urls_status(self) -> dict[str, bool]:
+        with self.worker_info_lock:
+            return {info.url: info.is_active for info in self.rank2info.values()}
+
+    def get_ready_status(self) -> tuple[bool, dict[str, Any]]:
+        with self.worker_info_lock:
+            active_workers = sum(1 for info in self.rank2info.values() if info.is_active)
+            total_workers = len(self.rank2info)
+        return active_workers > 0, {
+            "active_workers": active_workers,
+            "total_workers": total_workers,
+        }
+
+    async def get_worker(self, session_id: int) -> Any | None:
+        return await self.router.get_worker(session_id)
+
+    async def get_worker_route_info(self, session_id: int) -> RolloutWorkerRouteInfo | None:
+        actor = await self.router.get_worker(session_id)
+        if actor is None:
+            return None
+        with self.worker_info_lock:
+            for rank, info in self.rank2info.items():
+                if info.actor == actor:
+                    return RolloutWorkerRouteInfo(
+                        rank=rank,
+                        actor=info.actor,
+                        url=info.url,
+                        is_active=info.is_active,
+                    )
+        return None
+
+    def get_active_actors(self) -> list[Any]:
+        with self.worker_info_lock:
+            return [info.actor for info in self.rank2info.values() if info.is_active]
+
+    def pause(self) -> None:
+        self.health_checker.pause()
+
+    def resume(self) -> None:
+        self.health_checker.resume()
+
+    def stop(self) -> None:
+        self.health_checker.stop()
+
+    def report_worker_failure(self, rank: int, error_msg: str | None = None) -> None:
+        worker = self._mark_worker_inactive(rank, "failure_report", error_msg)
+        if worker is None:
+            return
+        self.logger.warning(f"Rollout worker {rank} marked inactive from failure report: {error_msg}")
+
+    def recover_failed_workers(self) -> None:
+        self.health_checker.pause()
+        with self.worker_info_lock:
+            failed_workers = [info for info in self.rank2info.values() if not info.is_active]
+        if not failed_workers:
+            self.logger.info("No failed workers detected during recovery.")
+            self.health_checker.resume()
+            return
+
+        self.logger.warning(f"Detected {len(failed_workers)} failed workers. Initiating recovery process.")
+        for info in failed_workers:
+            self._shutdown_worker(info.rank, info.actor)
+            url = self._restart_failed_worker(info.actor)
+            if url is None:
+                continue
+            with self.worker_info_lock:
+                current = self.rank2info.get(info.rank)
+                if current is None:
+                    continue
+                current.url = url
+                current.is_active = True
+        self.health_checker.resume()
+
+    def _mark_worker_inactive(self, rank: int, reason: str, error_msg: str | None = None) -> Any | None:
+        with self.worker_info_lock:
+            info = self.rank2info.get(rank)
+            if info is None:
+                self.logger.warning(f"Received inactive update for unknown rollout worker rank {rank}: {error_msg}")
+                return None
+
+            worker = info.actor
+            if info.is_active:
+                info.is_active = False
+            return worker
+
+    def _restart_failed_worker(self, worker: Any) -> str | None:
+        try:
+            dist_init_addr = ray.get(worker.init_dist_port.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)
+            _, url = ray.get(worker.init.remote(dist_init_addr), timeout=ROLLOUT_RAY_GET_TIMEOUT)
+            is_healthy = ray.get(worker.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)
+            if is_healthy:
+                self.logger.info(f"Successfully restarted worker {worker} with URL {url}.")
+                return url
+            self.logger.error(f"Worker {worker} is still unhealthy after restart.")
+            return None
+        except Exception as e:
+            self.logger.error(f"Failed to restart worker: {e}")
+            return None
+
+    def _shutdown_worker(self, rank: int, worker: Any) -> None:
+        try:
+            ray.get(worker.offload.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)
+            ray.get(worker.shutdown.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)
+        except Exception as e:
+            self.logger.error(f"Exception while shutting down worker {rank}: {e}")
+
+
+RayRolloutHealthManager = ray.remote(RolloutHealthManager)
+RolloutHealthManagerProxy: TypeAlias = ActorProxy[RayRolloutHealthManager]

--- a/xtuner/v1/rl/rollout/utils.py
+++ b/xtuner/v1/rl/rollout/utils.py
@@ -242,7 +242,19 @@ async def send_abort_request(client: httpx.AsyncClient, url: str, timeout: float
 async def pause_generation(rollout_ctl: "RolloutControllerProxy", pause_time_out: float = 60.0) -> None:
     await rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
     rollout_ctl_metadata = await rollout_ctl.get_rollout_metadata.remote()  # type: ignore[attr-defined]
-    infer_server_url = list(rollout_ctl_metadata["server_url_dict"].values())
+    worker_server_urls_status = rollout_ctl_metadata.get("worker_server_urls_status", {})
+    infer_server_url = []
+    rank_by_url: dict[str, int] = {}
+    for rank, urls in rollout_ctl_metadata["server_url_dict"].items():
+        urls = urls if isinstance(urls, list) else [urls]
+        for url in urls:
+            if worker_server_urls_status.get(url, True):
+                infer_server_url.append(url)
+                try:
+                    rank_by_url[url] = int(rank)
+                except (TypeError, ValueError):
+                    pass
+
     async with httpx.AsyncClient() as client:
         tasks = [send_abort_request(client, url, timeout=pause_time_out) for url in infer_server_url]
         results = await asyncio.gather(*tasks)
@@ -251,6 +263,14 @@ async def pause_generation(rollout_ctl: "RolloutControllerProxy", pause_time_out
     succeeded_count = len(infer_server_url) - len(failed_workers)
 
     if failed_workers:
+        try:
+            health_manager = await rollout_ctl.get_health_manager.remote()  # type: ignore[attr-defined]
+            for url in failed_workers:
+                rank = rank_by_url.get(url)
+                if rank is not None:
+                    await health_manager.report_worker_failure.remote(rank, f"abort_request_failed: {url}")
+        except Exception as e:
+            logger.error(f"Failed to report abort request failures to health manager: {e}")
         logger.warning(
             f"Abort requests completed. Succeeded: {succeeded_count}, "
             f"Failed: {len(failed_workers)}. Failed workers: {failed_workers}"

--- a/xtuner/v1/rl/rollout/utils.py
+++ b/xtuner/v1/rl/rollout/utils.py
@@ -156,12 +156,18 @@ class RolloutHealthChecker:
         if self._worker_infos_lock is None:
             workers_snapshot = {
                 rank: (info.actor, info.url, info.is_active) for rank, info in self._workers_info.items()
+                if info.is_active
             }
         else:
             with self._worker_infos_lock:
                 workers_snapshot = {
                     rank: (info.actor, info.url, info.is_active) for rank, info in self._workers_info.items()
+                    if info.is_active
                 }
+
+        if not workers_snapshot:
+            logger.debug("No active rollout workers to check.")
+            return
 
         tasks = [
             check_worker_health(

--- a/xtuner/v1/rl/rollout/worker_extern_router.py
+++ b/xtuner/v1/rl/rollout/worker_extern_router.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import httpx
+
+from xtuner.v1.utils import get_logger
+
+from .health_manager import RolloutHealthManagerProxy, RolloutWorkerRouteInfo
+
+
+@dataclass
+class WorkerExternRouterConfig:
+    """Control-plane config for a known external HTTP router.
+
+    This class does not proxy user requests. It checks rollout worker URLs and
+    keeps an external high-throughput router's worker table updated.
+    """
+
+    base_url: str
+    worker_health_path: str = "/health"
+    register_path: str = "/admin/rollout_workers"
+    remove_path: str = "/admin/rollout_workers/remove"
+    register_method: Literal["POST", "PUT"] = "POST"
+    remove_method: Literal["POST", "DELETE"] = "POST"
+    request_timeout: float = 10.0
+    poll_interval_seconds: float = 1.0
+    api_key: str | None = None
+    worker_api_key: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+class WorkerExternRouter:
+    def __init__(
+        self,
+        health_manager: RolloutHealthManagerProxy,
+        config: WorkerExternRouterConfig,
+        *,
+        log_dir: str | None = None,
+    ) -> None:
+        self.health_manager = health_manager
+        self.config = config
+        self.logger = get_logger(log_dir=log_dir, tag="WorkerExternRouter")
+        self._registered_urls: dict[int, str] = {}
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="worker-extern-router")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._thread = None
+
+    async def sync_once(self) -> None:
+        route_infos = await self.health_manager.get_worker_route_infos.remote()
+        current_ranks = {info.rank for info in route_infos}
+        async with self._client() as client:
+            for rank, url in list(self._registered_urls.items()):
+                if rank not in current_ranks:
+                    await self._remove_worker(client, rank, url)
+
+            for info in route_infos:
+                is_healthy = info.is_active and await self._check_worker_url(client, info.url)
+                registered_url = self._registered_urls.get(info.rank)
+                if is_healthy:
+                    if registered_url != info.url:
+                        if registered_url is not None:
+                            await self._remove_worker(client, info.rank, registered_url)
+                        await self._register_worker(client, info)
+                elif registered_url is not None:
+                    await self._remove_worker(client, info.rank, registered_url)
+
+    async def run_forever(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                await self.sync_once()
+            except Exception as exc:
+                self.logger.error(f"Worker external router sync failed: {exc}")
+            await asyncio.sleep(self.config.poll_interval_seconds)
+
+    async def _check_worker_url(self, client: httpx.AsyncClient, url: str) -> bool:
+        try:
+            headers = {}
+            if self.config.worker_api_key is not None:
+                headers["authorization"] = f"Bearer {self.config.worker_api_key}"
+            response = await client.get(self._worker_health_url(url), headers=headers)
+            return response.status_code == 200
+        except Exception as exc:
+            self.logger.warning(f"Worker URL health check failed for {url}: {exc}")
+            return False
+
+    async def _register_worker(self, client: httpx.AsyncClient, info: RolloutWorkerRouteInfo) -> None:
+        payload = self._worker_payload(info)
+        response = await client.request(self.config.register_method, self._url(self.config.register_path), json=payload)
+        response.raise_for_status()
+        self._registered_urls[info.rank] = info.url
+        self.logger.info(f"Registered rollout worker {info.rank} to external router: {info.url}")
+
+    async def _remove_worker(self, client: httpx.AsyncClient, rank: int, url: str) -> None:
+        payload = {"rank": rank, "url": url}
+        response = await client.request(self.config.remove_method, self._url(self.config.remove_path), json=payload)
+        response.raise_for_status()
+        self._registered_urls.pop(rank, None)
+        self.logger.warning(f"Removed rollout worker {rank} from external router: {url}")
+
+    def _worker_payload(self, info: RolloutWorkerRouteInfo) -> dict[str, Any]:
+        return {
+            "rank": info.rank,
+            "url": info.url,
+            "is_active": info.is_active,
+        }
+
+    def _client(self) -> httpx.AsyncClient:
+        headers = dict(self.config.headers)
+        if self.config.api_key is not None:
+            headers.setdefault("authorization", f"Bearer {self.config.api_key}")
+        return httpx.AsyncClient(timeout=self.config.request_timeout, headers=headers)
+
+    def _url(self, path: str) -> str:
+        return f"{self.config.base_url.rstrip('/')}/{path.lstrip('/')}"
+
+    def _run(self) -> None:
+        try:
+            asyncio.run(self.run_forever())
+        except Exception as exc:
+            self.logger.error(f"Worker external router stopped unexpectedly: {exc}")
+
+    def _worker_health_url(self, url: str) -> str:
+        return f"{url.rstrip('/')}/{self.config.worker_health_path.lstrip('/')}"

--- a/xtuner/v1/rl/rollout/worker_http_router.py
+++ b/xtuner/v1/rl/rollout/worker_http_router.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import hashlib
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import ray
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse
+
+from xtuner.v1.utils import get_logger
+
+from .health_manager import RolloutHealthManagerProxy, RolloutWorkerRouteInfo
+from .worker import RolloutConfig
+
+
+@dataclass
+class WorkerHttpRouterConfig:
+    port: int
+    host: str = "0.0.0.0"
+    title: str = "XTuner Worker Router"
+    version: str = "0.1.0"
+    log_level: str = "warning"
+    request_timeout: float | None = None
+    stream_timeout: float | None = None
+
+
+class WorkerHttpRouter:
+    def __init__(
+        self,
+        health_manager: RolloutHealthManagerProxy,
+        rollout_config: RolloutConfig,
+        config: WorkerHttpRouterConfig,
+    ) -> None:
+        self.health_manager = health_manager
+        self.rollout_config = rollout_config
+        self.config = config
+        timeout = config.request_timeout or rollout_config.rollout_timeout
+        self.client = httpx.AsyncClient(timeout=timeout)
+        self.stream_timeout = config.stream_timeout or rollout_config.rollout_timeout
+        self.logger = get_logger(log_dir=rollout_config.worker_log_dir, tag="WorkerHttpRouter")
+
+    async def health(self) -> tuple[bool, dict[str, Any]]:
+        return await self.health_manager.get_ready_status.remote()
+
+    async def models(self) -> dict[str, Any]:
+        model_id = self.rollout_config.model_name or "xtuner-rollout"
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": model_id,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "xtuner",
+                }
+            ],
+        }
+
+    async def chat_completions(self, request: Request) -> Response:
+        payload = await request.json()
+        session_id = self._extract_session_id(payload, request)
+        route_info = await self.health_manager.get_worker_route_info.remote(session_id)
+        if route_info is None:
+            raise HTTPException(status_code=503, detail={"error": "No active rollout worker available."})
+
+        url = f"{route_info.url.rstrip('/')}/v1/chat/completions"
+        headers = self._forward_headers(request)
+        if payload.get("stream") is True:
+            return await self._stream_chat_completions(url, payload, headers, route_info)
+        return await self._post_chat_completions(url, payload, headers, route_info)
+
+    def _extract_session_id(self, payload: dict[str, Any], request: Request) -> int:
+        for header_name in ("x-session-uid", "x-session-id", "x-request-id"):
+            header_value = request.headers.get(header_name)
+            if header_value:
+                return self._stable_int(header_value)
+
+        metadata = payload.get("metadata")
+        if isinstance(metadata, dict):
+            for key in ("session_uid", "session_id", "conversation_id", "thread_id"):
+                if key in metadata and metadata[key] is not None:
+                    return self._stable_int(metadata[key])
+
+        for key in ("session_uid", "session_id"):
+            if key in payload and payload[key] is not None:
+                return self._stable_int(payload[key])
+
+        return uuid4().int
+
+    def _stable_int(self, value: Any) -> int:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            try:
+                return int(value)
+            except ValueError:
+                return uuid4().int if not value else self._hash_to_int(value)
+        return self._hash_to_int(json.dumps(value, sort_keys=True, default=str))
+
+    def _hash_to_int(self, value: str) -> int:
+        return int.from_bytes(hashlib.sha256(value.encode("utf-8")).digest()[:16], byteorder="big")
+
+    def _forward_headers(self, request: Request) -> dict[str, str]:
+        ignored = {
+            "host",
+            "content-length",
+            "connection",
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-authorization",
+            "te",
+            "trailers",
+            "transfer-encoding",
+            "upgrade",
+        }
+        headers = {key: value for key, value in request.headers.items() if key.lower() not in ignored}
+        if "content-type" not in {key.lower() for key in headers}:
+            headers["content-type"] = "application/json"
+        return headers
+
+    async def _post_chat_completions(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+        route_info: RolloutWorkerRouteInfo,
+    ) -> Response:
+        try:
+            response = await self.client.post(url, json=payload, headers=headers)
+        except Exception as exc:
+            await self.health_manager.report_worker_failure.remote(route_info.rank, str(exc))
+            raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+
+        if response.status_code >= 500:
+            await self.health_manager.report_worker_failure.remote(route_info.rank, response.text)
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            media_type=response.headers.get("content-type", "application/json"),
+        )
+
+    async def _stream_chat_completions(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+        route_info: RolloutWorkerRouteInfo,
+    ) -> StreamingResponse:
+        async def stream_response():
+            try:
+                async with self.client.stream("POST", url, json=payload, headers=headers, timeout=self.stream_timeout) as response:
+                    if response.status_code >= 500:
+                        body = await response.aread()
+                        await self.health_manager.report_worker_failure.remote(route_info.rank, body.decode(errors="replace"))
+                        yield body
+                        return
+                    async for chunk in response.aiter_bytes():
+                        yield chunk
+            except Exception as exc:
+                await self.health_manager.report_worker_failure.remote(route_info.rank, str(exc))
+                self.logger.error(f"Streaming chat completion failed for worker {route_info.rank}: {exc}")
+                yield f'data: {{"error": {json.dumps(str(exc))}}}\n\n'.encode()
+
+        return StreamingResponse(stream_response(), media_type="text/event-stream")
+
+
+def build_worker_http_router_app(
+    health_manager: RolloutHealthManagerProxy,
+    rollout_config: RolloutConfig,
+    config: WorkerHttpRouterConfig,
+) -> FastAPI:
+    router = WorkerHttpRouter(health_manager=health_manager, rollout_config=rollout_config, config=config)
+    app = FastAPI(title=config.title, version=config.version)
+    app.state.worker_router = router
+
+    @app.get("/livez")
+    async def livez() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/readyz")
+    async def readyz():
+        ready, details = await router.health()
+        payload = {"ready": ready, "status": "ready" if ready else "unavailable", "details": details}
+        if ready:
+            return payload
+        raise HTTPException(status_code=503, detail=payload)
+
+    @app.get("/v1/models")
+    async def models():
+        return await router.models()
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        return await router.chat_completions(request)
+
+    return app
+
+
+def serve_worker_http_router(app: FastAPI, config: WorkerHttpRouterConfig) -> None:
+    _ensure_port_available(config)
+    uvicorn.run(app, host=config.host, port=config.port, log_level=config.log_level)
+
+
+def serve_worker_http_router_in_thread(app: FastAPI, config: WorkerHttpRouterConfig) -> threading.Thread:
+    thread = threading.Thread(
+        target=serve_worker_http_router,
+        args=(app, config),
+        daemon=True,
+        name="worker-http-router",
+    )
+    thread.start()
+    return thread
+
+
+def wait_for_worker_http_router_ready(base_url: str, *, timeout_seconds: float = 180.0) -> None:
+    deadline = time.time() + timeout_seconds
+    last_error = None
+    while time.time() < deadline:
+        try:
+            response = httpx.get(f"{base_url}/livez", timeout=5.0)
+            if response.status_code == 200:
+                return
+            last_error = response.text
+        except Exception as exc:
+            last_error = exc
+        time.sleep(1)
+    raise TimeoutError(f"Worker router did not become ready at {base_url}: {last_error}")
+
+
+def _ensure_port_available(config: WorkerHttpRouterConfig) -> None:
+    host = "127.0.0.1" if config.host in ("", "0.0.0.0") else config.host
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1.0)
+        if sock.connect_ex((host, config.port)) == 0:
+            raise OSError(f"Worker router port already in use: {config.host}:{config.port}")

--- a/xtuner/v1/rl/rollout/worker_local_router.py
+++ b/xtuner/v1/rl/rollout/worker_local_router.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import ray
+from ray.exceptions import RayActorError
+from pydantic import BaseModel, ConfigDict, Field
+from transformers import AutoTokenizer
+
+from xtuner.v1.data_proto.rl_data import RolloutState, Status
+from xtuner.v1.utils import XTUNER_DETERMINISTIC, get_logger
+
+from .health_manager import RolloutHealthManagerProxy
+from .parser.factory import build_reasoning_parser, build_tool_call_parser
+from .parser.reasoning_parser import ReasoningParser
+from .parser.tool_parser import ToolCallParser
+from .worker import RolloutConfig
+
+
+class WorkerLocalRouterConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    timeout_multiplier: float = Field(default=2.0, gt=0)
+
+    def build(self, rollout_controller) -> "WorkerLocalRouter":
+        rollout_metadata = ray.get(rollout_controller.get_rollout_metadata.remote())
+        health_manager = ray.get(rollout_controller.get_health_manager.remote())
+        return WorkerLocalRouter(
+            rollout_controller=rollout_controller,
+            health_manager=health_manager,
+            rollout_config=rollout_metadata["rollout_config"],
+            timeout_multiplier=self.timeout_multiplier,
+        )
+
+
+class WorkerLocalRouter:
+    def __init__(
+        self,
+        rollout_controller,
+        health_manager: RolloutHealthManagerProxy,
+        rollout_config: RolloutConfig,
+        timeout_multiplier: float = 2.0,
+    ) -> None:
+        self.rollout_controller = rollout_controller
+        self.health_manager = health_manager
+        self.config = rollout_config
+        self.timeout_multiplier = timeout_multiplier
+        self.logger = get_logger(log_dir=rollout_config.worker_log_dir, tag="WorkerLocalRouter")
+        self._tool_call_parser, self._reasoning_parser = self._build_output_parsers()
+
+    def _build_output_parsers(self) -> tuple[ToolCallParser | None, ReasoningParser | None]:
+        tool_call_parser = None
+        reasoning_parser = None
+
+        if self.config.tool_call_parser != "none":
+            tool_call_parser = build_tool_call_parser(self.config.tool_call_parser)
+
+        if self.config.reasoning_parser != "none":
+            tokenizer_path = self.config.tokenizer_path or self.config.model_path
+            tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+            reasoning_parser = build_reasoning_parser(self.config.reasoning_parser, tokenizer)
+
+        return tool_call_parser, reasoning_parser
+
+    def _apply_output_parsers(self, rollout_state: RolloutState) -> None:
+        if self._tool_call_parser is not None:
+            parsed = self._tool_call_parser.parse(rollout_state)
+            rollout_state.tool_calls = parsed.tool_calls
+            rollout_state.response = parsed.remaining_text or None
+        if self._reasoning_parser is not None:
+            parsed_reasoning = self._reasoning_parser.parse(rollout_state)
+            rollout_state.response = parsed_reasoning.remaining_text
+            if parsed_reasoning.reasoning_text:
+                rollout_state.extra_fields["reasoning_text"] = parsed_reasoning.reasoning_text
+            else:
+                rollout_state.extra_fields.pop("reasoning_text", None)
+
+    async def generate(self, rollout_state: RolloutState) -> RolloutState:
+        if XTUNER_DETERMINISTIC:
+            sample_params = rollout_state.sample_params.model_copy(deep=True)
+            sample_params.sampling_seed = self.config.random_seed + (
+                (rollout_state.uid or 0) - (rollout_state.message_uid or 0)
+            )
+            rollout_state.sample_params = sample_params
+
+        session_id = rollout_state.session_uid if rollout_state.session_uid is not None else uuid4().int
+        worker_info = await self.health_manager.get_worker_route_info.remote(session_id)
+        worker = worker_info.actor if worker_info is not None else None
+        if worker is None:
+            rollout_state.status = Status.FAILED
+            rollout_state.error_msg = "No active rollout worker available."
+            return rollout_state
+
+        response_ref = worker.generate.remote(rollout_state=rollout_state)
+        try:
+            response_rollout_state = await asyncio.wait_for(
+                response_ref, timeout=self.config.rollout_timeout * self.timeout_multiplier
+            )
+            self._apply_output_parsers(response_rollout_state)
+            return response_rollout_state
+        except (asyncio.TimeoutError, RayActorError) as e:
+            await self.health_manager.report_worker_failure.remote(worker_info.rank, str(e))
+            self.logger.error(f"Rollout failed for worker {worker}. Skipping sample. Error: {e}")
+            rollout_state.status = Status.FAILED
+            if isinstance(e, asyncio.TimeoutError):
+                rollout_state.error_msg = (
+                    f"Rollout request timed out after {self.config.rollout_timeout * self.timeout_multiplier} seconds."
+                )
+            else:
+                rollout_state.error_msg = f"Rollout worker failed with error: {e}"
+            return rollout_state

--- a/xtuner/v1/rl/trainer/worker.py
+++ b/xtuner/v1/rl/trainer/worker.py
@@ -917,6 +917,7 @@ class TrainingWorker(SingleAcceleratorWorker):
         rollout_config: RolloutConfig,
         worker_server_urls_status: Dict[str, bool],
         api_server_url: str | None = None,
+        worker_http_router_url: str | None = None,
     ):
         """Update the rollout information for the training worker."""
         tp = rollout_config.tensor_parallel_size

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -34,6 +34,8 @@ from xtuner.v1.rl.replay_buffer import (
     _snapshot_nested_objectrefs,
 )
 from xtuner.v1.rl.rollout.controller import RolloutControllerProxy
+from xtuner.v1.rl.rollout.endpoint import RolloutEndpointConfig
+from xtuner.v1.rl.rollout.worker_extern_router import WorkerExternRouter
 from xtuner.v1.rl.rollout.worker import RolloutConfig
 from xtuner.v1.rl.trainer.controller import TrainingController
 from xtuner.v1.rl.trainer.worker import WorkerConfig, WorkerLogItem
@@ -208,6 +210,7 @@ class BaseRLTrainerConfig(BaseModel):
     advantage_estimator_config: BaseAdvantageConfig = Field(default_factory=GRPOAdvantageConfig)
     sync_weights_interval: int = 1
     gateway_config: GatewayConfig | None = None
+    rollout_endpoint_config: RolloutEndpointConfig = Field(default_factory=RolloutEndpointConfig)
 
     enable_evaluate: bool = True
     enable_initial_evaluate: bool = False
@@ -276,6 +279,7 @@ class BaseRLTrainer:
     train_controller: TrainingController
     rollout_controller: RolloutControllerProxy
     _debug_train_files: dict[int, Path]
+    _worker_extern_router: WorkerExternRouter | None = None
 
     def _init_common(self, cfg: BaseRLTrainerConfig, *, meta_path: str, logger_tag: str) -> None:
         check_fa3()
@@ -366,10 +370,30 @@ class BaseRLTrainer:
         # gateway 依赖 rollout controller，因此在 rollout controller 构建完成后统一启动。
         ray.get(self.rollout_controller.start_gateway.remote(cfg.gateway_config))
 
+    def _maybe_start_worker_http_router(self, cfg: BaseRLTrainerConfig) -> None:
+        worker_http_router_config = cfg.rollout_endpoint_config.build_worker_http_router_config()
+        if worker_http_router_config is None:
+            return
+        # TODO: 这个 router 应该启动在哪里比较合适？
+        ray.get(self.rollout_controller.start_worker_http_router.remote(worker_http_router_config))
+
+    def _maybe_start_worker_extern_router(self, cfg: BaseRLTrainerConfig) -> None:
+        worker_extern_router_config = cfg.rollout_endpoint_config.build_worker_extern_router_config()
+        if worker_extern_router_config is None:
+            return
+        health_manager = ray.get(self.rollout_controller.get_health_manager.remote())
+        self._worker_extern_router = WorkerExternRouter(
+            health_manager=health_manager,
+            config=worker_extern_router_config,
+            log_dir=str(self.exp_dir / "logs"),
+        )
+        self._worker_extern_router.start()
+
     def _build_agent_loop_components(self, cfg: BaseRLTrainerConfig, replay_buffer) -> None:
+        rollout_endpoint = cfg.rollout_endpoint_config.build(self.rollout_controller)
         self.tokenizer = AutoTokenizer.from_pretrained(cfg.tokenizer_path, trust_remote_code=True)
         self.agent_loop_manager = cfg.agent_loop_manager_cfg.build(
-            rollout_controller=self.rollout_controller,
+            rollout_endpoint=rollout_endpoint,
             tokenizer=self.tokenizer,
             replay_buffer=replay_buffer,
             logger=self.logger,
@@ -379,7 +403,7 @@ class BaseRLTrainer:
         if self._enable_evaluate:
             assert cfg.eval_agent_loop_manager_cfg is not None
             self.eval_agent_loop_manager = cfg.eval_agent_loop_manager_cfg.build(
-                rollout_controller=self.rollout_controller,
+                rollout_endpoint=rollout_endpoint,
                 tokenizer=self.tokenizer,
                 replay_buffer=replay_buffer,
                 logger=self.logger,
@@ -941,6 +965,8 @@ class RLColocateTrainer(BaseRLTrainer):
                 self._rollout_config.skip_load_weights = False
             self.rollout_controller = self._rollout_config.build(self._pg)
             self._maybe_start_gateway(cfg)
+            self._maybe_start_worker_http_router(cfg)
+            self._maybe_start_worker_extern_router(cfg)
             replay_buffer = cfg.replay_buffer_config.build()
             self._build_agent_loop_components(cfg, replay_buffer)
             self.logger.warning("Debug rollout mode is enabled. Only rollout workers will be started.")
@@ -970,6 +996,8 @@ class RLColocateTrainer(BaseRLTrainer):
 
         self.rollout_controller = self._rollout_config.build(self._pg)
         self._maybe_start_gateway(cfg)
+        self._maybe_start_worker_http_router(cfg)
+        self._maybe_start_worker_extern_router(cfg)
         bind_train_rollout(train_controller=self.train_controller, rollout_controller=self.rollout_controller)
 
         replay_buffer = cfg.replay_buffer_config.build()
@@ -1118,6 +1146,8 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
         self.train_controller = self._train_worker_cfg.build(self._train_pg)
         self.rollout_controller = self._rollout_config.build(self._rollout_pg)
         self._maybe_start_gateway(cfg)
+        self._maybe_start_worker_http_router(cfg)
+        self._maybe_start_worker_extern_router(cfg)
 
         replay_buffer = cfg.replay_buffer_config.build()
         self._build_agent_loop_components(cfg, replay_buffer)


### PR DESCRIPTION
# 重构目的

- 当前即使在简单的单轮推理场景下，由于中心化的 rollout controller 绑定了 generate 方法导致所有的 agentloop 都需要首先将数据序列化到这个中心化控制器中，然后再次序列化给每个选中的 worker。如果 agentloop 不是一个 ray actor 则可能问题不大，因为 agentloop 和 rollout controller 在同一个节点，序列化开销小。但是如果 agentloop  是 ray actor 则问题比较严重，存在明显的不合理
- 在 agentic rl 场景下，agentloop 在 sandbox 中执行，此时 rollout controller的 generate 方法无用，需要走额外的逻辑。这种情况下也存在不一致调用问题。
- 即使不从性能角度出发，目前 rollout controller 做的事情过多，需要做一定程度解耦

基于此，我们希望能将 rollout controller 定位于真正的中心化控制器，数据生成 generate  和它没有关系。这样解耦后，虽然 rollout controller 目前做的事情还是有点多，但是已经把最严重的 generate  问题移除了。

不过将 generate  移除后会引入新的问题，健康检测如何在多个类进行同步？

# 运行模式

## 模式 1.1
**agentloop 内联普通类模式，直接调用 worker 进行生成**

在这种模式下，agentloop 调用的 generate  方法不再经过中心化控制器，而是普通的异步类，可以少一次全局序列化。

## 模式 1.2
**agentloop 内联 ray actor 类模式，直接调用 worker 进行生成**

在这种模式下，agentloop 调用的 generate  方法不再经过中心化控制器，可以少一次全局序列化。但是因为 agentloop 和 worker 关系不是一一绑定的，因此会出现 agentloop 向某个 worker 发送序列化数据场合。

## 模式 2
**agentloop 内联模式，调用 worker 对应的 endpoint url 进行生成**

如果希望能接入任意内联 agent，那么模式 1 就不合适了，此时可以使用模式 2。在模式 2 情况下，每个 worker 会自动绑定一个对应的 endpoint url，然后全局 router 管理这些 url，并对外提供一个唯一的 router url 供 agentloop  使用。
此时内部会先走 router  url，然后再走 worker url，router  url 此时可能成为热点。

## 模式 3
**agentloop sandbox，调用第三方对应的 endpoint url 进行生成**

在生成场景中，router url 此时成为热点问题可以通过扩容或者独立部署集群来解决，这时候就不会走模式2，而是通过将每个 worker 会自动绑定一个对应的 endpoint url 注册到第三方 router 中进行生成。 此时内部会先走外部提供的 router  url，然后再走 worker url

# worker url 要干啥？

为应对黑白盒 sandbox agent 需求，worker 所启动的 url server 需要承担比较重要的工作：基于 session id 或者 api key 的前缀匹配，token id 缓存池，rollout router replay 管理等。所做的事情很多，额外要避免中心化内存，需要单独设计。

# 健康检测如何在多个类进行同步？
通过将健康检测设置为 ray actor 避免多个 actor 间序列化导致的管理状态不一致问题

