### PR TITLE
Add reduced train policy metrics

### DIFF
--- a/xtuner/v1/model/utils/misc.py
+++ b/xtuner/v1/model/utils/misc.py
@@ -84,21 +84,37 @@ class ModelForwardExtraLogInfo(dict):
             else:
                 self[key] = tensor
 
+    @staticmethod
+    def _reduce_tensor(value: torch.Tensor, op: str) -> torch.Tensor:
+        while value.dim() >= 1:
+            if op == "sum":
+                value = torch.sum(value, dim=-1)
+            elif op == "max":
+                value = torch.max(value, dim=-1).values
+            elif op == "min":
+                value = torch.min(value, dim=-1).values
+            else:
+                raise ValueError(f"Unsupported reduce op: {op}")
+        return value
+
     def get(self):
         return_dict = {}
         # 当增加新的字段时，需要在这里添加相应的处理逻辑
-        if "max_ratio" in self:
-            while self["max_ratio"].dim() >= 1:
-                self["max_ratio"] = torch.max(self["max_ratio"], dim=-1).values
-            max_ratio_value = self["max_ratio"].item()
-            return_dict["max_ratio"] = max_ratio_value
-        if "local_base_loss" in self:
-            while self["local_base_loss"].dim() >= 1:
-                self["local_base_loss"] = torch.sum(self["local_base_loss"], dim=-1)
-            local_base_loss_value = self["local_base_loss"].item()
-            # vague keys such as `loss` should be avoided in extra_log_info,
-            # otherwise it may cause confusion in exp-track logs.
-            return_dict["local_base_loss"] = local_base_loss_value
+        sum_keys = (
+            "local_base_loss",
+            "reduced_train_policy_ratio_abs_dev_sum",
+            "reduced_train_policy_clip_low_count",
+            "reduced_train_policy_clip_high_count",
+            "reduced_train_policy_kl1_sum",
+            "reduced_train_policy_kl3_sum",
+            "reduced_train_policy_valid_count",
+        )
+        max_keys = ("max_ratio", "reduced_train_policy_ratio_max")
+        min_keys = ("reduced_train_policy_ratio_min",)
+        for keys, op in ((sum_keys, "sum"), (max_keys, "max"), (min_keys, "min")):
+            for key in keys:
+                if key in self:
+                    return_dict[key] = self._reduce_tensor(self[key], op).item()
         return return_dict
 
 

--- a/xtuner/v1/rl/loss/__init__.py
+++ b/xtuner/v1/rl/loss/__init__.py
@@ -1,4 +1,10 @@
-from .base_loss import BaseRLLossConfig, BaseRLLossContext, BaseRLLossKwargs, compute_kl_loss_weight
+from .base_loss import (
+    BaseRLLossConfig,
+    BaseRLLossContext,
+    BaseRLLossKwargs,
+    compute_kl_loss_weight,
+    finalize_train_policy_metrics,
+)
 from .grpo_loss import GRPOLossConfig, GRPOLossContext, GRPOLossKwargs
 from .loss_fn import check_config, get_policy_loss_fn, kl_penalty, pg_loss_fn, register_policy_loss, sft_loss_fn
 from .oreal_loss import OrealLossConfig, OrealLossContext, OrealLossKwargs

