### PR TITLE
[Tool] Analyze train logs

### DIFF
--- a/.dev_scripts/analyze_train_logs.py
+++ b/.dev_scripts/analyze_train_logs.py
@@ -1,0 +1,480 @@
+"""Analyze multi-node torchrun training logs to localise tgs drops.
+
+The script parses ``node_*.txt`` files emitted by torchrun, extracts per-rank
+metrics for every step, and surfaces three kinds of problems:
+
+1. Steps with a clear tgs drop (median tgs below a ratio of the run baseline).
+2. Whether each drop is **data-bound** (dataloader stalled some rank) or
+   **compute/comm-bound** (step time itself ballooned with healthy data_time).
+3. For compute-bound steps it prints the distribution of ``efficient_attn_ratio``
+   / ``img_tokens`` / ``text_tokens`` so the user can tell when an outlier
+   sample has dominated a pack. For data-bound steps it prints the slowest
+   ranks together with their data_time.
+
+Example:
+    python xtuner/tools/analyze_train_logs.py /path/to/torchrun_logs/xxx \\
+        --tgs-drop-ratio 0.7
+
+Default heuristics (overridable via CLI):
+    * ``baseline_tgs``  -- median tgs of non-warmup steps.
+    * tgs drop        -- median(tgs) < 0.7 * baseline_tgs.
+    * data-bound      -- dt_max > 1s OR dt_max > 10 * (median of step_median dt).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# Captures every metric we currently emit in xtuner's training INFO line. The
+# regex is intentionally permissive about field ordering changes (e.g. extra
+# fields appearing between known ones).
+_LINE_RE = re.compile(
+    r"\[RANK (?P<rank>\d+)\].*?"
+    r"Step (?P<step>\d+)/\d+\s+"
+    r"data_time:\s*(?P<dt>[\d.]+)\s+"
+    r"lr:\s*[\d.eE+\-]+\s+"
+    r"time:\s*(?P<st>[\d.]+)\s+"
+    r"text_tokens:\s*(?P<text_tokens>\d+)\s+"
+    r"img_tokens:\s*(?P<img_tokens>[\d.]+)\s+"
+    r".*?efficient_attn_ratio:\s*(?P<eff>[\d.]+),\s*"
+    r"img_efficient_attn_ratio:\s*(?P<img_eff>[\d.]+)\s+"
+    r".*?max_memory:\s*(?P<max_mem>[\d.]+)\s*GB\s+"
+    r"reserved_memory:\s*(?P<rsv_mem>[\d.]+)\s*GB\s+"
+    r"tgs:\s*(?P<tgs>[\d.]+)\s+"
+    r"exp_tgs:\s*(?P<exp_tgs>[\d.]+)"
+)
+
+
+@dataclass(slots=True)
+class RankRecord:
+    """One rank's metrics at one step."""
+
+    rank: int
+    data_time: float
+    step_time: float
+    text_tokens: int
+    img_tokens: float
+    eff_attn: float
+    img_eff_attn: float
+    max_mem: float
+    tgs: float
+
+
+@dataclass(slots=True)
+class StepSummary:
+    """Aggregated view of a single step across all ranks."""
+
+    step: int
+    n_ranks: int
+    dt_min: float
+    dt_med: float
+    dt_max: float
+    st_min: float
+    st_med: float
+    st_max: float
+    tgs_min: float
+    tgs_med: float
+    tgs_max: float
+    eff_attn_med: float
+    eff_attn_p90: float
+    eff_attn_max: float
+    img_eff_attn_max: float
+    img_tokens_med: float
+    img_tokens_max: float
+    text_tokens_min: int
+    text_tokens_max: int
+    max_mem_max: float
+    # Filled in later when we decide attribution.
+    is_drop: bool = False
+    attribution: str = ""  # "data" | "compute" | ""
+    notes: list[str] = field(default_factory=list)
+
+
+def parse_logs(log_dir: Path) -> dict[int, dict[int, RankRecord]]:
+    """Parse all ``node_*.txt`` files under ``log_dir``.
+
+    Args:
+        log_dir (Path): Directory holding torchrun node logs.
+
+    Returns:
+        dict[int, dict[int, RankRecord]]: ``{step: {rank: RankRecord}}``. Late
+            entries for the same (step, rank) silently overwrite earlier ones,
+            which is fine for resumed/retried runs.
+    """
+    by_step: dict[int, dict[int, RankRecord]] = {}
+    files = sorted(log_dir.glob("node_*.txt"))
+    if not files:
+        raise FileNotFoundError(f"No node_*.txt files found under {log_dir}")
+
+    for path in files:
+        with path.open("r", errors="replace") as fh:
+            for line in fh:
+                if "data_time:" not in line:
+                    continue
+                m = _LINE_RE.search(line)
+                if m is None:
+                    continue
+                step = int(m["step"])
+                rec = RankRecord(
+                    rank=int(m["rank"]),
+                    data_time=float(m["dt"]),
+                    step_time=float(m["st"]),
+                    text_tokens=int(m["text_tokens"]),
+                    img_tokens=float(m["img_tokens"]),
+                    eff_attn=float(m["eff"]),
+                    img_eff_attn=float(m["img_eff"]),
+                    max_mem=float(m["max_mem"]),
+                    tgs=float(m["tgs"]),
+                )
+                by_step.setdefault(step, {})[rec.rank] = rec
+    return by_step
+
+
+def summarize_step(step: int, ranks: dict[int, RankRecord]) -> StepSummary:
+    """Reduce all rank records of a step to a single :class:`StepSummary`."""
+    recs = list(ranks.values())
+    dts = sorted(r.data_time for r in recs)
+    sts = sorted(r.step_time for r in recs)
+    tgs = sorted(r.tgs for r in recs)
+    effs = sorted(r.eff_attn for r in recs)
+    imgs = sorted(r.img_tokens for r in recs)
+
+    def pct(values: list[float], p: float) -> float:
+        idx = min(len(values) - 1, max(0, int(round(p * (len(values) - 1)))))
+        return values[idx]
+
+    return StepSummary(
+        step=step,
+        n_ranks=len(recs),
+        dt_min=dts[0],
+        dt_med=statistics.median(dts),
+        dt_max=dts[-1],
+        st_min=sts[0],
+        st_med=statistics.median(sts),
+        st_max=sts[-1],
+        tgs_min=tgs[0],
+        tgs_med=statistics.median(tgs),
+        tgs_max=tgs[-1],
+        eff_attn_med=statistics.median(effs),
+        eff_attn_p90=pct(effs, 0.9),
+        eff_attn_max=effs[-1],
+        img_eff_attn_max=max(r.img_eff_attn for r in recs),
+        img_tokens_med=statistics.median(imgs),
+        img_tokens_max=imgs[-1],
+        text_tokens_min=min(r.text_tokens for r in recs),
+        text_tokens_max=max(r.text_tokens for r in recs),
+        max_mem_max=max(r.max_mem for r in recs),
+    )
+
+
+def find_anomalies(
+    summaries: list[StepSummary],
+    tgs_drop_ratio: float,
+    data_bound_abs: float,
+    data_bound_rel: float,
+    warmup_steps: int,
+) -> tuple[float, float]:
+    """Mark drop steps in-place and decide data-bound vs compute-bound.
+
+    Args:
+        summaries (list[StepSummary]): Summaries sorted by ``step``, mutated in place.
+        tgs_drop_ratio (float): Step counts as a drop when ``tgs_med`` falls
+            below ``tgs_drop_ratio * baseline_tgs``.
+        data_bound_abs (float): Absolute ``dt_max`` (in seconds) above which a
+            drop is attributed to data loading.
+        data_bound_rel (float): Multiplier on the run-wide median of
+            ``dt_med``; if ``dt_max`` exceeds this it also counts as data-bound.
+        warmup_steps (int): Number of leading steps to exclude from the
+            baseline computation (the first iteration is always cold-start).
+
+    Returns:
+        tuple[float, float]: ``(baseline_tgs, dt_med_baseline)`` so the caller
+            can echo the chosen baselines in its report.
+    """
+    eligible = [s for s in summaries if s.step > warmup_steps]
+    baseline_tgs = statistics.median(s.tgs_med for s in eligible)
+    dt_med_baseline = statistics.median(s.dt_med for s in eligible)
+    dt_max_threshold = max(data_bound_abs, data_bound_rel * dt_med_baseline)
+
+    for s in summaries:
+        # Always tag the warmup step but never reclassify it as a real drop.
+        if s.step <= warmup_steps:
+            s.notes.append(f"warmup (step <= {warmup_steps})")
+            continue
+        if s.tgs_med >= tgs_drop_ratio * baseline_tgs:
+            continue
+        s.is_drop = True
+        if s.dt_max > dt_max_threshold:
+            s.attribution = "data"
+        else:
+            s.attribution = "compute"
+    return baseline_tgs, dt_max_threshold
+
+
+_LEGEND = """\
+Columns:
+  step             training step index (1-based)
+  cause            'data'    -> some rank(s) stalled in the dataloader
+                   'compute' -> step_time itself ballooned (pack/comm/compile)
+  tgs(med)         median tgs across ranks (tokens/GPU/s); throughput of this step
+  ratio            tgs(med) / baseline_tgs; <1 means slowdown
+                   (e.g. 0.41 == this step ran at 41% of normal speed)
+  step_t(s)        median step_time across ranks (seconds)
+  data_max(s)      max  data_time across ranks (= slowest dataloader rank)
+  data_med(s)      median data_time across ranks (= typical loader cost)
+  attn(max)        max efficient_attn_ratio (LLM side); 1.0 means one sample
+                   fills the LLM pack -> attention becomes full O(L^2)
+  img_attn(max)    max img_efficient_attn_ratio (vision side); 1.0 means one
+                   image dominates the vision pack
+  text_tok(min)    min text_tokens across ranks; 0 means some rank received
+                   no LLM tokens this step (data starvation / SP partitioning)
+  text_tok(max)    max text_tokens across ranks (usually == pack length)
+  img_tok(med)     median img_tokens across ranks (typical image load per pack)
+  img_tok(max)     max img_tokens across ranks (heaviest pack)
+"""
+
+
+def format_drop_table(
+    summaries: list[StepSummary], baseline_tgs: float
+) -> str:
+    """One-line-per-step table for every tgs drop."""
+    drops = [s for s in summaries if s.is_drop]
+    if not drops:
+        return _LEGEND + "\n(no tgs drop detected)"
+
+    header = (
+        f"{'step':>5}  {'cause':>7}  {'tgs(med)':>9}  {'ratio':>6}  "
+        f"{'step_t(s)':>10}  {'data_max(s)':>12}  {'data_med(s)':>12}  "
+        f"{'attn(max)':>10}  {'img_attn(max)':>14}  "
+        f"{'text_tok(min)':>14}  {'text_tok(max)':>14}  "
+        f"{'img_tok(med)':>13}  {'img_tok(max)':>13}"
+    )
+    lines = [_LEGEND, header, "-" * len(header)]
+    for s in drops:
+        lines.append(
+            f"{s.step:>5}  {s.attribution:>7}  {s.tgs_med:>9.1f}  "
+            f"{s.tgs_med / baseline_tgs:>6.2f}  {s.st_med:>10.2f}  "
+            f"{s.dt_max:>12.3f}  {s.dt_med:>12.4f}  "
+            f"{s.eff_attn_max:>10.4f}  {s.img_eff_attn_max:>14.4f}  "
+            f"{s.text_tokens_min:>14d}  {s.text_tokens_max:>14d}  "
+            f"{s.img_tokens_med:>13.0f}  {s.img_tokens_max:>13.0f}"
+        )
+    return "\n".join(lines)
+
+
+def format_data_bound_details(
+    summary: StepSummary, ranks: dict[int, RankRecord], top_n: int
+) -> str:
+    """Per-rank breakdown for a data-bound step."""
+    slowest = sorted(ranks.values(), key=lambda r: -r.data_time)[:top_n]
+    lines = [
+        f"  Top {top_n} slowest ranks by data_time "
+        f"(step_time_med={summary.st_med:.2f}s):",
+        f"    {'rank':>5}  {'data_time':>10}  {'step_time':>10}",
+    ]
+    for r in slowest:
+        lines.append(
+            f"    {r.rank:>5}  {r.data_time:>10.3f}  {r.step_time:>10.3f}"
+        )
+    # SP-group hint: if the top slow ranks are contiguous in groups of 4-8 the
+    # user almost always wants to know.
+    top_ranks = sorted(r.rank for r in slowest)
+    contiguous = _detect_contiguous_groups(top_ranks)
+    if contiguous:
+        lines.append(f"    [hint] contiguous rank groups: {contiguous}")
+    return "\n".join(lines)
+
+
+def format_compute_bound_details(
+    summary: StepSummary, ranks: dict[int, RankRecord], top_n: int
+) -> str:
+    """Per-step view for a compute-bound (pack-imbalance) step."""
+    heaviest = sorted(ranks.values(), key=lambda r: -r.eff_attn)[:top_n]
+    lines = [
+        f"  attn (LLM) ratio:      med={summary.eff_attn_med:.4f}  "
+        f"p90={summary.eff_attn_p90:.4f}  max={summary.eff_attn_max:.4f}",
+        f"  img_attn ratio:        max={summary.img_eff_attn_max:.4f}",
+        f"  text_tokens:           min={summary.text_tokens_min}  "
+        f"max={summary.text_tokens_max}",
+        f"  img_tokens:            med={summary.img_tokens_med:.0f}  "
+        f"max={summary.img_tokens_max:.0f}",
+        f"  max_mem (any rank):    {summary.max_mem_max:.2f} GB",
+        f"  Top {top_n} ranks by attn(LLM) ratio (single-sample-dominated packs):",
+        f"    {'rank':>5}  {'attn':>9}  {'img_attn':>9}  "
+        f"{'img_tok':>9}  {'text_tok':>9}  {'max_mem':>8}",
+    ]
+    for r in heaviest:
+        lines.append(
+            f"    {r.rank:>5}  {r.eff_attn:>9.4f}  {r.img_eff_attn:>8.4f}  "
+            f"{r.img_tokens:>9.0f}  {r.text_tokens:>9}  {r.max_mem:>8.2f}"
+        )
+    contiguous = _detect_contiguous_groups(sorted(r.rank for r in heaviest))
+    if contiguous:
+        lines.append(f"    [hint] contiguous rank groups: {contiguous}")
+    return "\n".join(lines)
+
+
+def write_json(
+    summaries: list[StepSummary], path: Path, baseline_tgs: float, dt_threshold: float
+) -> None:
+    """Dump the analysis to JSON for downstream tooling."""
+    out = {
+        "baseline_tgs": baseline_tgs,
+        "data_bound_dt_threshold": dt_threshold,
+        "steps": [
+            {
+                "step": s.step,
+                "is_drop": s.is_drop,
+                "attribution": s.attribution,
+                "tgs_med": s.tgs_med,
+                "tgs_ratio": s.tgs_med / baseline_tgs if baseline_tgs else None,
+                "st_med": s.st_med,
+                "dt_med": s.dt_med,
+                "dt_max": s.dt_max,
+                "eff_attn_med": s.eff_attn_med,
+                "eff_attn_p90": s.eff_attn_p90,
+                "eff_attn_max": s.eff_attn_max,
+                "img_eff_attn_max": s.img_eff_attn_max,
+                "text_tokens_min": s.text_tokens_min,
+                "text_tokens_max": s.text_tokens_max,
+                "img_tokens_med": s.img_tokens_med,
+                "img_tokens_max": s.img_tokens_max,
+                "max_mem_max": s.max_mem_max,
+                "notes": s.notes,
+            }
+            for s in summaries
+        ],
+    }
+    path.write_text(json.dumps(out, indent=2))
+
+
+def _detect_contiguous_groups(ranks: Iterable[int]) -> list[list[int]]:
+    """Collapse a sorted rank list into contiguous runs.
+
+    Useful for flagging that all slow ranks belong to the same SP / PP group.
+    Only runs of length >= 2 are returned, since stragglers tend to come in
+    SP-sized clusters (4, 8, ...).
+    """
+    groups: list[list[int]] = []
+    current: list[int] = []
+    for r in ranks:
+        if not current or r == current[-1] + 1:
+            current.append(r)
+            continue
+        if len(current) >= 2:
+            groups.append(current)
+        current = [r]
+    if len(current) >= 2:
+        groups.append(current)
+    return groups
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Diagnose tgs drops in xtuner torchrun logs. Splits drops into "
+            "data-bound (slow ranks) and compute-bound (pack imbalance)."
+        )
+    )
+    parser.add_argument("log_dir", type=Path, help="Directory containing node_*.txt logs.")
+    parser.add_argument(
+        "--tgs-drop-ratio",
+        type=float,
+        default=0.7,
+        help="Step is flagged when median tgs falls below this ratio of the run baseline.",
+    )
+    parser.add_argument(
+        "--data-bound-abs",
+        type=float,
+        default=1.0,
+        help="Absolute data_time (s) above which a drop is attributed to dataloading.",
+    )
+    parser.add_argument(
+        "--data-bound-rel",
+        type=float,
+        default=10.0,
+        help="Multiplier on the global median dt_med; data_time above this is data-bound.",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=1,
+        help="Leading steps excluded from baseline (cold-start).",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=10,
+        help="Number of ranks to print per anomaly.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="Optional path to dump the full analysis as JSON.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    by_step = parse_logs(args.log_dir)
+    summaries = [summarize_step(s, by_step[s]) for s in sorted(by_step)]
+
+    baseline_tgs, dt_threshold = find_anomalies(
+        summaries,
+        tgs_drop_ratio=args.tgs_drop_ratio,
+        data_bound_abs=args.data_bound_abs,
+        data_bound_rel=args.data_bound_rel,
+        warmup_steps=args.warmup_steps,
+    )
+
+    n_ranks = max(s.n_ranks for s in summaries)
+    n_drops = sum(1 for s in summaries if s.is_drop)
+    n_data = sum(1 for s in summaries if s.attribution == "data")
+    n_compute = sum(1 for s in summaries if s.attribution == "compute")
+    print(f"Parsed {len(summaries)} steps from {args.log_dir} ({n_ranks} ranks).")
+    print(
+        f"Baseline tgs (median over step>{args.warmup_steps}) = {baseline_tgs:.1f}; "
+        f"data_time threshold for data-bound = {dt_threshold:.3f}s "
+        f"(max of {args.data_bound_abs}s and {args.data_bound_rel}x median dt_med)."
+    )
+    print(
+        f"Detected {n_drops} drop step(s): {n_data} data-bound, {n_compute} compute-bound."
+    )
+
+    print("\n=== 1. tgs drop summary (median tgs < {:.2f} x baseline) ===".format(
+        args.tgs_drop_ratio
+    ))
+    print(format_drop_table(summaries, baseline_tgs))
+
+    data_drops = [s for s in summaries if s.attribution == "data"]
+    if data_drops:
+        print("\n=== 2. Data-bound steps -- slowest ranks ===")
+        for s in data_drops:
+            print(f"\n[step {s.step}] step_time={s.st_med:.2f}s  "
+                  f"dt_med={s.dt_med:.4f}s  dt_max={s.dt_max:.2f}s")
+            print(format_data_bound_details(s, by_step[s.step], args.top_n))
+
+    compute_drops = [s for s in summaries if s.attribution == "compute"]
+    if compute_drops:
+        print("\n=== 3. Compute-bound steps -- pack imbalance / heavy samples ===")
+        for s in compute_drops:
+            print(f"\n[step {s.step}] step_time={s.st_med:.2f}s  "
+                  f"tgs_med={s.tgs_med:.1f} ({s.tgs_med / baseline_tgs:.2f}x baseline)")
+            print(format_compute_bound_details(s, by_step[s.step], args.top_n))
+
+    if args.json_out is not None:
+        write_json(summaries, args.json_out, baseline_tgs, dt_threshold)
+        print(f"\nJSON dump written to {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Usage:

```console
python .dev_scripts/analyze_train_logs.py  <multi-nodes-logs-dir>
```

the structure of logs dir:

```console
❯ tree <logs_dir>
├── node_0.txt
├── node_1.txt
├── node_10.txt
├── node_11.txt
├── node_12.txt
├── node_13.txt
├── node_14.txt

```



```console
=== 1. tgs drop summary (median tgs < 0.70 x baseline) ===
Columns:
  step             training step index (1-based)
  cause            'data'    -> some rank(s) stalled in the dataloader
                   'compute' -> step_time itself ballooned (pack/comm/compile)
  tgs(med)         median tgs across ranks (tokens/GPU/s); throughput of this step
  ratio            tgs(med) / baseline_tgs; <1 means slowdown
                   (e.g. 0.41 == this step ran at 41% of normal speed)
  step_t(s)        median step_time across ranks (seconds)
  data_max(s)      max  data_time across ranks (= slowest dataloader rank)
  data_med(s)      median data_time across ranks (= typical loader cost)
  attn(max)        max efficient_attn_ratio (LLM side); 1.0 means one sample
                   fills the LLM pack -> attention becomes full O(L^2)
  img_attn(max)    max img_efficient_attn_ratio (vision side); 1.0 means one
                   image dominates the vision pack
  text_tok(min)    min text_tokens across ranks; 0 means some rank received
                   no LLM tokens this step (data starvation / SP partitioning)
  text_tok(max)    max text_tokens across ranks (usually == pack length)
  img_tok(med)     median img_tokens across ranks (typical image load per pack)
  img_tok(max)     max img_tokens across ranks (heaviest pack)

 step    cause   tgs(med)   ratio   step_t(s)   data_max(s)   data_med(s)   attn(max)   img_attn(max)   text_tok(min)   text_tok(max)   img_tok(med)   img_tok(max)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
   11  compute      848.7    0.51       76.96         0.025        0.0025      0.1827          1.0000            6175           65536          58040         139959
   12  compute      879.8    0.53       74.09         0.216        0.0025      0.2000          1.0000               0           65536          69940         156895
   20  compute      624.9    0.38      104.88         0.023        0.0026      1.0000          0.4276           44017           65536         187968         260848
   31  compute     1141.4    0.69       57.42         0.035        0.0026      0.3952          1.0000               0           65536          36122         193828
   36  compute     1079.3    0.65       60.72         0.011        0.0026      0.5131          1.0000            9588           65536          27646         183009
   37  compute     1052.1    0.64       62.29         0.034        0.0027      0.4798          1.0000           31165           65536          34392         205150
   44  compute     1128.8    0.68       58.05         0.060        0.0025      0.1276          1.0000               0           65536          84880         144194
   48  compute     1137.8    0.69       57.60         0.020        0.0026      0.2896          1.0000               0           65536         104770         181359
   50  compute     1128.3    0.68       58.09         0.403        0.0026      0.2101          1.0000           40828           65536          46397         124944
   58  compute      662.8    0.40       98.87         0.007        0.0026      1.0000          0.3453               0           65536         188608         260684
  110  compute      656.9    0.40       99.76         0.007        0.0026      0.9993          1.0000               0           65536         185620         260582
  114  compute     1142.0    0.69       57.38         0.006        0.0026      0.5476          1.0000           28333           65536          46322         197460
  144  compute     1134.0    0.68       57.79         0.020        0.0026      0.5039          1.0000               0           65536          56774         200308
  146  compute     1156.4    0.70       56.67         0.006        0.0026      0.5423          1.0000           40013           65536          25633         178486
  148  compute     1074.6    0.65       60.98         0.017        0.0026      0.6248          1.0000               0           65536          41383         215510
  173     data      172.0    0.10      381.06       332.459        0.0028      0.3143          1.0000           47415           65536         109051         157531
  187  compute     1121.9    0.68       58.41         0.007        0.0026      0.5387          1.0000               0           65536          89132         206744
  198  compute      661.9    0.40       99.01         0.164        0.0025      1.0000          1.0000               0           65536         192344         260596
  199     data       58.3    0.04     1123.72      1085.331        0.0026      0.1744          1.0000           36243           65536          60708         148603
  236  compute      660.5    0.40       99.21         0.017        0.0026      1.0000          0.3399               0           65536         195726         260124
  282  compute      679.7    0.41       96.41         0.007        0.0026      0.9978          1.0000               0           65536         187523         260792
  307  compute      679.2    0.41       96.49         0.007        0.0027      1.0000          1.0000           33031           65536         178323         260974
  347  compute      934.9    0.56       70.09         0.008        0.0028      0.8084          1.0000           17726           65536          25330         238937
  352     data     1040.4    0.63       62.99        20.943        0.0026      0.2266          1.0000            2316           65536          65140         209186
  374     data      248.8    0.15      263.40       223.824        0.0026      0.1890          1.0000               0           65536          86808         157567

=== 2. Data-bound steps -- slowest ranks ===

[step 173] step_time=381.06s  dt_med=0.0028s  dt_max=332.46s
  Top 10 slowest ranks by data_time (step_time_med=381.06s):
     rank   data_time   step_time
      144     332.459      48.455
      145     332.214      48.553
      147     311.960      68.953
      146     195.487     185.265
      160       0.053     381.009
      328       0.025     381.041
      138       0.022     381.038
      139       0.019     381.038
      136       0.018     381.042
      140       0.009     381.050
    [hint] contiguous rank groups: [[138, 139, 140], [144, 145, 146, 147]]

[step 199] step_time=1123.72s  dt_med=0.0026s  dt_max=1085.33s
  Top 10 slowest ranks by data_time (step_time_med=1123.72s):
     rank   data_time   step_time
      157    1085.331      38.098
      156    1060.093      63.326
      159    1059.593      63.893
      158    1058.120      65.351
       84       0.007    1123.715
       86       0.007    1123.712
      119       0.007    1123.711
      510       0.006    1123.721
      363       0.006    1123.713
       85       0.006    1123.712
    [hint] contiguous rank groups: [[84, 85, 86], [156, 157, 158, 159]]

[step 352] step_time=62.99s  dt_med=0.0026s  dt_max=20.94s
  Top 10 slowest ranks by data_time (step_time_med=62.99s):
     rank   data_time   step_time
      335      20.943      41.373
      334       0.077      62.241
      268       0.038      62.953
      332       0.026      62.470
      333       0.015      62.074
       96       0.009      62.985
      433       0.008      62.979
      269       0.007      62.983
      147       0.007      62.987
      104       0.007      62.983
    [hint] contiguous rank groups: [[268, 269], [332, 333, 334, 335]]

[step 374] step_time=263.40s  dt_med=0.0026s  dt_max=223.82s
  Top 10 slowest ranks by data_time (step_time_med=263.40s):
     rank   data_time   step_time
      326     223.824      39.240
      327     223.556      39.423
      324     223.477      39.589
      325     223.412      39.672
      127       0.007     263.397
      378       0.006     263.392
      383       0.006     263.395
      119       0.006     263.390
       86       0.006     263.394
       70       0.006     263.395
    [hint] contiguous rank groups: [[324, 325, 326, 327]]

=== 3. Compute-bound steps -- pack imbalance / heavy samples ===

[step 11] step_time=76.96s  tgs_med=848.7 (0.51x baseline)
  attn (LLM) ratio:      med=0.0890  p90=0.1206  max=0.1827
  img_attn ratio:        max=1.0000
  text_tokens:           min=6175  max=65536
  img_tokens:            med=58040  max=139959
  max_mem (any rank):    81.63 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      162     0.1827    0.0887     139959      65536     81.63
      161     0.1827    0.0887     139959      65536     81.63
      163     0.1827    0.0887     139959      63788     81.63
      160     0.1827    0.0887     139959      65536     81.63
      204     0.1737    1.0000      43692      65536     80.19
      206     0.1737    1.0000      43692      65536     80.19
      207     0.1737    1.0000      43692      64651     80.19
      205     0.1737    1.0000      43692      65536     80.19
        3     0.1725    0.0723     136433      65333     81.54
        1     0.1725    0.0723     136433      65536     81.54
    [hint] contiguous rank groups: [[160, 161, 162, 163], [204, 205, 206, 207]]

[step 12] step_time=74.09s  tgs_med=879.8 (0.53x baseline)
  attn (LLM) ratio:      med=0.0641  p90=0.0946  max=0.2000
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=69940  max=156895
  max_mem (any rank):    81.97 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      470     0.2000    0.0550     148612      65536     81.68
      468     0.2000    0.0550     148612      65536     81.68
      469     0.2000    0.0550     148612      65536     81.68
      471     0.2000    0.0550     148612      64391     81.68
      214     0.1715    0.0622     123068      65536     81.24
      213     0.1715    0.0622     123068      65536     81.24
      212     0.1715    0.0622     123068      65536     81.24
      215     0.1715    0.0622     123068      65277     81.24
      193     0.1446    0.9670      58565      65536     80.41
      195     0.1446    0.9670      58565      64457     80.41
    [hint] contiguous rank groups: [[212, 213, 214, 215], [468, 469, 470, 471]]

[step 20] step_time=104.88s  tgs_med=624.9 (0.38x baseline)
  attn (LLM) ratio:      med=0.3996  p90=0.8742  max=1.0000
  img_attn ratio:        max=0.4276
  text_tokens:           min=44017  max=65536
  img_tokens:            med=187968  max=260848
  max_mem (any rank):    83.35 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      281     1.0000    0.0625     259840      65536     83.26
      280     1.0000    0.0625     259840      65536     83.26
      282     1.0000    0.0625     259840      65536     83.26
      283     1.0000    0.0625     259840      65535     83.26
      285     1.0000    0.0625     259840      65536     83.35
      286     1.0000    0.0625     259840      65536     83.35
      287     1.0000    0.0625     259840      65535     83.35
      284     1.0000    0.0625     259840      65536     83.35
      289     1.0000    0.0625     259840      65536     83.23
      290     1.0000    0.0625     259840      65536     83.23
    [hint] contiguous rank groups: [[280, 281, 282, 283, 284, 285, 286, 287], [289, 290]]

[step 31] step_time=57.42s  tgs_med=1141.4 (0.69x baseline)
  attn (LLM) ratio:      med=0.1594  p90=0.1811  max=0.3952
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=36122  max=193828
  max_mem (any rank):    82.30 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      129     0.3952    0.0316     193828      65536     82.30
      131     0.3952    0.0316     193828      58510     82.30
      128     0.3952    0.0316     193828      65536     82.30
      130     0.3952    0.0316     193828      65536     82.30
      235     0.2617    0.0688     108379      63465     81.05
      232     0.2617    0.0688     108379      65536     81.05
      233     0.2617    0.0688     108379      65536     81.05
      234     0.2617    0.0688     108379      65536     81.05
      218     0.2353    0.1379      89283      65536     80.83
      217     0.2353    0.1379      89283      65536     80.83
    [hint] contiguous rank groups: [[128, 129, 130, 131], [217, 218], [232, 233, 234, 235]]

[step 36] step_time=60.72s  tgs_med=1079.3 (0.65x baseline)
  attn (LLM) ratio:      med=0.2518  p90=0.3018  max=0.5131
  img_attn ratio:        max=1.0000
  text_tokens:           min=9588  max=65536
  img_tokens:            med=27646  max=183009
  max_mem (any rank):    82.19 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      162     0.5131    0.0251     183009      65536     82.19
      163     0.5131    0.0251     183009      65122     82.19
      160     0.5131    0.0251     183009      65536     82.19
      161     0.5131    0.0251     183009      65536     82.19
      234     0.3810    0.0340     115866      65536     81.24
      235     0.3810    0.0340     115866      62941     81.24
      233     0.3810    0.0340     115866      65536     81.24
      232     0.3810    0.0340     115866      65536     81.24
      511     0.3582    1.0000      28452      65516     80.11
      508     0.3582    1.0000      28452      65536     80.11
    [hint] contiguous rank groups: [[160, 161, 162, 163], [232, 233, 234, 235]]

[step 37] step_time=62.29s  tgs_med=1052.1 (0.64x baseline)
  attn (LLM) ratio:      med=0.1754  p90=0.2016  max=0.4798
  img_attn ratio:        max=1.0000
  text_tokens:           min=31165  max=65536
  img_tokens:            med=34392  max=205150
  max_mem (any rank):    82.39 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      510     0.4798    0.0267     205150      65536     82.39
      511     0.4798    0.0267     205150      62832     82.39
      508     0.4798    0.0267     205150      65536     82.39
      509     0.4798    0.0267     205150      65536     82.39
      407     0.2635    0.0343      91810      65395     80.73
      405     0.2635    0.0343      91810      65536     80.73
      406     0.2635    0.0343      91810      65536     80.73
      404     0.2635    0.0343      91810      65536     80.73
      364     0.2557    0.0470     101544      65536     80.93
      365     0.2557    0.0470     101544      65536     80.93
    [hint] contiguous rank groups: [[364, 365], [404, 405, 406, 407], [508, 509, 510, 511]]

[step 44] step_time=58.05s  tgs_med=1128.8 (0.68x baseline)
  attn (LLM) ratio:      med=0.0470  p90=0.0916  max=0.1276
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=84880  max=144194
  max_mem (any rank):    81.70 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      255     0.1276    0.0868     107555      62374     81.17
      252     0.1276    0.0868     107555      65536     81.17
      254     0.1276    0.0868     107555      65536     81.17
      253     0.1276    0.0868     107555      65536     81.17
      481     0.1123    0.8811      61892      65536     80.52
      482     0.1123    0.8811      61892      65536     80.52
      483     0.1123    0.8811      61892      65362     80.52
      480     0.1123    0.8811      61892      65536     80.52
      114     0.1103    1.0000      72471      65536     80.61
      112     0.1103    1.0000      72471      65536     80.61
    [hint] contiguous rank groups: [[252, 253, 254, 255], [480, 481, 482, 483]]

[step 48] step_time=57.60s  tgs_med=1137.8 (0.69x baseline)
  attn (LLM) ratio:      med=0.0448  p90=0.1153  max=0.2896
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=104770  max=181359
  max_mem (any rank):    82.29 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      474     0.2896    0.0662     181359      65536     82.29
      472     0.2896    0.0662     181359      65536     82.29
      475     0.2896    0.0662     181359      64291     82.29
      473     0.2896    0.0662     181359      65536     82.29
       70     0.2822    0.1930      94510      65536     80.96
       69     0.2822    0.1930      94510      65536     80.96
       68     0.2822    0.1930      94510      65536     80.96
       71     0.2822    0.1930      94510      65313     80.96
       54     0.2525    0.2017      87498      65536     80.83
       55     0.2525    0.2017      87498      65488     80.83
    [hint] contiguous rank groups: [[54, 55], [68, 69, 70, 71], [472, 473, 474, 475]]

[step 50] step_time=58.09s  tgs_med=1128.3 (0.68x baseline)
  attn (LLM) ratio:      med=0.1172  p90=0.1374  max=0.2101
  img_attn ratio:        max=1.0000
  text_tokens:           min=40828  max=65536
  img_tokens:            med=46397  max=124944
  max_mem (any rank):    81.37 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      265     0.2101    0.9057      46754      65536     80.37
      266     0.2101    0.9057      46754      65536     80.37
      267     0.2101    0.9057      46754      65213     80.37
      264     0.2101    0.9057      46754      65536     80.37
      321     0.1898    0.0347      99226      65536     81.03
      323     0.1898    0.0347      99226      65375     81.03
      322     0.1898    0.0347      99226      65536     81.03
      320     0.1898    0.0347      99226      65536     81.03
      472     0.1889    0.0794     124944      65536     81.37
      474     0.1889    0.0794     124944      65536     81.37
    [hint] contiguous rank groups: [[264, 265, 266, 267], [320, 321, 322, 323]]

[step 58] step_time=98.87s  tgs_med=662.8 (0.40x baseline)
  attn (LLM) ratio:      med=0.4067  p90=0.8749  max=1.0000
  img_attn ratio:        max=0.3453
  text_tokens:           min=0  max=65536
  img_tokens:            med=188608  max=260684
  max_mem (any rank):    83.56 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      294     1.0000    0.0625     259840      65536     83.39
      293     1.0000    0.0625     259840      65536     83.39
      295     1.0000    0.0625     259840      65535     83.39
      292     1.0000    0.0625     259840      65536     83.39
      276     0.9973    0.0625     260224      65536     83.36
      278     0.9973    0.0625     260224      65536     83.36
      277     0.9973    0.0625     260224      65536     83.36
      279     0.9973    0.0625     260224      65399     83.36
      291     0.9950    0.0625     259960      65402     83.37
      290     0.9950    0.0625     259960      65536     83.37
    [hint] contiguous rank groups: [[276, 277, 278, 279], [290, 291, 292, 293, 294, 295]]

[step 110] step_time=99.76s  tgs_med=656.9 (0.40x baseline)
  attn (LLM) ratio:      med=0.4024  p90=0.8692  max=0.9993
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=185620  max=260582
  max_mem (any rank):    83.35 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      262     0.9993    0.0625     259840      65536     83.27
      260     0.9993    0.0625     259840      65536     83.27
      261     0.9993    0.0625     259840      65536     83.27
      263     0.9993    0.0625     259840      65450     83.27
      253     0.9946    0.0625     260368      65536     83.28
      255     0.9946    0.0625     260368      65521     83.28
      252     0.9946    0.0625     260368      65536     83.28
      254     0.9946    0.0625     260368      65536     83.28
      246     0.9901    0.0625     260352      65536     83.33
      245     0.9901    0.0625     260352      65536     83.33
    [hint] contiguous rank groups: [[245, 246], [252, 253, 254, 255], [260, 261, 262, 263]]

[step 114] step_time=57.38s  tgs_med=1142.0 (0.69x baseline)
  attn (LLM) ratio:      med=0.1182  p90=0.1517  max=0.5476
  img_attn ratio:        max=1.0000
  text_tokens:           min=28333  max=65536
  img_tokens:            med=46322  max=197460
  max_mem (any rank):    82.29 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      103     0.5476    0.0395     197460      65191     82.29
      101     0.5476    0.0395     197460      65536     82.29
      100     0.5476    0.0395     197460      65536     82.29
      102     0.5476    0.0395     197460      65536     82.29
      305     0.2981    0.0408     169899      65536     81.99
      307     0.2981    0.0408     169899      56123     81.99
      304     0.2981    0.0408     169899      65536     81.99
      306     0.2981    0.0408     169899      65536     81.99
      370     0.2447    0.0435     127415      65536     81.31
      369     0.2447    0.0435     127415      65536     81.31
    [hint] contiguous rank groups: [[100, 101, 102, 103], [304, 305, 306, 307], [369, 370]]

[step 144] step_time=57.79s  tgs_med=1134.0 (0.68x baseline)
  attn (LLM) ratio:      med=0.0887  p90=0.1105  max=0.5039
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=56774  max=200308
  max_mem (any rank):    82.57 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      479     0.5039    0.0391     197594      65332     82.57
      476     0.5039    0.0391     197594      65536     82.57
      478     0.5039    0.0391     197594      65536     82.57
      477     0.5039    0.0391     197594      65536     82.57
       46     0.2366    0.0434     200308      65536     82.41
       47     0.2366    0.0434     200308      64857     82.41
       44     0.2366    0.0434     200308      65536     82.41
       45     0.2366    0.0434     200308      65536     82.41
      308     0.1731    0.5988      42712      65536     80.14
      309     0.1731    0.5988      42712      65536     80.14
    [hint] contiguous rank groups: [[44, 45, 46, 47], [308, 309], [476, 477, 478, 479]]

[step 146] step_time=56.67s  tgs_med=1156.4 (0.70x baseline)
  attn (LLM) ratio:      med=0.2446  p90=0.3091  max=0.5423
  img_attn ratio:        max=1.0000
  text_tokens:           min=40013  max=65536
  img_tokens:            med=25633  max=178486
  max_mem (any rank):    82.03 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      384     0.5423    0.0250     178486      65536     82.03
      387     0.5423    0.0250     178486      65426     82.03
      386     0.5423    0.0250     178486      65536     82.03
      385     0.5423    0.0250     178486      65536     82.03
      511     0.3945    0.4162      13199      63697     79.66
      508     0.3945    0.4162      13199      65536     79.66
      509     0.3945    0.4162      13199      65536     79.66
      510     0.3945    0.4162      13199      65536     79.66
      506     0.3705    1.0000      19557      65536     79.78
      505     0.3705    1.0000      19557      65536     79.78
    [hint] contiguous rank groups: [[384, 385, 386, 387], [505, 506], [508, 509, 510, 511]]

[step 148] step_time=60.98s  tgs_med=1074.6 (0.65x baseline)
  attn (LLM) ratio:      med=0.1484  p90=0.1747  max=0.6248
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=41383  max=215510
  max_mem (any rank):    82.82 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      402     0.6248    0.0330     215510      65536     82.82
      400     0.6248    0.0330     215510      65536     82.82
      401     0.6248    0.0330     215510      65536     82.82
      403     0.6248    0.0330     215510      64696     82.82
      185     0.2351    0.9985      63231      65536     80.66
      187     0.2351    0.9985      63231      54828     80.66
      186     0.2351    0.9985      63231      65536     80.66
      184     0.2351    0.9985      63231      65536     80.66
      370     0.2238    0.0510     110092      65536     81.13
      369     0.2238    0.0510     110092      65536     81.13
    [hint] contiguous rank groups: [[184, 185, 186, 187], [369, 370], [400, 401, 402, 403]]

[step 187] step_time=58.41s  tgs_med=1121.9 (0.68x baseline)
  attn (LLM) ratio:      med=0.0459  p90=0.1083  max=0.5387
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=89132  max=206744
  max_mem (any rank):    82.71 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      366     0.5387    0.0444     206744      65536     82.58
      364     0.5387    0.0444     206744      65536     82.58
      367     0.5387    0.0444     206744      65222     82.58
      365     0.5387    0.0444     206744      65536     82.58
      478     0.4066    0.0460     193625      65536     82.71
      476     0.4066    0.0460     193625      65536     82.71
      477     0.4066    0.0460     193625      65536     82.71
      479     0.4066    0.0460     193625      48085     82.71
       66     0.2652    0.0568     202061      65536     82.46
       67     0.2652    0.0568     202061      65321     82.46
    [hint] contiguous rank groups: [[66, 67], [364, 365, 366, 367], [476, 477, 478, 479]]

[step 198] step_time=99.01s  tgs_med=661.9 (0.40x baseline)
  attn (LLM) ratio:      med=0.4163  p90=0.8699  max=1.0000
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=192344  max=260596
  max_mem (any rank):    83.71 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      325     1.0000    0.0625     259840      65536     83.10
      327     1.0000    0.0625     259840      65535     83.10
      326     1.0000    0.0625     259840      65536     83.10
      324     1.0000    0.0625     259840      65536     83.10
      312     0.9968    0.0625     260224      65536     83.34
      315     0.9968    0.0625     260224      65432     83.34
      314     0.9968    0.0625     260224      65536     83.34
      313     0.9968    0.0625     260224      65536     83.34
      260     0.9903    0.0625     260549      65536     83.24
      261     0.9903    0.0625     260549      65536     83.24
    [hint] contiguous rank groups: [[260, 261], [312, 313, 314, 315], [324, 325, 326, 327]]

[step 236] step_time=99.21s  tgs_med=660.5 (0.40x baseline)
  attn (LLM) ratio:      med=0.4167  p90=0.8760  max=1.0000
  img_attn ratio:        max=0.3399
  text_tokens:           min=0  max=65536
  img_tokens:            med=195726  max=260124
  max_mem (any rank):    83.32 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      311     1.0000    0.0625     259840      65535     83.19
      310     1.0000    0.0625     259840      65536     83.19
      308     1.0000    0.0625     259840      65536     83.19
      309     1.0000    0.0625     259840      65536     83.19
      300     0.9994    0.0625     259840      65536     83.20
      301     0.9994    0.0625     259840      65536     83.20
      303     0.9994    0.0625     259840      65451     83.20
      302     0.9994    0.0625     259840      65536     83.20
      299     0.9981    0.0625     259936      65461     83.32
      298     0.9981    0.0625     259936      65536     83.32
    [hint] contiguous rank groups: [[298, 299, 300, 301, 302, 303], [308, 309, 310, 311]]

[step 282] step_time=96.41s  tgs_med=679.7 (0.41x baseline)
  attn (LLM) ratio:      med=0.3636  p90=0.8745  max=0.9978
  img_attn ratio:        max=1.0000
  text_tokens:           min=0  max=65536
  img_tokens:            med=187523  max=260792
  max_mem (any rank):    83.43 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      262     0.9978    0.0625     259984      65536     83.29
      261     0.9978    0.0625     259984      65536     83.29
      260     0.9978    0.0625     259984      65536     83.29
      263     0.9978    0.0625     259984      65428     83.29
      245     0.9976    0.0625     260224      65536     83.29
      244     0.9976    0.0625     260224      65536     83.29
      246     0.9976    0.0625     260224      65536     83.29
      247     0.9976    0.0625     260224      65382     83.29
      256     0.9973    0.0625     259840      65536     83.31
      257     0.9973    0.0625     259840      65536     83.31
    [hint] contiguous rank groups: [[244, 245, 246, 247], [256, 257], [260, 261, 262, 263]]

[step 307] step_time=96.49s  tgs_med=679.2 (0.41x baseline)
  attn (LLM) ratio:      med=0.3767  p90=0.8645  max=1.0000
  img_attn ratio:        max=1.0000
  text_tokens:           min=33031  max=65536
  img_tokens:            med=178323  max=260974
  max_mem (any rank):    83.25 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      224     1.0000    0.0625     260224      65536     83.24
      226     1.0000    0.0625     260224      65536     83.24
      225     1.0000    0.0625     260224      65536     83.24
      227     1.0000    0.0625     260224      65535     83.24
      241     0.9999    0.0625     259840      65536     83.17
      240     0.9999    0.0625     259840      65536     83.17
      242     0.9999    0.0625     259840      65536     83.17
      243     0.9999    0.0625     259840      65522     83.17
      190     0.9884    0.0625     260974      65536     83.25
      188     0.9884    0.0625     260974      65536     83.25
    [hint] contiguous rank groups: [[224, 225, 226, 227], [240, 241, 242, 243]]

[step 347] step_time=70.09s  tgs_med=934.9 (0.56x baseline)
  attn (LLM) ratio:      med=0.2587  p90=0.3074  max=0.8084
  img_attn ratio:        max=1.0000
  text_tokens:           min=17726  max=65536
  img_tokens:            med=25330  max=238937
  max_mem (any rank):    82.92 GB
  Top 10 ranks by attn(LLM) ratio (single-sample-dominated packs):
     rank       attn   img_attn    img_tok   text_tok   max_mem
      284     0.8084    0.0280     238937      65536     82.92
      285     0.8084    0.0280     238937      65536     82.92
      287     0.8084    0.0280     238937      63554     82.92
      286     0.8084    0.0280     238937      65536     82.92
       92     0.5134    0.0264     190409      65536     82.26
       95     0.5134    0.0264     190409      64100     82.26
       93     0.5134    0.0264     190409      65536     82.26
       94     0.5134    0.0264     190409      65536     82.26
      509     0.4295    1.0000       3652      65536     79.63
      511     0.4295    1.0000       3652      64403     79.63
    [hint] contiguous rank groups: [[92, 93, 94, 95], [284, 285, 286, 287]]

```