### PR TITLE
fix: correct example script path in analyze_train_logs.py

### DIFF
--- a/.dev_scripts/analyze_train_logs.py
+++ b/.dev_scripts/analyze_train_logs.py
@@ -12,7 +12,7 @@ metrics for every step, and surfaces three kinds of problems:
    ranks together with their data_time.
 
 Example:
-    python xtuner/tools/analyze_train_logs.py /path/to/torchrun_logs/xxx \\
+    python .dev_scripts/analyze_train_logs.py /path/to/torchrun_logs/xxx \\
         --tgs-drop-ratio 0.7
 
 Default heuristics (overridable via CLI):


### PR DESCRIPTION
## Summary

The docstring example in `.dev_scripts/analyze_train_logs.py:L15` references:
`
python xtuner/tools/analyze_train_logs.py /path/to/torchrun_logs/xxx
`

But the script actually lives at `.dev_scripts/analyze_train_logs.py`.

This PR fixes the example path to:
`
python .dev_scripts/analyze_train_logs.py /path/to/torchrun_logs/xxx
`

## Context

Fixes #1795

One-line fix in the docstring. No functional changes.