--- a/xtuner/v1/rl/loss/base_loss.py
+++ b/xtuner/v1/rl/loss/base_loss.py
@@ -298,7 +298,7 @@ def finalize_train_policy_metrics(extra_info_dict: dict[str, Any], device: str |
     for output_key, sum_key in output_keys.items():
         extra_info_dict[output_key] = train_policy_values[sum_key] / valid_count if valid_count > 0 else 0.0
 
-    ratio_max = train_policy_values["reduced_train_policy_ratio_max"]
+    ratio_max = train_policy_values["reduced_train_policy_ratio_max"] if valid_count > 0 else 0.0
     ratio_min = train_policy_values["reduced_train_policy_ratio_min"] if valid_count > 0 else 0.0
     extra_info_dict["reduced_train_policy_ratio_max"] = ratio_max
     extra_info_dict["reduced_train_policy_ratio_min"] = ratio_min

--- a/xtuner/v1/rl/loss/base_loss.py
+++ b/xtuner/v1/rl/loss/base_loss.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal
 
 import torch
+import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 from typing_extensions import Self
 
@@ -249,3 +250,58 @@ class BaseRLLossContext(CELossContext):
 
         self.loss_kwargs.is_weights = rollout_is_weights
         return mismatch_metrics, rollout_is_metrics
+
+
+def finalize_train_policy_metrics(extra_info_dict: dict[str, Any], device: str | torch.device) -> dict[str, Any]:
+    if "reduced_train_policy_valid_count" not in extra_info_dict:
+        return extra_info_dict
+
+    has_clip_count = (
+        "reduced_train_policy_clip_low_count" in extra_info_dict
+        and "reduced_train_policy_clip_high_count" in extra_info_dict
+    )
+    sum_keys = [
+        "reduced_train_policy_ratio_abs_dev_sum",
+        "reduced_train_policy_kl1_sum",
+        "reduced_train_policy_kl3_sum",
+        "reduced_train_policy_valid_count",
+    ]
+    if has_clip_count:
+        sum_keys.extend(["reduced_train_policy_clip_low_count", "reduced_train_policy_clip_high_count"])
+    max_keys = ("reduced_train_policy_ratio_max",)
+    min_keys = ("reduced_train_policy_ratio_min",)
+
+    def reduce_values(keys, op):
+        values = torch.tensor([extra_info_dict.pop(key, 0.0) for key in keys], dtype=torch.float32, device=device)
+        if dist.is_initialized():
+            dist.all_reduce(values, op=op)
+        return dict(zip(keys, values.tolist()))
+
+    train_policy_values = {}
+    train_policy_values.update(reduce_values(sum_keys, dist.ReduceOp.SUM))
+    train_policy_values.update(reduce_values(max_keys, dist.ReduceOp.MAX))
+    train_policy_values.update(reduce_values(min_keys, dist.ReduceOp.MIN))
+
+    valid_count = train_policy_values["reduced_train_policy_valid_count"]
+    output_keys = {
+        "reduced_train_policy_ratio_abs_dev_mean": "reduced_train_policy_ratio_abs_dev_sum",
+        "reduced_train_policy_kl1": "reduced_train_policy_kl1_sum",
+        "reduced_train_policy_kl3": "reduced_train_policy_kl3_sum",
+    }
+    if has_clip_count:
+        output_keys.update(
+            {
+                "reduced_train_policy_clip_frac_low": "reduced_train_policy_clip_low_count",
+                "reduced_train_policy_clip_frac_high": "reduced_train_policy_clip_high_count",
+            }
+        )
+    for output_key, sum_key in output_keys.items():
+        extra_info_dict[output_key] = train_policy_values[sum_key] / valid_count if valid_count > 0 else 0.0
+
+    ratio_max = train_policy_values["reduced_train_policy_ratio_max"]
+    ratio_min = train_policy_values["reduced_train_policy_ratio_min"] if valid_count > 0 else 0.0
+    extra_info_dict["reduced_train_policy_ratio_max"] = ratio_max
+    extra_info_dict["reduced_train_policy_ratio_min"] = ratio_min
+    # legacy metric，keep here
+    extra_info_dict["max_ratio"] = ratio_max
+    return extra_info_dict

--- a/xtuner/v1/rl/loss/grpo_loss.py
+++ b/xtuner/v1/rl/loss/grpo_loss.py
@@ -166,9 +166,33 @@ class GRPOLossContext(BaseRLLossContext):
         )
 
         assert old_logprobs is not None
