### PR TITLE
Fix rollout_is_seq metrics by excluding padded tokens in packed sequences

### DIFF
--- a/xtuner/v1/rl/base/rollout_is.py
+++ b/xtuner/v1/rl/base/rollout_is.py
@@ -338,7 +338,7 @@ def compute_is_metrics(
     in sequence/geometric mode via log-space) and safety-clamped values (for mean/std/ESS)
     to balance accuracy with numerical stability and avoid overflow.
     """
-    metrics = {}
+    metrics: dict[str, bool | int | float | torch.Tensor] = {}
     device = rollout_is_weights.device
     seq_valid = response_mask.sum(dim=-1, keepdim=True) > 0
     metrics["valid"] = response_mask.any().item()
@@ -544,12 +544,15 @@ def merge_rollout_is_metrics(rollout_is_metrics: list[dict[str, float]], device=
     metrics = {}
     keys = [k for k in rollout_is_metrics[0].keys() if k != "mismatch/valid"]
 
+    is_valids = [m.get("mismatch/valid", True) for m in rollout_is_metrics]
+    valid_tensor = torch.tensor(is_valids, dtype=torch.float32, device=device)
+    count_value = valid_tensor.sum()
+    dist.all_reduce(count_value, op=dist.ReduceOp.SUM)
+    count = count_value.item()
+
     for key in keys:
         values = []
-        valids = []
-        for m in rollout_is_metrics:
-            is_valid = m.get("mismatch/valid", True)
-            valids.append(float(is_valid))
+        for m, is_valid in zip(rollout_is_metrics, is_valids):
             if is_valid:
                 values.append(m[key])
             elif "max" in key:
@@ -559,12 +562,9 @@ def merge_rollout_is_metrics(rollout_is_metrics: list[dict[str, float]], device=
             else:
                 values.append(0.0)
         value_tensor = torch.tensor(values, dtype=torch.float32, device=device)
-        valid_tensor = torch.tensor(valids, dtype=torch.float32, device=device)
-        count_value = valid_tensor.sum()
-        dist.all_reduce(count_value, op=dist.ReduceOp.SUM)
 
         # Aggregate across all processes
-        if count_value.item() == 0:
+        if count == 0:
             metrics[key] = 0.0
         elif "max" in key:
             max_value = value_tensor.max()
@@ -577,6 +577,6 @@ def merge_rollout_is_metrics(rollout_is_metrics: list[dict[str, float]], device=
         else:
             sum_value = value_tensor.sum()
             dist.all_reduce(sum_value, op=dist.ReduceOp.SUM)
-            metrics[key] = sum_value.item() / count_value.item()
+            metrics[key] = sum_value.item() / count
 
     return metrics

--- a/xtuner/v1/rl/base/rollout_is.py
+++ b/xtuner/v1/rl/base/rollout_is.py
@@ -340,9 +340,11 @@ def compute_is_metrics(
     """
     metrics = {}
     device = rollout_is_weights.device
+    seq_valid = response_mask.sum(dim=-1, keepdim=True) > 0
+    metrics["valid"] = response_mask.any().item()
 
     # Track veto statistics
-    metrics["rollout_is_veto_fraction"] = has_catastrophic.float().mean()
+    metrics["rollout_is_veto_fraction"] = masked_mean(has_catastrophic.float(), seq_valid)
     metrics["rollout_is_catastrophic_token_fraction"] = masked_mean(catastrophic_tokens.float(), response_mask)
 
     # Compute metrics based on IS level