-        ratio = (logprobs - old_logprobs.detach()).exp()
-        ratio = ratio * (shifted_labels != self.loss_cfg.ignore_idx).float()
-        extra_info = {"max_ratio": ratio.max()}
+        valid_mask = shifted_labels != self.loss_cfg.ignore_idx
+        valid_float = valid_mask.float()
+        cliprange_low = self.loss_cfg.policy_loss_cfg.get("cliprange_low")
+        cliprange_high = self.loss_cfg.policy_loss_cfg.get("cliprange_high")
+
+        log_ratio = logprobs.detach() - old_logprobs.detach()
+        log_ratio_safe = torch.clamp(log_ratio, min=-20.0, max=20.0)
+        ratio = torch.exp(log_ratio_safe)
+        kl1 = -log_ratio
+        kl3 = ratio - 1.0 - log_ratio_safe
+        ratio_abs_dev = (ratio - 1.0).abs()
+        ratio_max = ratio.masked_fill(~valid_mask, 0.0).max()
+        ratio_min = ratio.masked_fill(~valid_mask, float("inf")).min()
+        extra_info = {
+            "max_ratio": ratio_max,
+            "reduced_train_policy_ratio_abs_dev_sum": (ratio_abs_dev * valid_float).sum(),
+            "reduced_train_policy_kl1_sum": (kl1 * valid_float).sum(),
+            "reduced_train_policy_kl3_sum": (kl3 * valid_float).sum(),
+            "reduced_train_policy_valid_count": valid_float.sum(),
+            "reduced_train_policy_ratio_max": ratio_max,
+            "reduced_train_policy_ratio_min": ratio_min,
+        }
+        if cliprange_low is not None and cliprange_high is not None:
+            clip_low_mask = ratio < 1 - cliprange_low
+            clip_high_mask = ratio > 1 + cliprange_high
+            extra_info["reduced_train_policy_clip_low_count"] = (clip_low_mask & valid_mask).float().sum()
+            extra_info["reduced_train_policy_clip_high_count"] = (clip_high_mask & valid_mask).float().sum()
 
         if self.loss_cfg.use_kl_loss:
             ref_logprobs = loss_kwargs.ref_logprobs

--- a/xtuner/v1/rl/trainer/worker.py
+++ b/xtuner/v1/rl/trainer/worker.py
@@ -760,6 +760,7 @@ class TrainingWorker(SingleAcceleratorWorker, UpdateWeighter):
             log_str = ", ".join(
                 f"{key}={value:.4f}" if isinstance(value, float) else f"{key}={value}"
                 for key, value in train_log_item.items()
+                if not key.startswith("reduced_train_policy_") and key != "max_ratio"
             )
             log_str = f"Rank{self.rank} Rollout {rollout_idx} Step {i}: " + log_str
             self.logger.info(log_str)

--- a/xtuner/v1/rl/trainer/worker.py
+++ b/xtuner/v1/rl/trainer/worker.py
@@ -37,7 +37,7 @@ from xtuner.v1.model.base import ModelItem, TransformerConfig
 from xtuner.v1.model.compose.base import BaseComposeConfig, BaseComposeModel
 from xtuner.v1.model.utils.misc import ModelForwardExtraLogInfo
 from xtuner.v1.profiler import profiling_memory, profiling_time
-from xtuner.v1.rl.loss import BaseRLLossConfig, BaseRLLossContext, kl_penalty
+from xtuner.v1.rl.loss import BaseRLLossConfig, BaseRLLossContext, finalize_train_policy_metrics, kl_penalty
 from xtuner.v1.rl.utils import SingleAcceleratorWorker
 from xtuner.v1.train.trainer import LoadCheckpointConfig
 from xtuner.v1.utils import (
@@ -740,7 +740,12 @@ class TrainingWorker(SingleAcceleratorWorker, UpdateWeighter):
             else:
                 extra_info_dict = cast(dict, engine_extra_info)
 
-            extra_info_dict = {k: v.item() for k, v in extra_info_dict.items() if isinstance(v, torch.Tensor)}
+            extra_info_dict = {
+                k: v.item() if isinstance(v, torch.Tensor) else v
+                for k, v in extra_info_dict.items()
+                if isinstance(v, (torch.Tensor, int, float))
+            }
+            extra_info_dict = finalize_train_policy_metrics(extra_info_dict, DEVICE)
             train_step_info.pop("total_loss")  # type: ignore[misc]
 
             train_log_item = WorkerTrainLogItem(


### PR DESCRIPTION
## Summary

Add reduced train policy metrics to monitor the mismatch between current policy logprobs and rollout-time old logprobs.

The new metrics include:

- policy ratio min / max
- policy ratio absolute deviation mean
- approximate KL estimates `kl1` and `kl3`
- low / high clip fractions

The rollout-time old logprobs are generated on GPU during rollout. These metrics are therefore used to monitor policy lag between rollout-time sampling/logprob computation and subsequent training, which is different from train-inference implementation mismatch metrics.

## Motivation

Policy lag health is an important reference when tuning `RLDisaggregatedTrainer`. In disaggregated RL training, rollout / training resource allocation and related hyperparameters can change how stale rollout samples are by the time they are optimized.

These metrics help decide whether the current train / rollout resource ratio and update schedule are reasonable.

## Example

<img width="2130" height="963" alt="image" src="https://github.com/user-attachments/assets/d1a25564-046d-4c45-b921-80950c69d463" />