@@ -413,22 +415,33 @@ def compute_is_metrics(
     if rollout_is_weights.dim() > 1:
         # Compute mean IS weight per sequence
         seq_mean_weights = masked_mean(rollout_is_weights, response_mask, axis=-1)
+        seq_mean_weights = seq_mean_weights[seq_valid.squeeze(-1)]
 
         # Per-sequence statistics
-        metrics["rollout_is_seq_mean"] = seq_mean_weights.mean()
-        metrics["rollout_is_seq_std"] = (
-            seq_mean_weights.std() if seq_mean_weights.numel() > 1 else torch.tensor(0.0, device=device)
-        )
-        metrics["rollout_is_seq_max"] = seq_mean_weights.max()
-        metrics["rollout_is_seq_min"] = seq_mean_weights.min()
+        if seq_mean_weights.numel() > 0:
+            metrics["rollout_is_seq_mean"] = seq_mean_weights.mean()
+            metrics["rollout_is_seq_std"] = (
+                seq_mean_weights.std() if seq_mean_weights.numel() > 1 else torch.tensor(0.0, device=device)
+            )
+            metrics["rollout_is_seq_max"] = seq_mean_weights.max()
+            metrics["rollout_is_seq_min"] = seq_mean_weights.min()
 
-        # Identify most problematic sequences
-        seq_deviation = (seq_mean_weights - 1.0).abs()
-        metrics["rollout_is_seq_max_deviation"] = seq_deviation.max()
+            # Identify most problematic sequences
+            seq_deviation = (seq_mean_weights - 1.0).abs()
+            metrics["rollout_is_seq_max_deviation"] = seq_deviation.max()
 
-        # Fraction of sequences with high IS weights
-        metrics["rollout_is_seq_fraction_high"] = (seq_mean_weights > rollout_is_threshold_upper).float().mean()
-        metrics["rollout_is_seq_fraction_low"] = (seq_mean_weights < rollout_is_threshold_lower).float().mean()
+            # Fraction of sequences with high IS weights
+            metrics["rollout_is_seq_fraction_high"] = (seq_mean_weights > rollout_is_threshold_upper).float().mean()
+            metrics["rollout_is_seq_fraction_low"] = (seq_mean_weights < rollout_is_threshold_lower).float().mean()
+        else:
+            zero = torch.tensor(0.0, device=device)
+            metrics["rollout_is_seq_mean"] = zero
+            metrics["rollout_is_seq_std"] = zero
+            metrics["rollout_is_seq_max"] = zero
+            metrics["rollout_is_seq_min"] = zero
+            metrics["rollout_is_seq_max_deviation"] = zero
+            metrics["rollout_is_seq_fraction_high"] = zero
+            metrics["rollout_is_seq_fraction_low"] = zero
 
     return metrics
 
@@ -537,12 +550,23 @@ def merge_rollout_is_metrics(rollout_is_metrics: list[dict[str, float]], device=
         for m in rollout_is_metrics:
             is_valid = m.get("mismatch/valid", True)
             valids.append(float(is_valid))
-            values.append(m[key] if is_valid else 0.0)  # set to 0.0 if invalid
+            if is_valid:
+                values.append(m[key])
+            elif "max" in key:
+                values.append(float("-inf"))
+            elif "min" in key:
+                values.append(float("inf"))
+            else:
+                values.append(0.0)
         value_tensor = torch.tensor(values, dtype=torch.float32, device=device)
         valid_tensor = torch.tensor(valids, dtype=torch.float32, device=device)
+        count_value = valid_tensor.sum()
+        dist.all_reduce(count_value, op=dist.ReduceOp.SUM)
 
         # Aggregate across all processes
-        if "max" in key:
+        if count_value.item() == 0:
+            metrics[key] = 0.0
+        elif "max" in key:
             max_value = value_tensor.max()
             dist.all_reduce(max_value, op=dist.ReduceOp.MAX)
             metrics[key] = max_value.item()
@@ -552,9 +576,7 @@ def merge_rollout_is_metrics(rollout_is_metrics: list[dict[str, float]], device=
             metrics[key] = min_value.item()
         else:
             sum_value = value_tensor.sum()
-            count_value = valid_tensor.sum()
             dist.all_reduce(sum_value, op=dist.ReduceOp.SUM)
-            dist.all_reduce(count_value, op=dist.ReduceOp.SUM)
-            metrics[key] = sum_value.item() / count_value.item() if count_value.item() > 0 else 0.0
+            metrics[key] = sum_value.item() / count_value.item()
 
     return metrics


### PR DESCRIPTION
<img width="1105" height="367" alt="image" src="https://github.com/user-attachments/assets/473a18f6-e248-4afe-a5f6-39fe37d41331" />

## Summary

This PR fixes the `rollout_is_seq` metric computation for packed sequences.

Previously, padded positions in packed sequences were included in the `rollout_is_seq` statistics. As a result, some metrics were dominated by padding artifacts:

- `rollout_is/mismatch/rollout_is_seq_min` stayed close to `0`.
- `rollout_is/mismatch/rollout_is_seq_mean` was biased downward.
- `rollout_is/mismatch/rollout_is_seq_max_deviation` stayed close to `1`.

This PR masks out padded positions so that these metrics are computed only over valid sequence tokens.

## Validation

I compared TensorBoard metrics before and after the fix.

- Green: before the fix
- Red: after the fix

After the fix, `rollout_is_seq_min` and `rollout_is_seq_max_deviation` are no longer affected by padded tokens.