### PR TITLE
mv abort_request to rollout worker and optimize pause time

### DIFF
--- a/tests/rl/test_lmdeploy_abort_integration.py
+++ b/tests/rl/test_lmdeploy_abort_integration.py
@@ -1,0 +1,255 @@
+import asyncio
+import math
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import httpx
+import ray
+import torch
+
+from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
+from xtuner.v1.rl.rollout.worker import RolloutConfig
+from xtuner.v1.rl.utils import AcceleratorResourcesConfig, AutoAcceleratorWorkers
+
+
+MODEL_PATH = os.environ.get("ROLLOUT_MODEL_PATH") or os.environ.get("MODEL_PATH", "")
+_RESOURCE_MAP = {"npu": "NPU", "cuda": "GPU"}
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, default))
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(os.environ.get(name, default))
+
+
+def _accelerator_type() -> str:
+    return _RESOURCE_MAP[torch.accelerator.current_accelerator().type]
+
+
+def _parse_prometheus_gauge(text: str, metric_name: str) -> float:
+    total = 0.0
+    for line in text.splitlines():
+        if not line.startswith(metric_name):
+            continue
+        try:
+            total += float(line.rsplit(" ", 1)[1])
+        except (IndexError, ValueError):
+            continue
+    return total
+
+
+async def _fetch_lmdeploy_metrics(server_urls: list[str]) -> dict[str, float]:
+    metric_names = {
+        "api_routed": "lmdeploy:num_api_requests_routed",
+        "api_waiting": "lmdeploy:num_api_requests_waiting",
+        "engine_running": "lmdeploy:num_requests_running",
+        "engine_waiting": "lmdeploy:num_requests_waiting",
+        "failed": "lmdeploy:num_requests_failed",
+    }
+    totals = dict.fromkeys(metric_names, 0.0)
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        for url in server_urls:
+            response = await client.get(f"{url}/metrics")
+            response.raise_for_status()
+            text = response.text
+            for key, metric_name in metric_names.items():
+                totals[key] += _parse_prometheus_gauge(text, metric_name)
+    return totals
+
+
+async def _wait_for_lmdeploy_activity(
+    server_urls: list[str],
+    *,
+    min_active: int,
+    timeout_s: float,
+) -> dict[str, float]:
+    deadline = time.perf_counter() + timeout_s
+    last_metrics: dict[str, float] = {}
+    while time.perf_counter() < deadline:
+        last_metrics = await _fetch_lmdeploy_metrics(server_urls)
+        active = (
+            last_metrics["api_routed"]
+            + last_metrics["api_waiting"]
+            + last_metrics["engine_running"]
+            + last_metrics["engine_waiting"]
+        )
+        if active >= min_active:
+            return last_metrics
+        await asyncio.sleep(0.2)
+    return last_metrics
+
+
+async def _wait_for_lmdeploy_idle(server_urls: list[str], *, timeout_s: float) -> dict[str, float]:
+    deadline = time.perf_counter() + timeout_s
+    last_metrics: dict[str, float] = {}
+    while time.perf_counter() < deadline:
+        last_metrics = await _fetch_lmdeploy_metrics(server_urls)
+        if (
+            last_metrics["api_routed"] == 0
+            and last_metrics["api_waiting"] == 0
+            and last_metrics["engine_running"] == 0
+            and last_metrics["engine_waiting"] == 0
+        ):
+            return last_metrics
+        await asyncio.sleep(0.2)
+    return last_metrics
+
+
+@unittest.skipUnless(
+    os.environ.get("XTUNER_USE_LMDEPLOY", "0") == "1" and MODEL_PATH,
+    "real LMDeploy abort integration requires XTUNER_USE_LMDEPLOY=1 and ROLLOUT_MODEL_PATH or MODEL_PATH",
+)
+class TestLMDeployAbortIntegration(unittest.IsolatedAsyncioTestCase):
+    """Regression test for real LMDeploy abort behavior under over-concurrency.
+
+    This intentionally starts a real LMDeploy server through XTuner's
+    RolloutController, sends more requests than the LMDeploy max batch size, and
+    asserts that /abort_request drains both API-side waiting requests and engine
+    requests within a short deadline.
+    """
+
+    async def asyncSetUp(self):
+        os.environ.setdefault("XTUNER_USE_FA3", "1")
+        os.environ.setdefault("LMD_SKIP_WARMUP", "1")
+
+        self.num_workers = _env_int("XTUNER_LMDEPLOY_ABORT_TEST_NUM_WORKERS", 1)
+        self.tensor_parallel_size = _env_int("XTUNER_LMDEPLOY_ABORT_TEST_TP", self.num_workers)
+        self.max_batch_size = _env_int("XTUNER_LMDEPLOY_ABORT_TEST_MAX_BATCH", 8)
+        self.request_count = _env_int("XTUNER_LMDEPLOY_ABORT_TEST_REQUESTS", self.max_batch_size * 4)
+        self.max_tokens = _env_int("XTUNER_LMDEPLOY_ABORT_TEST_MAX_TOKENS", 1024)
+        self.min_tokens = _env_int("XTUNER_LMDEPLOY_ABORT_TEST_MIN_TOKENS", min(256, self.max_tokens))
+        self.abort_deadline_s = _env_float("XTUNER_LMDEPLOY_ABORT_TEST_ABORT_DEADLINE_S", 15.0)
+        self.startup_activity_timeout_s = _env_float("XTUNER_LMDEPLOY_ABORT_TEST_ACTIVITY_TIMEOUT_S", 60.0)
+
+        ray.init(num_cpus=max(16, self.num_workers * 8), ignore_reinit_error=True)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.pg = None
+        self.rollout_ctl = None
+
+    async def asyncTearDown(self):
+        if self.rollout_ctl is not None:
+            try:
+                await asyncio.wait_for(self.rollout_ctl.shutdown.remote(), timeout=120)
+            except Exception:
+                pass
+        if self.pg is not None:
+            try:
+                ray.util.remove_placement_group(self.pg)
+            except Exception:
+                pass
+        ray.shutdown()
+        self.temp_dir.cleanup()
+
+    def _build_rollout_controller(self):
+        resources_cfg = AcceleratorResourcesConfig(
+            accelerator=_accelerator_type(),
+            num_workers=self.num_workers,
+            num_cpus_per_worker=8,
+            cpu_memory_per_worker=16 * 1024**3,
+        )
+        self.pg = AutoAcceleratorWorkers.build_placement_group(resources_cfg, name="lmdeploy_abort_integration_pg")
+
+        over_concurrency = max(1.0, math.ceil(self.request_count / self.max_batch_size))
+        rollout_config = RolloutConfig(
+            env="lmdeploy_abort_integration",
+            device=resources_cfg.accelerator,
+            model_path=MODEL_PATH,
+            model_name=Path(MODEL_PATH).name.lower(),
+            tokenizer_path=MODEL_PATH,
+            tensor_parallel_size=self.tensor_parallel_size,
+            expert_parallel_size=1,
+            context_length=self.max_tokens + 512,
+            rollout_max_batch_size_per_instance=self.max_batch_size,
+            allow_over_concurrency_ratio=over_concurrency,
+            rollout_timeout=max(300.0, self.max_tokens),
+            gpu_memory_utilization=_env_float("XTUNER_LMDEPLOY_ABORT_TEST_GPU_MEM", 0.8),
+            worker_log_dir=Path(self.temp_dir.name) / "work_dirs",
+            health_check_interval_seconds=60.0,
+            health_check_failure_threshold=3,
+            max_retry_per_sample=0,
+            extra_rollout_config={
+                "lmdeploy_backend": "pytorch",
+                "lmdeploy_log_level": os.environ.get("XTUNER_LMDEPLOY_ABORT_TEST_LOG_LEVEL", "INFO"),
+                "lmdeploy_uvicorn_log_level": "WARNING",
+            },
+        )
+        self.rollout_ctl = rollout_config.build(self.pg)
+        return self.rollout_ctl
+
+    def _make_state(self, idx: int) -> RolloutState:
+        return RolloutState(
+            uid=idx,
+            message_uid=idx,
+            message=[
+                {
+                    "role": "user",
+                    "content": (
+                        "Write a long numbered list. Keep going until you are stopped. "
+                        f"This is abort integration request {idx}."
+                    ),
+                }
+            ],
+            sample_params=SampleParams(
+                min_tokens=self.min_tokens,
+                max_tokens=self.max_tokens,
+                temperature=1.0,
+                top_k=0,
+                top_p=1.0,
+                return_token_ids=True,
+            ),
+        )
+
+    async def test_large_overconcurrent_abort_drains_real_lmdeploy_quickly(self):
+        rollout_ctl = self._build_rollout_controller()
+        metadata = await rollout_ctl.get_rollout_metadata.remote()
+        server_urls = list(metadata["server_url_dict"].values())
+        self.assertGreater(len(server_urls), 0)
+
+        refs = [rollout_ctl.generate.remote(self._make_state(i)) for i in range(self.request_count)]
+
+        pre_abort_metrics = await _wait_for_lmdeploy_activity(
+            server_urls,
+            min_active=min(self.max_batch_size + 1, self.request_count),
+            timeout_s=self.startup_activity_timeout_s,
+        )
+        self.assertGreater(
+            pre_abort_metrics.get("api_routed", 0)
+            + pre_abort_metrics.get("api_waiting", 0)
+            + pre_abort_metrics.get("engine_running", 0)
+            + pre_abort_metrics.get("engine_waiting", 0),
+            0,
+            msg=f"LMDeploy did not show active requests before abort. metrics={pre_abort_metrics}",
+        )
+
+        abort_start = time.perf_counter()
+        await rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
+        post_abort_metrics = await _wait_for_lmdeploy_idle(server_urls, timeout_s=self.abort_deadline_s)
+        abort_elapsed = time.perf_counter() - abort_start
+
+        results = await asyncio.wait_for(
+            asyncio.gather(*refs, return_exceptions=True),
+            timeout=self.abort_deadline_s,
+        )
+        exceptions = [result for result in results if isinstance(result, BaseException)]
+        self.assertFalse(exceptions, msg=f"Rollout refs raised after abort: {exceptions[:3]}")
+
+        statuses = [result.status for result in results]
+        self.assertIn(Status.ABORTED, statuses, msg=f"Expected at least one aborted rollout, got statuses={statuses}")
+        self.assertLess(
+            abort_elapsed,
+            self.abort_deadline_s,
+            msg=f"LMDeploy abort exceeded deadline. elapsed={abort_elapsed:.2f}s metrics={post_abort_metrics}",
+        )
+        self.assertEqual(post_abort_metrics["api_routed"], 0, msg=f"metrics after abort: {post_abort_metrics}")
+        self.assertEqual(post_abort_metrics["api_waiting"], 0, msg=f"metrics after abort: {post_abort_metrics}")
+        self.assertEqual(post_abort_metrics["engine_running"], 0, msg=f"metrics after abort: {post_abort_metrics}")
+        self.assertEqual(post_abort_metrics["engine_waiting"], 0, msg=f"metrics after abort: {post_abort_metrics}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/rl/test_multi_task_agent_loop_manager.py
+++ b/tests/rl/test_multi_task_agent_loop_manager.py
@@ -360,7 +360,6 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         )
         manager._status = AgentLoopManagerStatus.EXPIRED_BATCH
         manager._model_step = 2
-        manager._pause_time_s = 1.5
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             checkpoint_path = Path(tmp_dir)
@@ -385,7 +384,6 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(manager._status, AgentLoopManagerStatus.UPDATE_WEIGHT_AND_ABORT)
         self.assertTrue(manager._update_event.is_set())
         self.assertFalse(manager._finish_event.is_set())
-        self.assertEqual(manager._pause_time_s, 0.0)
         self.assertEqual(manager._model_step, 7)
         self.assertEqual(sampler.saved_paths, [Path(tmp_dir) / manager._TASK_CHECKPOINT_DIR / "task_a"])
         self.assertEqual(sampler.resumed_paths, [Path(tmp_dir) / manager._TASK_CHECKPOINT_DIR / "task_a"])
@@ -523,7 +521,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(AssertionError, "must return non-empty rollout_states"):
             await manager.produce_batch(batch_size=1, train_step=3, model_step=2)
 
-    async def test_pause_produce_from_async_produce_loop_sets_status_and_pause_time(self):
+    async def test_pause_produce_from_async_produce_loop_sets_status_and_returns_pause_time(self):
         strategy = _FakeProduceStrategy(cleanup_pause_time_s=2.5)
         manager = AgentLoopManager(
             task_runners=[
@@ -548,7 +546,6 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         self.assertIs(strategy.cleanup_progresses[0], manager._produce_progress)
         self.assertTrue(manager._update_event.is_set())
         self.assertEqual(manager._status, AgentLoopManagerStatus.UPDATE_WEIGHT_AND_ABORT)
-        self.assertEqual(manager._pause_time_s, 2.5)
 
     async def test_pause_produce_validates_progress_selection_before_state_change(self):
         strategy = _FakeProduceStrategy(cleanup_pause_time_s=2.5)
@@ -571,8 +568,8 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(manager._update_event.is_set())
         self.assertEqual(manager._status, AgentLoopManagerStatus.NORMAL)
 
-        with self.assertRaisesRegex(ValueError, "progress must be provided"):
-            await manager.pause_produce(use_global_progress=False)
+        with self.assertRaisesRegex(ValueError, "progress must not be provided"):
+            await manager.pause_produce(use_global_progress=False, progress=object())
         self.assertFalse(manager._update_event.is_set())
         self.assertEqual(manager._status, AgentLoopManagerStatus.NORMAL)
         self.assertEqual(strategy.cleanup_call_count, 0)

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -190,10 +190,10 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             nonlocal spawn_count
             spawn_count += 1
 
-            async def wait_forever():
-                await asyncio.Event().wait()
+            async def done():
+                return "done"
 
-            return asyncio.create_task(wait_forever())
+            return asyncio.create_task(done())
 
         self.assertFalse(
             await pending_tasks.schedule_one(max_pending=0, should_abort=lambda: False, spawn_one=spawn_one)
@@ -209,23 +209,9 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(spawn_count, 1)
 
-        self.assertEqual(await pending_tasks.cancel_all(), 1)
-        self.assertEqual(pending_tasks.count(), 0)
-
-    async def test_pending_tasks_cancel_all_clears_before_wait_claims(self):
-        pending_tasks = _PendingTasks()
-
-        async def spawn_one():
-            async def wait_forever():
-                await asyncio.Event().wait()
-
-            return asyncio.create_task(wait_forever())
-
-        self.assertTrue(
-            await pending_tasks.schedule_one(max_pending=1, should_abort=lambda: False, spawn_one=spawn_one)
-        )
-        self.assertEqual(await pending_tasks.cancel_all(), 1)
-        self.assertEqual(await pending_tasks.wait_and_claim(timeout_s=0), set())
+        await asyncio.sleep(0)
+        claimed = await pending_tasks.claim_ready()
+        self.assertEqual(len(claimed), 1)
         self.assertEqual(pending_tasks.count(), 0)
 
     async def test_sampler_with_replay_buffer(self):
@@ -335,6 +321,40 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(final_data), 2)
         self.assertEqual(final_data[0][0].id, 0)
         self.assertEqual(final_data[1][0].id, 1)
+
+    async def test_sync_produce_strategy_aborts_and_collects_early_stop_pending_tasks(self):
+        task_name = "test_sync_early_stop"
+        mock_agent_loop = self._build_agent_loop({0: 0.0, 1: 0.05})
+        produce_strategy_cfg = SyncProduceStrategyConfig(
+            should_continue_fn=lambda completed_sample_count, task_batch_size: completed_sample_count < 1
+        )
+        sampler = self._build_sampler()
+        strategy = produce_strategy_cfg.build()
+
+        ctx = self._build_context(
+            strategy,
+            task_name,
+            mock_agent_loop,
+            sampler,
+            batch_size=2,
+            train_step=4,
+            model_step=3,
+            progress=self._build_progress(task_name, target=2, train_step=4),
+        )
+        status = await strategy.produce_batch(ctx)
+
+        self.assertEqual(status, ProduceBatchStatus.NORMAL)
+        self.assertEqual(await self.replay_buffer.count(task_name, Status.COMPLETED), 1)
+        self.assertGreater(strategy.pending_task_count(), 0)
+        mock_agent_loop.rollout_ctl.pause_generation.remote.assert_not_awaited()
+
+        pause_time_s = await strategy.pause_produce(ctx)
+
+        self.assertGreaterEqual(pause_time_s, 0.0)
+        self.assertEqual(strategy.pending_task_count(), 0)
+        self.assertEqual(mock_agent_loop.rollout_ctl.pause_generation.remote.await_count, 1)
+        final_data = await self.replay_buffer.get(10, task_name, Status.COMPLETED)
+        self.assertEqual(len(final_data), 2)
 
     async def test_async_produce_strategy(self):
         # 这个async_produce_strategy的测试主要验证超发逻辑 + staleness 优先get的逻辑
@@ -705,14 +725,14 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         aborted = await self.replay_buffer.count(task_name, Status.ABORTED)
         expired = await self.replay_buffer.count(task_name, Status.EXPIRED)
         self.assertEqual(completed + aborted + expired, 3)
+        self.assertEqual(mock_agent_loop.rollout_ctl.pause_generation.remote.await_count, 1)
 
-    async def test_async_produce_strategy_pause_produce_cancels_all_on_timeout(self):
-        task_name = "test_cleanup_timeout"
-        mock_agent_loop = self._build_agent_loop({0: 0.01, 1: 60.0, 2: 60.0})
+    async def test_async_produce_strategy_pause_produce_collects_without_cancelling(self):
+        task_name = "test_cleanup_without_cancel"
+        mock_agent_loop = self._build_agent_loop({0: 0.01, 1: 0.03, 2: 0.03})
         produce_strategy_cfg = AsyncProduceStrategyConfig(over_sample_threshold=2.0, enable_partial_rollout=True)
         sampler = self._build_sampler()
         strategy = produce_strategy_cfg.build()
-        strategy.cleanup_task_time = 0
         progress = self._build_progress(task_name, target=1)
 
         ctx = self._build_context(
@@ -733,7 +753,8 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         completed = await self.replay_buffer.count(task_name, Status.COMPLETED)
         aborted = await self.replay_buffer.count(task_name, Status.ABORTED)
         expired = await self.replay_buffer.count(task_name, Status.EXPIRED)
-        self.assertEqual(completed + aborted + expired, 1)
+        self.assertEqual(completed + aborted + expired, 3)
+        self.assertEqual(mock_agent_loop.rollout_ctl.pause_generation.remote.await_count, 1)
 
     async def test_async_produce_strategy_returns_update_abort_without_sampling(self):
         task_name = "test_update_abort"

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -1,4 +1,3 @@
-import asyncio
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,65 +8,9 @@ import ray
 import torch
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status
-from xtuner.v1.rl.agent_loop_manager import AsyncProduceStrategyConfig, ProduceBatchResult
-from xtuner.v1.rl.agent_loop_manager.agent_loop_manager import AgentLoopManager, _TaskRunner
-from xtuner.v1.rl.replay_buffer import AsyncReplayBufferConfig, SerializedRayObjectRef
+from xtuner.v1.rl.agent_loop_manager import ProduceBatchResult
+from xtuner.v1.rl.replay_buffer import SerializedRayObjectRef
 from xtuner.v1.train.rl_trainer import RLColocateTrainer
-
-
-class _FakeRolloutState:
-    def __init__(self, uid: int):
-        self.id = uid
-        self.uid = str(uid)
-        self.message_uid = uid
-        self.status = Status.INIT
-        self.seq_staleness = 0
-        self.response_ids = []
-        self.response = None
-        self.reward = None
-        self.extra_fields = {}
-        self.response_model_steps = []
-
-
-class _FakeSampler:
-    def __init__(self):
-        self._next_id = 0
-
-    def __len__(self):
-        return 8
-
-    def save(self, checkpoint_path):
-        return None
-
-    def resume(self, checkpoint_path):
-        return None
-
-    async def sample(self, task_name, group_status=None, **kwargs):
-        item = _FakeRolloutState(self._next_id)
-        self._next_id += 1
-        return [item]
-
-
-def _build_fake_agent_loop():
-    rollout_ctl = MagicMock()
-    rollout_ctl.continue_generation.remote = AsyncMock(return_value=None)
-    rollout_ctl.pause_generation.remote = AsyncMock(return_value=None)
-    rollout_ctl.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
-    agent_loop = MagicMock()
-    agent_loop.rollout_ctl = rollout_ctl
-
-    async def generate_group(rollout_states, **kwargs):
-        model_step = kwargs.get("model_step", kwargs.get("train_step", 0))
-        for state in rollout_states:
-            state.status = Status.COMPLETED
-            state.response_ids = [1, 2, 3]
-            state.response = "ok"
-            state.reward = {"score": 1.0}
-            state.response_model_steps = [model_step]
-        return rollout_states
-
-    agent_loop.generate_group = generate_group
-    return agent_loop
 
 
 class TestRLColocateTrainer(unittest.TestCase):
@@ -113,6 +56,8 @@ class TestRLColocateTrainer(unittest.TestCase):
 
         trainer.rollout_controller = SimpleNamespace(
             offload=SimpleNamespace(remote=MagicMock(return_value="rollout_offloaded")),
+            pause_generation=SimpleNamespace(remote=AsyncMock(return_value=None)),
+            get_rollout_metadata=SimpleNamespace(remote=AsyncMock(return_value={"server_url_dict": {}})),
         )
         trainer.train_controller = SimpleNamespace(
             onload=MagicMock(return_value="train_onloaded"),
@@ -131,30 +76,44 @@ class TestRLColocateTrainer(unittest.TestCase):
         )
         return trainer
 
-    def test_fit_accepts_async_strategy_manager_on_colocate_path(self):
-        replay_buffer = AsyncReplayBufferConfig().build()
-        manager = AgentLoopManager(
-            task_runners=[
-                _TaskRunner(
-                    task_name="train_task",
-                    agent_loop=_build_fake_agent_loop(),
-                    produce_strategy=AsyncProduceStrategyConfig(over_sample_threshold=0.0).build(),
-                    sampler=_FakeSampler(),
-                    weight=1.0,
-                    order=0,
-                )
-            ],
-            replay_buffer=replay_buffer,
+    def test_fit_prepares_and_pauses_before_offload_on_colocate_path(self):
+        async def _produce_batch(batch_size, train_step, *, model_step):
+            return ProduceBatchResult(rollout_states=[[SimpleNamespace(message_uid=train_step, uid=train_step)]])
+
+        async def pause_produce(*args, **kwargs):
+            events.append("pause_produce")
+            return 0.25
+
+        manager = SimpleNamespace(
+            produce_batch=_produce_batch,
+            pause_produce=AsyncMock(side_effect=pause_produce),
         )
         trainer = self._make_trainer(manager)
+        events: list[str] = []
+
+        def offload_rollout():
+            events.append("offload_rollout")
+            return "rollout_offloaded"
+
+        def prepare_train_data(*args, **kwargs):
+            events.append("prepare_data")
+            return ([{"seq_ctx": "fake"}], {"batch_size": 1, "rewards/mean": 1.0})
+
+        def onload_train(*, target):
+            events.append("onload_train")
+            return "train_onloaded"
+
+        trainer.rollout_controller.offload.remote = MagicMock(side_effect=offload_rollout)
+        trainer._prepare_train_data = MagicMock(side_effect=prepare_train_data)
+        trainer.train_controller.onload = MagicMock(side_effect=onload_train)
 
         with (
-            patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
             patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
         ):
             trainer.fit()
 
         trainer.rollout_controller.offload.remote.assert_called_once_with()
+        manager.pause_produce.assert_awaited_once_with(use_global_progress=False)
         trainer.train_controller.onload.assert_called_once_with(target="all")
         trainer.train_controller.fit.assert_called_once()
         trainer._prepare_train_data.assert_called_once()
@@ -162,22 +121,29 @@ class TestRLColocateTrainer(unittest.TestCase):
         trainer._sync_weights_and_save.assert_called_once()
         trainer._log_step.assert_called_once()
         self.assertEqual(trainer._cur_step, 1)
+        self.assertLess(events.index("prepare_data"), events.index("offload_rollout"))
+        self.assertLess(events.index("pause_produce"), events.index("offload_rollout"))
+        self.assertLess(events.index("offload_rollout"), events.index("onload_train"))
 
     def test_fit_requires_non_empty_batch_from_manager(self):
         async def _produce_empty(batch_size, train_step, **kwargs):
             return ProduceBatchResult(rollout_states=[])
 
-        empty_manager = SimpleNamespace(produce_batch=_produce_empty)
+        empty_manager = SimpleNamespace(
+            produce_batch=_produce_empty,
+            pause_produce=AsyncMock(return_value=0.25),
+        )
         trainer = self._make_trainer(empty_manager)
 
         with (
-            patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
             patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
         ):
             with self.assertRaisesRegex(AssertionError, "return non-empty rollout_states"):
                 trainer.fit()
 
         trainer.rollout_controller.offload.remote.assert_not_called()
+        trainer.rollout_controller.pause_generation.remote.assert_not_awaited()
+        trainer.rollout_controller.get_rollout_metadata.remote.assert_not_awaited()
         trainer.train_controller.onload.assert_not_called()
         trainer.train_controller.fit.assert_not_called()
         trainer._prepare_train_data.assert_not_called()
@@ -196,12 +162,14 @@ class TestRLColocateTrainer(unittest.TestCase):
             )
 
         trainer = self._make_trainer(
-            SimpleNamespace(produce_batch=_produce_batch),
+            SimpleNamespace(
+                produce_batch=_produce_batch,
+                pause_produce=AsyncMock(return_value=0.25),
+            ),
             total_train_steps=3,
             sync_weights_interval=2,
         )
         with (
-            patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
             patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
         ):
             trainer.fit()
@@ -225,20 +193,23 @@ class TestRLColocateTrainer(unittest.TestCase):
         async def _produce_batch(batch_size, train_step, *, model_step):
             return ProduceBatchResult(rollout_states=[[rollout_state]])
 
-        trainer = self._make_trainer(SimpleNamespace(produce_batch=_produce_batch))
+        trainer = self._make_trainer(
+            SimpleNamespace(
+                produce_batch=_produce_batch,
+                pause_produce=AsyncMock(return_value=0.25),
+            )
+        )
         trainer._debug_rollout = True
         trainer._debug_rollout_dir = Path(self.temp_dir.name) / "debug_rollout"
 
-        with (
-            patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
-            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
-        ):
+        with patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj):
             trainer.fit()
 
         saved_path = trainer._debug_rollout_dir / "debug_rollout_1.pt"
         self.assertTrue(saved_path.exists())
         saved_batch = torch.load(saved_path, map_location="cpu", weights_only=False)
         self.assertEqual(saved_batch[0][0].response, "ok")
+        trainer.agent_loop_manager.pause_produce.assert_awaited_once_with(use_global_progress=False)
         trainer.train_controller.fit.assert_not_called()
         trainer._sync_weights_and_save.assert_not_called()
 
@@ -251,26 +222,11 @@ class TestRLColocateTrainer(unittest.TestCase):
                 [[SimpleNamespace(uid=2, message_uid=2)]],
             ]
         )
-        trainer._train_one_batch = MagicMock(
-            return_value={
-                "data_info": {"batch_size": 1},
-                "workers_log_item": [
-                    {
-                        "rollout_is_metrics": {},
-                        "mismatch_metrics": {},
-                        "rollout_entropy": 0.0,
-                        "train_entropy": 0.0,
-                        "train_metrics": [],
-                        "sft_train_metrics": {},
-                    }
-                ],
-            }
-        )
-
         trainer.fit()
 
         self.assertEqual([call.args[0] for call in trainer._load_debug_rollout_batch.call_args_list], [1, 2])
-        self.assertEqual(trainer._train_one_batch.call_count, 2)
+        self.assertEqual(trainer._prepare_train_data.call_count, 2)
+        self.assertEqual(trainer.train_controller.fit.call_count, 2)
         trainer._sync_weights_and_save.assert_not_called()
         self.assertEqual(trainer._cur_step, 2)
 

--- a/tests/rl/test_rl_disaggregated_trainer.py
+++ b/tests/rl/test_rl_disaggregated_trainer.py
@@ -68,7 +68,10 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
         )
         Path(trainer.exp_dir).mkdir(parents=True, exist_ok=True)
         trainer.agent_loop_manager = agent_loop_manager
-        trainer.eval_agent_loop_manager = SimpleNamespace(produce_batch=AsyncMock())
+        trainer.eval_agent_loop_manager = SimpleNamespace(
+            produce_batch=AsyncMock(),
+            pause_produce=AsyncMock(return_value=0.25),
+        )
         trainer.evaluator = MagicMock(eval_batch_size=1, run=MagicMock(return_value={"acc": 1.0}))
         trainer._exp_tracker = MagicMock()
         trainer._prepare_train_data = MagicMock(
@@ -90,6 +93,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
             onload_kvcache=SimpleNamespace(remote=MagicMock(return_value="onload_kvcache")),
             pause_generation=SimpleNamespace(remote=MagicMock(return_value="pause_generation")),
             continue_generation=SimpleNamespace(remote=MagicMock(return_value="continue_generation")),
+            get_rollout_metadata=SimpleNamespace(remote=MagicMock(return_value={"server_url_dict": {}})),
         )
         return trainer
 

--- a/tests/rl/test_rollout_pause_simulation.py
+++ b/tests/rl/test_rollout_pause_simulation.py
@@ -1,0 +1,276 @@
+"""CPU-only Ray simulation for rollout pause latency.
+
+Run a small sanity case:
+
+    XTUNER_RUN_ROLLOUT_PAUSE_SIM=1 \
+    XTUNER_PAUSE_SIM_WORKERS=4 \
+    XTUNER_PAUSE_SIM_BATCH_PER_WORKER=2 \
+    python tests/rl/test_rollout_pause_simulation.py -v
+
+Run the default 128-worker, 1x oversend case:
+
+    XTUNER_RUN_ROLLOUT_PAUSE_SIM=1 \
+    python tests/rl/test_rollout_pause_simulation.py -v
+"""
+
+import asyncio
+import math
+import os
+import random
+import threading
+import time
+import unittest
+from collections import Counter
+from dataclasses import dataclass
+
+os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+
+import ray
+
+
+GENERATE_GROUP = "generate"
+CONTROL_GROUP = "control"
+
+
+@dataclass(frozen=True)
+class PauseSimulationConfig:
+    worker_count: int
+    batch_per_worker: int
+    oversend_ratio: float
+    pending_per_worker: int
+    total_pending: int
+    abort_timeout_s: float
+    collect_timeout_s: float
+    abort_ack_delay_s: float
+    fast_return_ratio: float
+    fast_return_max_s: float
+    slow_return_s: float
+    seed: int
+    start_timeout_s: float
+
+    @classmethod
+    def from_env(cls) -> "PauseSimulationConfig":
+        worker_count = int(os.environ.get("XTUNER_PAUSE_SIM_WORKERS", "128"))
+        batch_per_worker = int(os.environ.get("XTUNER_PAUSE_SIM_BATCH_PER_WORKER", "16"))
+        oversend_ratio = float(os.environ.get("XTUNER_PAUSE_SIM_OVERSEND_RATIO", "1.0"))
+        pending_per_worker = int(math.ceil(batch_per_worker * (1.0 + oversend_ratio)))
+        return cls(
+            worker_count=worker_count,
+            batch_per_worker=batch_per_worker,
+            oversend_ratio=oversend_ratio,
+            pending_per_worker=pending_per_worker,
+            total_pending=worker_count * pending_per_worker,
+            abort_timeout_s=float(os.environ.get("XTUNER_PAUSE_SIM_ABORT_TIMEOUT_S", "10.0")),
+            collect_timeout_s=float(os.environ.get("XTUNER_PAUSE_SIM_COLLECT_TIMEOUT_S", "10.0")),
+            abort_ack_delay_s=float(os.environ.get("XTUNER_PAUSE_SIM_ABORT_ACK_DELAY_S", "0.0")),
+            fast_return_ratio=float(os.environ.get("XTUNER_PAUSE_SIM_FAST_RETURN_RATIO", "0.95")),
+            fast_return_max_s=float(os.environ.get("XTUNER_PAUSE_SIM_FAST_RETURN_MAX_S", "2.0")),
+            slow_return_s=float(os.environ.get("XTUNER_PAUSE_SIM_SLOW_RETURN_S", "30.0")),
+            seed=int(os.environ.get("XTUNER_PAUSE_SIM_SEED", "0")),
+            start_timeout_s=float(os.environ.get("XTUNER_PAUSE_SIM_START_TIMEOUT_S", "60.0")),
+        )
+
+
+class SimulatedRolloutWorker:
+    def __init__(self, abort_timeout_s: float, abort_ack_delay_s: float) -> None:
+        self.abort_timeout_s = abort_timeout_s
+        self.abort_ack_delay_s = abort_ack_delay_s
+        self.abort_event = threading.Event()
+        self.started_count = 0
+
+    @ray.method(concurrency_group=GENERATE_GROUP)
+    async def generate(self, request_id: int, abort_return_delay_s: float) -> dict:
+        self.started_count += 1
+        while not self.abort_event.is_set():
+            await asyncio.sleep(0.01)
+        if abort_return_delay_s <= self.abort_timeout_s:
+            await asyncio.sleep(abort_return_delay_s)
+            return {
+                "request_id": request_id,
+                "status": "backend_returned_after_abort",
+                "delay_s": abort_return_delay_s,
+            }
+
+        await asyncio.sleep(self.abort_timeout_s)
+        return {
+            "request_id": request_id,
+            "status": "client_cancelled_after_abort_timeout",
+            "delay_s": self.abort_timeout_s,
+        }
+
+    @ray.method(concurrency_group=CONTROL_GROUP)
+    async def pause_generation(self) -> dict:
+        self.abort_event.set()
+        if self.abort_ack_delay_s > 0:
+            await asyncio.sleep(self.abort_ack_delay_s)
+        return {"started_count": self.started_count}
+
+    @ray.method(concurrency_group=CONTROL_GROUP)
+    def get_started_count(self) -> int:
+        return self.started_count
+
+
+class SimulatedRolloutController:
+    def __init__(self, workers: list) -> None:
+        self.workers = workers
+
+    @ray.method(concurrency_group=CONTROL_GROUP)
+    def pause_generation(self) -> dict:
+        start = time.perf_counter()
+        results = ray.get([worker.pause_generation.remote() for worker in self.workers])
+        return {
+            "worker_count": len(results),
+            "started_count": sum(item["started_count"] for item in results),
+            "fanout_s": time.perf_counter() - start,
+        }
+
+
+def _build_abort_return_delays(config: PauseSimulationConfig) -> list[float]:
+    rng = random.Random(config.seed)
+    delays = []
+    for _ in range(config.total_pending):
+        if rng.random() < config.fast_return_ratio:
+            delays.append(rng.random() * config.fast_return_max_s)
+        else:
+            delays.append(config.slow_return_s)
+    return delays
+
+
+def _ensure_ray_initialized() -> bool:
+    if ray.is_initialized():
+        return False
+    address = os.environ.get("XTUNER_PAUSE_SIM_RAY_ADDRESS", "local")
+    init_kwargs = dict(
+        address=address,
+        include_dashboard=False,
+        ignore_reinit_error=True,
+        log_to_driver=False,
+    )
+    if address == "local":
+        init_kwargs["num_cpus"] = max(1, min(os.cpu_count() or 1, 32))
+    ray.init(**init_kwargs)
+    return True
+
+
+def _wait_until_all_requests_start(workers: list, expected_total: int, timeout_s: float) -> int:
+    deadline = time.perf_counter() + timeout_s
+    started_total = 0
+    while time.perf_counter() < deadline:
+        started_counts = ray.get([worker.get_started_count.remote() for worker in workers])
+        started_total = sum(started_counts)
+        if started_total >= expected_total:
+            return started_total
+        time.sleep(0.1)
+    return started_total
+
+
+def _collect_until_timeout(refs: list, timeout_s: float) -> tuple[list[dict], list]:
+    remaining = refs
+    collected = []
+    deadline = time.perf_counter() + timeout_s
+    while remaining:
+        wait_s = min(1.0, max(0.0, deadline - time.perf_counter()))
+        if wait_s <= 0:
+            break
+        ready, remaining = ray.wait(remaining, num_returns=len(remaining), timeout=wait_s)
+        if not ready:
+            continue
+        collected.extend(ray.get(ready))
+    return collected, remaining
+
+
+@unittest.skipUnless(
+    os.environ.get("XTUNER_RUN_ROLLOUT_PAUSE_SIM") == "1",
+    "Set XTUNER_RUN_ROLLOUT_PAUSE_SIM=1 to run the CPU-only Ray rollout pause simulation.",
+)
+class TestRolloutPauseSimulation(unittest.TestCase):
+    def test_pause_with_many_workers_and_oversend(self):
+        config = PauseSimulationConfig.from_env()
+        started_ray = _ensure_ray_initialized()
+        try:
+            worker_cls = ray.remote(
+                num_cpus=0,
+                max_concurrency=config.pending_per_worker + 4,
+                concurrency_groups={
+                    GENERATE_GROUP: config.pending_per_worker,
+                    CONTROL_GROUP: 4,
+                },
+            )(SimulatedRolloutWorker)
+            workers = [
+                worker_cls.remote(config.abort_timeout_s, config.abort_ack_delay_s)
+                for _ in range(config.worker_count)
+            ]
+            controller_cls = ray.remote(
+                num_cpus=0,
+                max_concurrency=max(4, config.worker_count),
+                concurrency_groups={
+                    GENERATE_GROUP: max(1, config.total_pending),
+                    CONTROL_GROUP: max(1, config.worker_count),
+                },
+            )(SimulatedRolloutController)
+            controller = controller_cls.remote(workers)
+
+            delays = _build_abort_return_delays(config)
+            request_refs = []
+            request_id = 0
+            for worker in workers:
+                for _ in range(config.pending_per_worker):
+                    request_refs.append(worker.generate.remote(request_id, delays[request_id]))
+                    request_id += 1
+
+            started_total = _wait_until_all_requests_start(
+                workers,
+                expected_total=config.total_pending,
+                timeout_s=config.start_timeout_s,
+            )
+            self.assertEqual(started_total, config.total_pending)
+
+            pause_start = time.perf_counter()
+            pause_result = ray.get(controller.pause_generation.remote())
+            abort_fanout_s = time.perf_counter() - pause_start
+
+            collect_start = time.perf_counter()
+            collected, remaining = _collect_until_timeout(request_refs, config.collect_timeout_s)
+            collect_s = time.perf_counter() - collect_start
+            total_pause_s = time.perf_counter() - pause_start
+
+            status_counts = Counter(item["status"] for item in collected)
+            expected_fast = sum(delay <= config.abort_timeout_s for delay in delays)
+            expected_slow = config.total_pending - expected_fast
+
+            print("\nRollout pause simulation")
+            print(f"  workers                    : {config.worker_count}")
+            print(f"  batch_per_worker           : {config.batch_per_worker}")
+            print(f"  oversend_ratio             : {config.oversend_ratio:.2f}")
+            print(f"  pending_per_worker         : {config.pending_per_worker}")
+            print(f"  total_pending              : {config.total_pending}")
+            print(f"  abort_timeout_s            : {config.abort_timeout_s:.2f}")
+            print(f"  collect_timeout_s          : {config.collect_timeout_s:.2f}")
+            print(f"  fast_return_ratio          : {config.fast_return_ratio:.2f}")
+            print(f"  expected_backend_returned  : {expected_fast}")
+            print(f"  expected_client_cancelled  : {expected_slow}")
+            print(f"  abort_fanout_s             : {abort_fanout_s:.3f}")
+            print(f"  controller_fanout_s        : {pause_result['fanout_s']:.3f}")
+            print(f"  collect_s                  : {collect_s:.3f}")
+            print(f"  total_pause_s              : {total_pause_s:.3f}")
+            print(f"  collected                  : {len(collected)}")
+            print(f"  remaining_after_collect    : {len(remaining)}")
+            print(f"  status_counts              : {dict(status_counts)}")
+
+            self.assertEqual(pause_result["worker_count"], config.worker_count)
+            self.assertEqual(pause_result["started_count"], config.total_pending)
+            self.assertEqual(len(collected) + len(remaining), config.total_pending)
+
+            expected_max_pause_s = os.environ.get("XTUNER_PAUSE_SIM_EXPECT_MAX_PAUSE_S")
+            if expected_max_pause_s is not None:
+                self.assertLessEqual(total_pause_s, float(expected_max_pause_s))
+
+            for ref in remaining:
+                ray.cancel(ref)
+        finally:
+            if started_ray:
+                ray.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/rl/test_rollout_utils.py
+++ b/tests/rl/test_rollout_utils.py
@@ -11,12 +11,132 @@ from unittest.mock import patch
 from xtuner.v1.data_proto.rl_data import Status, RolloutState, SampleParams
 from xtuner.v1.rl.rollout.worker import RolloutConfig
 from xtuner.v1.rl.rollout.controller import RolloutController, WorkerInfo
-from xtuner.v1.rl.rollout.utils import RolloutHealthChecker, SessionRouter
+from xtuner.v1.rl.rollout.utils import (
+    PartialRolloutHandler,
+    RolloutHealthChecker,
+    SessionRouter,
+)
 from xtuner.v1.rl.utils import AcceleratorResourcesConfig, AutoAcceleratorWorkers, asyncio_run
 
 MODEL_PATH = os.environ.get("ROLLOUT_MODEL_PATH", "")
 RESOURCE_MAP = {"npu": "NPU", "cuda": "GPU"}
 TEST_TEXT_MESSAGES=[{"role": "user", "content": "Hello!"}]
+
+
+class _FakeRemoteMethod:
+    def __init__(self, name, call_log):
+        self.name = name
+        self.call_log = call_log
+
+    def remote(self):
+        self.call_log.append((self.name, "remote"))
+        return self.name
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.call_log = []
+        self.offload = _FakeRemoteMethod("offload", self.call_log)
+        self.shutdown = _FakeRemoteMethod("shutdown", self.call_log)
+
+
+class TestRolloutHealthChecker(unittest.TestCase):
+    def _build_checker(self, workers_info):
+        config = SimpleNamespace(health_check_interval_seconds=10, health_check_failure_threshold=1)
+        return RolloutHealthChecker(config, workers_info)
+
+    def test_shutdown_runs_when_offload_fails(self):
+        worker = _FakeWorker()
+        workers_info = {0: SimpleNamespace(actor=worker, url="http://worker-0", is_active=True)}
+        checker = self._build_checker(workers_info)
+
+        async def unhealthy_worker(*args, **kwargs):
+            return False
+
+        def ray_get(ref, timeout=None):
+            worker.call_log.append((ref, "get"))
+            if ref == "offload":
+                raise RuntimeError("offload failed")
+            return None
+
+        with (
+            patch("xtuner.v1.rl.rollout.utils.check_worker_health", side_effect=unhealthy_worker),
+            patch("xtuner.v1.rl.rollout.utils.ray.get", side_effect=ray_get),
+        ):
+            checker.run_once()
+
+        self.assertFalse(workers_info[0].is_active)
+        self.assertEqual(
+            worker.call_log,
+            [
+                ("offload", "remote"),
+                ("offload", "get"),
+                ("shutdown", "remote"),
+                ("shutdown", "get"),
+            ],
+        )
+
+    def test_inactive_worker_is_not_cleaned_up_again(self):
+        worker = _FakeWorker()
+        workers_info = {0: SimpleNamespace(actor=worker, url="http://worker-0", is_active=False)}
+        checker = self._build_checker(workers_info)
+
+        with (
+            patch("xtuner.v1.rl.rollout.utils.check_worker_health") as check_worker_health_mock,
+            patch("xtuner.v1.rl.rollout.utils.ray.get") as ray_get_mock,
+        ):
+            checker.run_once()
+
+        check_worker_health_mock.assert_not_called()
+        ray_get_mock.assert_not_called()
+        self.assertEqual(worker.call_log, [])
+
+
+class TestPartialRolloutHandler(unittest.IsolatedAsyncioTestCase):
+    async def test_postprocess_frees_old_routed_expert_refs_after_concat(self):
+        class FakeObjectRef:
+            pass
+
+        history_ref = FakeObjectRef()
+        cur_ref = FakeObjectRef()
+        concat_ref = FakeObjectRef()
+        rollout_state = RolloutState(
+            message=[],
+            response="old",
+            response_ids=[1, 2],
+            logprobs=[0.1, 0.2],
+            routed_experts=history_ref,
+            status=Status.ABORTED,
+        )
+
+        async def resolve_routed_experts(value):
+            if value is history_ref:
+                return [[1], [2]]
+            if value is cur_ref:
+                return [[1], [2], [3]]
+            raise AssertionError(f"unexpected routed_experts value: {value}")
+
+        with (
+            patch("xtuner.v1.rl.rollout.utils.RayObjectRef", FakeObjectRef),
+            patch("xtuner.v1.rl.rollout.utils._resolve_routed_experts", side_effect=resolve_routed_experts),
+            patch("xtuner.v1.rl.rollout.utils.ray.put", return_value=concat_ref) as ray_put,
+            patch("xtuner.v1.rl.rollout.utils.free_object_refs") as free_object_refs,
+        ):
+            out = await PartialRolloutHandler().postprocess(
+                rollout_state,
+                response="new",
+                response_ids=[3],
+                logprobs=[0.3],
+                routed_experts=cur_ref,
+                finish_reason="abort",
+                status=Status.ABORTED,
+                enable_partial_rollout=True,
+            )
+
+        self.assertIs(out.routed_experts, concat_ref)
+        ray_put.assert_called_once_with([[1], [2], [3]])
+        free_object_refs.assert_called_once_with([history_ref, cur_ref])
+
 
 class TestRolloutControllerRecover(unittest.TestCase):
     @classmethod

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -74,6 +74,7 @@ class TestRolloutWorker(unittest.IsolatedAsyncioTestCase):
         worker.receive_abort_request = threading.Event()
         worker.logger = MagicMock()
         send_started = asyncio.Event()
+        send_cancelled = asyncio.Event()
 
         class _Client:
             def build_request(self, *args, **kwargs):
@@ -81,7 +82,11 @@ class TestRolloutWorker(unittest.IsolatedAsyncioTestCase):
 
             async def send(self, req):
                 send_started.set()
-                await asyncio.Event().wait()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    send_cancelled.set()
+                    raise
 
         worker.client = _Client()
 
@@ -93,6 +98,7 @@ class TestRolloutWorker(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result.error_type, HttpRequestErrorType.REQUEST_ABORTED)
         self.assertTrue(worker.receive_abort_request.is_set())
+        self.assertTrue(send_cancelled.is_set())
 
     async def test_safe_post_request_cancels_inflight_request_after_abort_timeout(self):
         worker = RolloutWorker.__new__(RolloutWorker)

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -1,14 +1,28 @@
 import asyncio
+import threading
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from xtuner.v1.rl.rollout.sglang import SGLangWorker
+from xtuner.v1.rl.rollout.worker import RolloutWorker
+from xtuner.v1.utils.httpx_utils import HttpRequestErrorType
 
 
 class TestSGLangWorker(unittest.TestCase):
+    def test_pause_generation_sets_abort_flag_before_server_pause(self):
+        worker = SGLangWorker.__new__(SGLangWorker)
+        worker.receive_abort_request = threading.Event()
+        worker._make_request = MagicMock(return_value="ok")
+
+        result = worker.pause_generation()
+
+        self.assertEqual(result, "ok")
+        self.assertTrue(worker.receive_abort_request.is_set())
+        worker._make_request.assert_called_once_with("pause_generation", {"mode": "abort"})
+
     def test_continue_generation_clears_abort_flag(self):
         worker = SGLangWorker.__new__(SGLangWorker)
-        worker.receive_abort_request = asyncio.Event()
+        worker.receive_abort_request = threading.Event()
         worker.receive_abort_request.set()
         worker._make_request = MagicMock(return_value="ok")
 
@@ -17,6 +31,133 @@ class TestSGLangWorker(unittest.TestCase):
         self.assertEqual(result, "ok")
         self.assertFalse(worker.receive_abort_request.is_set())
         worker._make_request.assert_called_once_with("continue_generation")
+
+
+class TestRolloutWorker(unittest.IsolatedAsyncioTestCase):
+    async def test_pause_generation_sets_abort_flag(self):
+        worker = RolloutWorker.__new__(RolloutWorker)
+        worker.receive_abort_request = threading.Event()
+        worker._send_abort_request = AsyncMock(return_value=True)
+
+        result = await worker.pause_generation()
+
+        self.assertTrue(result)
+        self.assertTrue(worker.receive_abort_request.is_set())
+        worker._send_abort_request.assert_awaited_once_with()
+
+    async def test_send_abort_request_uses_abort_timeout(self):
+        worker = RolloutWorker.__new__(RolloutWorker)
+        worker.server_url = "http://test"
+        worker.abort_timeout = 0.25
+        worker.logger = MagicMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        client_context = MagicMock()
+        client_context.__aenter__ = AsyncMock(return_value=client)
+        client_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("xtuner.v1.rl.rollout.worker.httpx.AsyncClient", return_value=client_context) as client_cls:
+            result = await worker._send_abort_request()
+
+        self.assertTrue(result)
+        client_cls.assert_called_once_with(timeout=0.25)
+        client.post.assert_awaited_once_with(
+            "http://test/abort_request",
+            json={"abort_all": True},
+        )
+
+    async def test_safe_post_request_returns_aborted_on_cancellation(self):
+        worker = RolloutWorker.__new__(RolloutWorker)
+        worker.receive_abort_request = threading.Event()
+        worker.logger = MagicMock()
+        send_started = asyncio.Event()
+
+        class _Client:
+            def build_request(self, *args, **kwargs):
+                return object()
+
+            async def send(self, req):
+                send_started.set()
+                await asyncio.Event().wait()
+
+        worker.client = _Client()
+
+        task = asyncio.create_task(worker._safe_post_request("http://test", headers={}, payload={"input_ids": [1]}))
+        await send_started.wait()
+        task.cancel()
+
+        result = await task
+
+        self.assertEqual(result.error_type, HttpRequestErrorType.REQUEST_ABORTED)
+        self.assertTrue(worker.receive_abort_request.is_set())
+
+    async def test_safe_post_request_cancels_inflight_request_after_abort_timeout(self):
+        worker = RolloutWorker.__new__(RolloutWorker)
+        worker.receive_abort_request = threading.Event()
+        worker.abort_timeout = 0.01
+        worker.logger = MagicMock()
+        send_started = asyncio.Event()
+        send_cancelled = asyncio.Event()
+
+        class _Client:
+            def build_request(self, *args, **kwargs):
+                return object()
+
+            async def send(self, req):
+                send_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    send_cancelled.set()
+                    raise
+
+        worker.client = _Client()
+
+        task = asyncio.create_task(worker._safe_post_request("http://test", headers={}, payload={"input_ids": [1]}))
+        await send_started.wait()
+        worker.receive_abort_request.set()
+
+        result = await task
+
+        self.assertEqual(result.error_type, HttpRequestErrorType.REQUEST_ABORTED)
+        self.assertTrue(send_cancelled.is_set())
+
+    async def test_safe_post_request_keeps_abort_response_within_timeout(self):
+        worker = RolloutWorker.__new__(RolloutWorker)
+        worker.receive_abort_request = threading.Event()
+        worker.abort_timeout = 1.0
+        worker.logger = MagicMock()
+        send_started = asyncio.Event()
+        finish_send = asyncio.Event()
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+        response = _Response()
+
+        class _Client:
+            def build_request(self, *args, **kwargs):
+                return object()
+
+            async def send(self, req):
+                send_started.set()
+                await finish_send.wait()
+                return response
+
+        worker.client = _Client()
+
+        task = asyncio.create_task(worker._safe_post_request("http://test", headers={}, payload={"input_ids": [1]}))
+        await send_started.wait()
+        worker.receive_abort_request.set()
+        finish_send.set()
+
+        result = await task
+
+        self.assertIs(result.response, response)
 
 
 if __name__ == "__main__":

--- a/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
+++ b/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from pydantic import BaseModel, ConfigDict
 
-from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
+from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams
 from xtuner.v1.rl.agent_loop import AgentLoop, AgentLoopConfig
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
@@ -101,8 +101,6 @@ class GSM8KToolAgentLoop(AgentLoop):
 
             rollout_state = await self.rollout_ctl.generate.remote(rollout_state)  # type: ignore[attr-defined]
             cur_turn += 1
-            if rollout_state.status != Status.COMPLETED:
-                return rollout_state
             response_ids = cast(list[int], rollout_state.response_ids)
             cur_turn_tokens.extend(response_ids)
 

--- a/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
+++ b/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from pydantic import BaseModel, ConfigDict
 
-from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams
+from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.agent_loop import AgentLoop, AgentLoopConfig
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
@@ -101,6 +101,8 @@ class GSM8KToolAgentLoop(AgentLoop):
 
             rollout_state = await self.rollout_ctl.generate.remote(rollout_state)  # type: ignore[attr-defined]
             cur_turn += 1
+            if rollout_state.status != Status.COMPLETED:
+                return rollout_state
             response_ids = cast(list[int], rollout_state.response_ids)
             cur_turn_tokens.extend(response_ids)
 

--- a/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
@@ -13,7 +13,7 @@ from xtuner.v1.data_proto.rl_data import RolloutState, Status
 from xtuner.v1.rl.agent_loop import AgentLoopConfig, AgentLoopSpec, get_agent_loop_rollout_ctl
 from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig, build_judger
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
-from xtuner.v1.rl.rollout import RolloutController, continue_generation, pause_generation
+from xtuner.v1.rl.rollout import RolloutController
 from xtuner.v1.rl.utils import asyncio_run
 from xtuner.v1.utils import get_logger
 
@@ -379,11 +379,7 @@ class AgentLoopManager:
         # self._status，不要跨 await 缓存局部快照，避免错过同步、过期或结束状态变化。
         self._status = AgentLoopManagerStatus.NORMAL
 
-        # pause_produce 写入、下一次 get batch 读取并清零的耗时指标。
-        # 只用于消费侧日志/metrics；读写不构成生产正确性依赖。
-        self._pause_time_s = 0.0
-
-        # 非共卡 producer / consumer 共享的绝对累计进度。对象引用必须保持稳定；
+        # producer / consumer 共享的当前进度。对象引用必须保持稳定；
         # consumer 原地更新字段，producer / strategy 需要字段值时直接读取 progress.xxx，
         # 不要把字段值复制成跨 await 使用的局部快照。
         self._produce_progress = ProduceProgress.build(self.task_names)
@@ -587,19 +583,13 @@ class AgentLoopManager:
         #
         # 因此调用方必须显式说明是否使用全局 progress：
         # - use_global_progress=True：非共卡后台生产循环在权重同步点前暂停；
-        # - use_global_progress=False：共卡同步 produce_batch 的本次调用收尾，使用本地 progress。
-        # 返回值 `pause_time_s` 不是业务语义，而是日志/诊断信息，
-        # 供训练侧在下一次消费 batch 时上报。
+        # - use_global_progress=False：共卡同步 produce_batch 的本次调用收尾，使用已 reset 到本次 batch 的 progress。
+        # 返回值 `pause_time_s` 不是业务语义，而是日志/诊断信息，由 trainer 直接写入当前 batch。
         # use_global_progress=False 模式会在下一次 produce_batch 入口通过 continue_produce 恢复；
         # use_global_progress=True 模式则由 trainer 在权重同步和评测完成后显式恢复。
-        if use_global_progress:
-            if progress is not None:
-                raise ValueError("progress must not be provided when use_global_progress=True.")
-            pause_progress = self._produce_progress
-        else:
-            if progress is None:
-                raise ValueError("progress must be provided when use_global_progress=False.")
-            pause_progress = progress
+        if progress is not None:
+            raise ValueError("progress must not be provided.")
+        pause_progress = self._produce_progress
 
         # 合法参数确认后，统一拉起 manager 级暂停信号，阻止仍在运行的 produce_batch 继续调度新 rollout。
         self._update_event.set()
@@ -686,9 +676,6 @@ class AgentLoopManager:
         task_batch_sizes: dict[str, int],
         consume_progress: ProduceProgress,
     ) -> ProduceBatchResult:
-        pause_time_s = self._pause_time_s
-        self._pause_time_s = 0.0
-
         self._validate_task_batch_sizes(task_batch_sizes, batch_size)
         batch_by_task, consumed_counts = await self.replay_buffer.take_batch(task_batch_sizes)
         consume_progress.mark_consumed(consumed_counts)
@@ -699,7 +686,7 @@ class AgentLoopManager:
             batch_by_task,
             leftover_counts,
             progress=consume_progress,
-            pause_time_s=pause_time_s,
+            pause_time_s=0.0,
         )
 
     def continue_produce(self, model_step: int) -> None:
@@ -733,10 +720,10 @@ class AgentLoopManager:
     ) -> ProduceBatchResult:
         # `produce_batch()` 是保留给 colocate 路径的同步入口。
         #
-        # 它虽然名字没变，但内部已经改成三段式：
+        # 它虽然名字没变，但内部已经改成拆分式：
         # 1. `_produce_batch_to_buffer()` 只负责生产，把结果写入 replay buffer
-        # 2. `pause_produce()` 显式收尾 pending rollout
-        # 3. `_get_batch_from_buffer()` 再把训练 batch 取出来
+        # 2. `_get_batch_from_buffer()` 把训练 batch 取出来
+        # 3. trainer 显式调用 `pause_produce(use_global_progress=False)` 收尾 pending rollout
         #
         # 这也是为什么这里要求返回非空 batch：
         # - colocate 语义下，调用它就是为了拿一批可训练 completed groups
@@ -753,38 +740,30 @@ class AgentLoopManager:
 
         rollout_ctl = await get_agent_loop_rollout_ctl(self.task_runners[0].agent_loop)
         # TODO: put in self.continue_produce()
-        await continue_generation(rollout_ctl)
-        try:
-            # 共卡路径不复用非共卡的 paused producer 状态机。
-            # 即使 manager 是从 resume() 恢复出来、当前仍处在 UPDATE_WEIGHT_AND_ABORT，
-            # produce_batch() 也应视作一次独立的同步生产过程，从干净状态开始。
-            #
-            # 共卡路径下，produce_batch() 对应 rollout worker 当前持有的权重版本。
-            self.continue_produce(model_step=model_step)
-            # 共卡 produce_batch 也是消费入口；生产前先刷新 buffer 中已有 completed / aborted。
-            await self._refresh_for_all_tasks(train_step, [Status.COMPLETED, Status.ABORTED])
-            local_progress = ProduceProgress.build_local(self.task_names, current_sizes, train_step)
-            status = await self._produce_batch_to_buffer(
-                task_batch_sizes=current_sizes,
-                progress=local_progress,
-            )
-            await self.pause_produce(
-                use_global_progress=False,
-                progress=local_progress,
-            )
-            result = await self._get_batch_from_buffer(
-                batch_size=batch_size,
-                task_batch_sizes=current_sizes,
-                consume_progress=local_progress,
-            )
-            result.status = status
-            assert result.rollout_states, (
-                "AgentLoopManager.produce_batch() must return non-empty rollout_states for colocated training. "
-                "Use get_batch() for disaggregated empty/expired reads."
-            )
-        finally:
-            # TODO: put in self.pause_produce()
-            await pause_generation(rollout_ctl)
+        await rollout_ctl.continue_generation.remote()  # type: ignore[attr-defined]
+        # 共卡路径不复用非共卡的 paused producer 状态机。
+        # 即使 manager 是从 resume() 恢复出来、当前仍处在 UPDATE_WEIGHT_AND_ABORT，
+        # produce_batch() 也应视作一次独立的同步生产过程，从干净状态开始。
+        #
+        # 共卡路径下，produce_batch() 对应 rollout worker 当前持有的权重版本。
+        self.continue_produce(model_step=model_step)
+        # 共卡 produce_batch 也是消费入口；生产前先刷新 buffer 中已有 completed / aborted。
+        await self._refresh_for_all_tasks(train_step, [Status.COMPLETED, Status.ABORTED])
+        self._produce_progress.reset(self.task_names, current_sizes, train_step)
+        status = await self._produce_batch_to_buffer(
+            task_batch_sizes=current_sizes,
+            progress=self._produce_progress,
+        )
+        result = await self._get_batch_from_buffer(
+            batch_size=batch_size,
+            task_batch_sizes=current_sizes,
+            consume_progress=self._produce_progress,
+        )
+        result.status = status
+        assert result.rollout_states, (
+            "AgentLoopManager.produce_batch() must return non-empty rollout_states for colocated training. "
+            "Use get_batch() for disaggregated empty/expired reads."
+        )
 
         self.logger.info(
             f"[AgentLoopManager][{self.name}] produce_batch done "
@@ -813,7 +792,7 @@ class AgentLoopManager:
                 continue
 
             rollout_ctl = await get_agent_loop_rollout_ctl(self.task_runners[0].agent_loop)
-            await continue_generation(rollout_ctl)
+            await rollout_ctl.continue_generation.remote()  # type: ignore[attr-defined]
             task_batch_sizes = self._produce_progress.ensure_target_upto(
                 batch_size=batch_size,
                 future_step=self._produce_progress.producer_future_step,
@@ -840,7 +819,7 @@ class AgentLoopManager:
         # `get_batch()` 是非共卡路径给 trainer 的消费接口。
         #
         # 设计上它和 `produce_batch()` 明确分工：
-        # - `produce_batch()`：colocate，一次调用内完成“生产+收尾+取数”
+        # - `produce_batch()`：colocate，一次调用内完成“生产+取数”，收尾由 trainer 显式调用
         # - `get_batch()`：disagg，等待 replay buffer 准备好当前训练步所需 batch 后再取数
         #
         # 因而这里允许返回空 batch 的唯一合法场景仍然只有：
@@ -933,6 +912,5 @@ class AgentLoopManager:
         self._finish_event = asyncio.Event()
         self._update_event.set()
         self._status = AgentLoopManagerStatus.UPDATE_WEIGHT_AND_ABORT
-        self._pause_time_s = 0.0
         self._model_step = saved_model_step
         return saved_model_step

--- a/xtuner/v1/rl/agent_loop_manager/producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/producer.py
@@ -22,7 +22,6 @@ from xtuner.v1.data_proto.rl_data import (
 )
 from xtuner.v1.rl.agent_loop import AgentLoopSpec, get_agent_loop_rollout_ctl
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
-from xtuner.v1.rl.rollout.utils import pause_generation
 from xtuner.v1.rl.utils import calculate_seq_staleness, create_task
 from xtuner.v1.utils import get_logger
 
@@ -207,6 +206,14 @@ class ProduceProgress:
             {task_name: int(state.get("raw_rewards_count", {}).get(task_name, 0)) for task_name in task_names}
         )
 
+    def reset(
+        self,
+        task_names: list[str],
+        task_batch_sizes: dict[str, int],
+        train_step: int,
+    ) -> None:
+        self.load_state_dict(self.build_local(task_names, task_batch_sizes, train_step).state_dict())
+
 
 class ProduceBatchStatus(Enum):
     NORMAL = auto()
@@ -277,6 +284,10 @@ class ProduceContext:
     def should_abort(self) -> bool:
         return self.update_event.is_set()
 
+    async def abort_generation(self) -> None:
+        rollout_ctl = await get_agent_loop_rollout_ctl(self.agent_loop)
+        await rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
+
     async def expired_count(self) -> int:
         return await self.replay_buffer.count(task_name=self.task_name, group_status=Status.EXPIRED)
 
@@ -297,10 +308,11 @@ class ProduceContext:
         # strategy 只表达“要生成”，不关心 agent_loop 是 ray actor 还是本地对象。
         start = time.perf_counter()
         if isinstance(self.agent_loop, ray.actor.ActorHandle):
-            result = await self.agent_loop.generate_group.remote(
+            result_ref = self.agent_loop.generate_group.remote(
                 rollout_state,
                 enable_partial_rollout=enable_partial_rollout,
             )
+            result = await result_ref
         else:
             result = await self.agent_loop.generate_group(
                 rollout_state,
@@ -469,6 +481,8 @@ class AsyncProduceStrategyConfig(ProduceStrategyConfig):
 
 
 class ProduceStrategy(ABC):
+    PENDING_TASK_COLLECT_TIMEOUT_S = 10.0
+
     def __init__(
         self,
         is_valid_sample_fn: IsValidSampleFn,
@@ -476,27 +490,87 @@ class ProduceStrategy(ABC):
     ):
         self.is_valid_sample_fn = is_valid_sample_fn
         self.should_continue_fn = should_continue_fn
+        self._pending_tasks = _PendingTasks()
 
     @abstractmethod
     async def produce_batch(self, ctx: ProduceContext) -> ProduceBatchStatus: ...
 
     async def pause_produce(self, ctx: ProduceContext) -> float:
-        return 0.0
+        pause_start = time.perf_counter()
+        if self.pending_task_count() == 0:
+            return 0.0
+
+        await ctx.abort_generation()
+        await self._collect_pending_tasks_after_abort(ctx)
+        pause_duration = time.perf_counter() - pause_start
+        logger.info(f"Paused production for task {ctx.task_name} in {pause_duration:.2f}s.")
+        return pause_duration
+
+    async def _put_claimed(
+        self,
+        claimed_tasks: set[asyncio.Task],
+        ctx: ProduceContext,
+        available_base: int | None = None,
+        progress_displayer: _ProgressDisplayer | None = None,
+    ) -> int:
+        completed_count = 0
+        for task in claimed_tasks:
+            is_completed = await ctx.put_generated_group(task.result())
+            if is_completed:
+                completed_count += 1
+            if is_completed and available_base is not None and progress_displayer is not None:
+                progress_displayer.update(available_base + completed_count)
+        return completed_count
 
     def is_model_expired(self, train_step: int, model_step: int) -> bool:
         # 默认同步策略没有跨权重版本的后台样本，只有异步策略需要判定模型过期。
         return False
 
     def pending_task_count(self) -> int:
-        return 0
+        return self._pending_tasks.count()
+
+    async def _collect_pending_tasks_after_abort(self, ctx: ProduceContext) -> int:
+        # pause_produce() sends one abort request before entering this method.
+        # Then we first collect tasks that already returned, wait briefly for
+        # more aborted requests to return, and finally stop waiting after the
+        # timeout so training can move on without producer-side cancellation.
+        claimed_done = await self._pending_tasks.claim_ready()
+        collected_count = await self._put_claimed(claimed_done, ctx)
+
+        pending_after_abort = self._pending_tasks.count()
+        if pending_after_abort:
+            logger.warning(
+                f"After one abort request, task {ctx.task_name} still has {pending_after_abort} pending rollout tasks. "
+                f"Waiting up to {self.PENDING_TASK_COLLECT_TIMEOUT_S:.2f}s for aborted requests to return."
+            )
+
+        collect_deadline = time.perf_counter() + self.PENDING_TASK_COLLECT_TIMEOUT_S
+        while self._pending_tasks.count() > 0:
+            remaining_time = collect_deadline - time.perf_counter()
+            if remaining_time <= 0:
+                break
+            claimed_done = await self._pending_tasks.wait_and_claim(timeout_s=min(1.0, remaining_time))
+            if not claimed_done:
+                continue
+            collected_count += await self._put_claimed(claimed_done, ctx)
+
+        if collected_count:
+            logger.info(f"Collected {collected_count} rollout tasks for task {ctx.task_name} after abort.")
+        pending_count = self._pending_tasks.count()
+        if pending_count:
+            logger.warning(
+                f"After waiting {self.PENDING_TASK_COLLECT_TIMEOUT_S:.2f}s for abort responses, "
+                f"task {ctx.task_name} still has {pending_count} pending rollout tasks. "
+                "The rollout worker request timeout is expected to finish them without producer-side cancellation."
+            )
+        return collected_count
 
 
 class _PendingTasks:
-    """AsyncProduceStrategy 的并发 pending task 集合。
+    """ProduceStrategy 的并发 pending task 集合。
 
     这里只封装 pending set 的并发协议，不理解 sampler / rollout / replay buffer：
     - wait 使用快照，随后必须二次 claim，避免 produce 和 pause 重复处理同一个 done task。
-    - cancel 前先原子 claim 并清空集合，避免 cancel 后又被其他路径 claim。
     - schedule one 在锁内同时检查 abort 和 pending 数，避免 pause 已触发后继续新增 task。
     """
 
@@ -540,33 +614,36 @@ class _PendingTasks:
             self._tasks.add(await spawn_one())
             return True
 
-    async def _claim_all(self) -> set[asyncio.Task]:
-        async with self._lock:
-            claimed = set(self._tasks)
-            self._tasks.clear()
-            return claimed
-
-    async def cancel_all(self) -> int:
-        tasks = await self._claim_all()
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        return len(tasks)
-
 
 class SyncProduceStrategy(ProduceStrategy):
+    def __init__(
+        self,
+        is_valid_sample_fn: IsValidSampleFn,
+        should_continue_fn: ShouldContinueFn,
+    ):
+        super().__init__(is_valid_sample_fn, should_continue_fn)
+
     async def produce_batch(self, ctx: ProduceContext) -> ProduceBatchStatus:
-        pending_tasks = set()
         completed_sample_count = await ctx.replay_buffer.count(task_name=ctx.task_name, group_status=Status.COMPLETED)
         # TODO: 是否支持 SyncProduceStrategy 在非共卡时使用？如果支持，下面这行注释掉？
         # assert completed_sample_count == 0, "SyncProduceStrategy assumes no completed samples at the start."
 
-        for _ in range(ctx.task_batch_size):
-            rollout_state = await ctx.sampler.sample(task_name=ctx.task_name)
-            task = create_task(ctx.generate_group(rollout_state))
-            pending_tasks.add(task)
+        claimed_done = await self._pending_tasks.claim_ready()
+        completed_sample_count += await self._put_claimed(claimed_done, ctx)
 
-        logger.info(f"[SyncProduceStrategy] Started {len(pending_tasks)} initial tasks.")
+        async def spawn_one() -> asyncio.Task:
+            rollout_state = await ctx.sampler.sample(task_name=ctx.task_name)
+            return create_task(ctx.generate_group(rollout_state))
+
+        started_count = 0
+        while await self._pending_tasks.schedule_one(
+            max_pending=ctx.task_batch_size,
+            should_abort=ctx.should_abort,
+            spawn_one=spawn_one,
+        ):
+            started_count += 1
+
+        logger.info(f"[SyncProduceStrategy] Started {started_count} initial tasks.")
 
         progress_displayer = _ProgressDisplayer.create(
             strategy_name=self.__class__.__name__,
@@ -575,31 +652,33 @@ class SyncProduceStrategy(ProduceStrategy):
             initial=completed_sample_count,
         )
         try:
+            progress_displayer.update(completed_sample_count)
             while self.should_continue_fn(completed_sample_count, ctx.task_batch_size):
-                if not pending_tasks:
+                if self._pending_tasks.count() == 0:
                     logger.warning("[SyncProduceStrategy] All tasks are done but not enough samples collected.")
                     break
-                done_tasks, pending_tasks = await asyncio.wait(
-                    pending_tasks, timeout=1, return_when=asyncio.FIRST_COMPLETED
-                )
+                done_tasks = await self._pending_tasks.wait_and_claim(timeout_s=1)
+                if not done_tasks:
+                    continue
                 # 如果要过滤，在这个地方处理，然后加入到 replay buffer
                 # 如果被过滤的数据就放到 put_to_filtered pool 中
-                for task in done_tasks:
-                    items = task.result()
+                completed_sample_count += await self._put_claimed(
+                    done_tasks,
+                    ctx,
+                    available_base=completed_sample_count,
+                    progress_displayer=progress_displayer,
+                )
 
-                    is_completed = await ctx.put_generated_group(items)
-                    if not is_completed:
-                        continue
-
-                    completed_sample_count += 1
-                    progress_displayer.update(completed_sample_count)
-
-                while len(pending_tasks) + completed_sample_count < ctx.task_batch_size and self.should_continue_fn(
-                    completed_sample_count, ctx.task_batch_size
+                while (
+                    self._pending_tasks.count() + completed_sample_count < ctx.task_batch_size
+                    and self.should_continue_fn(completed_sample_count, ctx.task_batch_size)
+                    and await self._pending_tasks.schedule_one(
+                        max_pending=max(0, ctx.task_batch_size - completed_sample_count),
+                        should_abort=ctx.should_abort,
+                        spawn_one=spawn_one,
+                    )
                 ):
-                    rollout_state = await ctx.sampler.sample(task_name=ctx.task_name)
-                    task = create_task(ctx.generate_group(rollout_state))
-                    pending_tasks.add(task)
+                    pass
         finally:
             progress_displayer.close()
 
@@ -637,66 +716,11 @@ class AsyncProduceStrategy(ProduceStrategy):
         self.sync_weights_interval = sync_weights_interval
         self.stale_threshold = calculate_stale_threshold(max_staleness, sync_weights_interval)
         self.tail_batch_trigger_size = tail_batch_trigger_size
-        self._pending_tasks = _PendingTasks()
         self.cleanup_task_time = 5 * 60  # 5 minutes
 
     def is_model_expired(self, train_step: int, model_step: int) -> bool:
         staleness = calculate_seq_staleness(model_step, train_step)
         return staleness >= self.stale_threshold
-
-    def pending_task_count(self) -> int:
-        return self._pending_tasks.count()
-
-    async def _put_claimed(
-        self,
-        claimed_tasks: set[asyncio.Task],
-        ctx: ProduceContext,
-        available_base: int | None = None,
-        progress_displayer: _ProgressDisplayer | None = None,
-    ) -> None:
-        completed_count = 0
-        for task in claimed_tasks:
-            is_completed = await ctx.put_generated_group(task.result())
-            if is_completed:
-                completed_count += 1
-            if is_completed and available_base is not None and progress_displayer is not None:
-                progress_displayer.update(available_base + completed_count)
-
-    async def pause_produce(self, ctx: ProduceContext) -> float:
-        pause_start = time.perf_counter()
-        if self._pending_tasks.count() == 0:
-            return 0.0
-
-        rollout_ctl = await get_agent_loop_rollout_ctl(ctx.agent_loop)
-        await pause_generation(rollout_ctl)
-        cleanup_start_time = time.perf_counter()
-        while True:
-            elapsed_time = time.perf_counter() - cleanup_start_time
-            if elapsed_time > self.cleanup_task_time:
-                cancelled_count = await self._pending_tasks.cancel_all()
-                logger.warning(
-                    f"Cleanup timeout of {self.cleanup_task_time}s reached. "
-                    f"Forcefully cancelling {cancelled_count} remaining tasks."
-                )
-                break
-
-            if self._pending_tasks.count() == 0:
-                break
-
-            claimed_done = await self._pending_tasks.wait_and_claim(timeout_s=1)
-            for task in claimed_done:
-                paused_items = task.result()
-                for item in paused_items:
-                    logger.debug(
-                        f"[{self.__class__.__name__}] Task {ctx.task_name} | "
-                        f"Collecting paused sample (uid: {item.uid}, status: {item.status}, "
-                        f"length: {len(item.response_ids or [])}) after pausing generation."
-                    )
-                await ctx.put_generated_group(paused_items)
-            if self._pending_tasks.count() > 0:
-                await pause_generation(rollout_ctl)
-                await asyncio.sleep(1)
-        return time.perf_counter() - pause_start
 
     async def produce_batch(self, ctx: ProduceContext) -> ProduceBatchStatus:
         if ctx.task_name not in ctx.progress.consumed_samples:

--- a/xtuner/v1/rl/agent_loop_manager/producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/producer.py
@@ -481,7 +481,7 @@ class AsyncProduceStrategyConfig(ProduceStrategyConfig):
 
 
 class ProduceStrategy(ABC):
-    PENDING_TASK_COLLECT_TIMEOUT_S = 10.0
+    PENDING_TASK_COLLECT_TIMEOUT_S = 15.0
 
     def __init__(
         self,
@@ -537,7 +537,8 @@ class ProduceStrategy(ABC):
         # more aborted requests to return, and finally stop waiting after the
         # timeout so training can move on without producer-side cancellation.
         claimed_done = await self._pending_tasks.claim_ready()
-        collected_count = await self._put_claimed(claimed_done, ctx)
+        collected_task_count = len(claimed_done)
+        completed_group_count = await self._put_claimed(claimed_done, ctx)
 
         pending_after_abort = self._pending_tasks.count()
         if pending_after_abort:
@@ -554,10 +555,14 @@ class ProduceStrategy(ABC):
             claimed_done = await self._pending_tasks.wait_and_claim(timeout_s=min(1.0, remaining_time))
             if not claimed_done:
                 continue
-            collected_count += await self._put_claimed(claimed_done, ctx)
+            collected_task_count += len(claimed_done)
+            completed_group_count += await self._put_claimed(claimed_done, ctx)
 
-        if collected_count:
-            logger.info(f"Collected {collected_count} rollout tasks for task {ctx.task_name} after abort.")
+        if collected_task_count:
+            logger.info(
+                f"Collected {collected_task_count} rollout tasks "
+                f"({completed_group_count} completed groups) for task {ctx.task_name} after abort."
+            )
         pending_count = self._pending_tasks.count()
         if pending_count:
             logger.warning(
@@ -565,7 +570,7 @@ class ProduceStrategy(ABC):
                 f"task {ctx.task_name} still has {pending_count} pending rollout tasks. "
                 "The rollout worker request timeout is expected to finish them without producer-side cancellation."
             )
-        return collected_count
+        return collected_task_count
 
 
 class _PendingTasks:

--- a/xtuner/v1/rl/agent_loop_manager/producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/producer.py
@@ -499,7 +499,9 @@ class ProduceStrategy(ABC):
         pause_start = time.perf_counter()
         if self.pending_task_count() == 0:
             return 0.0
-
+        logger.info(
+            f"Start pauseing production for task {ctx.task_name} with {self.pending_task_count()} pending rollout tasks..."
+        )
         await ctx.abort_generation()
         await self._collect_pending_tasks_after_abort(ctx)
         pause_duration = time.perf_counter() - pause_start

--- a/xtuner/v1/rl/rollout/__init__.py
+++ b/xtuner/v1/rl/rollout/__init__.py
@@ -10,5 +10,3 @@ if os.environ.get("XTUNER_USE_VLLM", "0") == "1":
     from .vllm import vLLMWorker
 if os.environ.get("XTUNER_USE_LMDEPLOY", "0") == "1":
     from .lmdeploy import LMDeployWorker
-
-from .utils import continue_generation, pause_generation

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -94,11 +94,7 @@ class RolloutController:
                 RolloutWorker actors.
         """
         self.config = infer_config
-        self.num_gpus_per_engine = (
-            self.config.expert_parallel_size
-            if self.config.expert_parallel_size > 1
-            else self.config.tensor_parallel_size
-        )
+        self.num_gpus_per_engine = self.config.num_gpus_per_engine
         self.logger = get_logger(log_dir=infer_config.worker_log_dir, tag="RolloutController")
         self.engine_rank_mesh_array: List[List[int]] = []
         self.worker_server_urls_map: dict[str, List[str]] = {}
@@ -347,37 +343,6 @@ class RolloutController:
                 dist_init_addrs[i : i + server_urls_per_engine] = [dist_init_addrs[i]] * server_urls_per_engine
         return dist_init_addrs
 
-    def _get_active_servers_count(self, infer_config: RolloutConfig, gpu_nums: int):
-        """Calculate the number of active servers and nodes per engine.
-
-        This calculation depends on the inference backend and parallelism settings.
-
-        Args:
-            infer_config (RolloutConfig): The rollout configuration.
-            gpu_nums (int): The total number of GPUs available.
-
-        Returns:
-            Tuple[int, int]: A tuple containing the number of active servers
-                and the number of nodes per engine.
-        """
-        # NOTE：Since different inference engines have different launch methods,
-        # the number of nodes contained in each engine is not consistent.
-        # For example: sglang requires starting an inference engine for each node,
-        # while lmdeploy and vllm does not. Therefore, we calculate the number
-        # of active servers based on the configuration.
-        support_cross_node_comm = infer_config.rollout_cross_node_comm
-        gpus_per_node = infer_config.gpus_per_node
-        nodes_per_engine = (
-            1
-            if support_cross_node_comm or self.num_gpus_per_engine < gpus_per_node
-            else self.num_gpus_per_engine // gpus_per_node
-        )
-
-        active_servers_count = int(
-            (gpu_nums // self.num_gpus_per_engine) * nodes_per_engine * infer_config.server_urls_per_engine
-        )
-        return active_servers_count, nodes_per_engine
-
     def _broadcast_to_active_workers(self, method_name: str):
         """Helper function to call a method on all active workers.
 
@@ -473,7 +438,7 @@ class RolloutController:
         workers, rank_bundle_idx_list = AutoAcceleratorWorkers.from_placement_group(
             self._get_worker_cls(), self.config, placement_group
         )
-        active_servers_count, nodes_per_engine = self._get_active_servers_count(self.config, len(workers))
+        active_servers_count, nodes_per_engine = self.config.get_active_servers_count(len(workers))
         interval = len(workers) // active_servers_count
         active_rollout_workers = workers[::interval]
         server_urls_per_engine = self.config.server_urls_per_engine

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -19,7 +19,15 @@ from .parser.factory import build_reasoning_parser, build_tool_call_parser
 from .parser.reasoning_parser import ReasoningParser
 from .parser.tool_parser import ToolCallParser
 from .utils import ROLLOUT_RAY_GET_TIMEOUT, RolloutHealthChecker, SessionRouter
-from .worker import RolloutConfig, RolloutWorker
+from .worker import (
+    ROLLOUT_CONCURRENCY_GROUP_CONTROL,
+    ROLLOUT_CONCURRENCY_GROUP_GENERATE,
+    RolloutConfig,
+    RolloutWorker,
+)
+
+
+ROLLOUT_WORKER_MAX_CONCURRENCY = 2000
 
 
 if TYPE_CHECKING:
@@ -145,6 +153,7 @@ class RolloutController:
         self.logger.info(f"Gateway server started at {url}, capture_folder: {config.capture_folder}")
         return url
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def get_rollout_metadata(self) -> RolloutWorkerMetadata:
         """Get information about the current rollout setup.
 
@@ -177,6 +186,7 @@ class RolloutController:
 
         return tool_call_parser, reasoning_parser
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def get_ready_status(self) -> tuple[bool, dict[str, Any]]:
         with self.worker_info_lock:
             active_workers = sum(1 for info in self.rank2info.values() if info.is_active)
@@ -186,6 +196,7 @@ class RolloutController:
             "total_workers": total_workers,
         }
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     async def generate(self, rollout_state: RolloutState) -> RolloutState:
         if XTUNER_DETERMINISTIC:
             sample_params = rollout_state.sample_params.model_copy(deep=True)
@@ -204,7 +215,8 @@ class RolloutController:
         response_ref = worker.generate.remote(rollout_state=rollout_state)  # type: ignore[attr-defined]
         try:
             response_rollout_state = await asyncio.wait_for(
-                response_ref, timeout=self.config.rollout_timeout * self.timeout_multiplier
+                response_ref,
+                timeout=self.config.rollout_timeout * self.timeout_multiplier,
             )
             self._apply_output_parsers(response_rollout_state)
             return response_rollout_state
@@ -231,30 +243,37 @@ class RolloutController:
             else:
                 rollout_state.extra_fields.pop("reasoning_text", None)
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def set_enable_partial_rollout(self, enable: bool) -> None:
         """Propagate enable_partial_rollout flag to all active workers."""
         with self.worker_info_lock:
             active_actors = [info.actor for info in self.rank2info.values() if info.is_active]
             ray.get([actor.set_enable_partial_rollout.remote(enable) for actor in active_actors])  # type: ignore[attr-defined]
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def pause_generation(self):
         self.health_checker.pause()
         self._broadcast_to_active_workers("pause_generation")
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def continue_generation(self):
         self.health_checker.resume()
         self._broadcast_to_active_workers("continue_generation")
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def offload(self):
         self._broadcast_to_active_workers("offload")
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload(self):
         self._broadcast_to_active_workers("onload_weights")
         self._broadcast_to_active_workers("onload_kvcache")
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_weights(self):
         self._broadcast_to_active_workers("onload_weights")
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_kvcache(self):
         self._broadcast_to_active_workers("onload_kvcache")
 
@@ -380,21 +399,28 @@ class RolloutController:
         if os.environ.get("XTUNER_USE_LMDEPLOY") == "1":
             from .lmdeploy import LMDeployWorker
 
-            return ray.remote(LMDeployWorker)
+            worker_cls = LMDeployWorker
         elif os.environ.get("XTUNER_USE_VLLM") == "1":
             from .vllm import vLLMWorker
 
-            return ray.remote(vLLMWorker)
+            worker_cls = vLLMWorker
         elif os.environ.get("XTUNER_USE_SGLANG") == "1":
             from .sglang import SGLangWorker
 
-            return ray.remote(SGLangWorker)
+            worker_cls = SGLangWorker
         else:
             raise NotImplementedError(
                 "Rollout backend is not supported."
                 "Please set XTUNER_USE_LMDEPLOY or XTUNER_USE_VLLM"
                 " or XTUNER_USE_SGLANG environment variable."
             )
+        return ray.remote(
+            max_concurrency=ROLLOUT_WORKER_MAX_CONCURRENCY,
+            concurrency_groups={
+                ROLLOUT_CONCURRENCY_GROUP_GENERATE: ROLLOUT_WORKER_MAX_CONCURRENCY,
+                ROLLOUT_CONCURRENCY_GROUP_CONTROL: ROLLOUT_WORKER_MAX_CONCURRENCY,
+            },
+        )(worker_cls)
 
     def _get_rank_by_actor(self, actor: RolloutWorker) -> Optional[int]:
         """Get rank by actor object.

--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -11,7 +11,7 @@ from ray.util.placement_group import placement_group_table
 from transformers import AutoTokenizer
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams
 
-from .worker import RolloutConfig, RolloutWorker
+from .worker import ROLLOUT_CONCURRENCY_GROUP_CONTROL, RolloutConfig, RolloutWorker
 
 
 SHARED_STORE = "shared_store"
@@ -80,14 +80,17 @@ class LMDeployWorker(RolloutWorker):
         self.enable_return_routed_experts = self.config.enable_return_routed_experts
         self.lmdeploy_actor = None
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def offload(self):
         """Offloads the model weights and KV cache."""
         return self._sleep(level=2)
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_weights(self):
         """Onloads the model weights by waking up the model."""
         return self._wake_up(tags=["weights"])
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_kvcache(self):
         """Onloads the KV cache by waking up the model."""
         return self._wake_up(tags=["kv_cache"])

--- a/xtuner/v1/rl/rollout/sglang.py
+++ b/xtuner/v1/rl/rollout/sglang.py
@@ -12,7 +12,7 @@ from transformers import AutoConfig, AutoTokenizer
 from xtuner.v1.data_proto.rl_data import RolloutState
 from xtuner.v1.utils import XTUNER_DETERMINISTIC
 
-from .worker import RolloutConfig, RolloutWorker
+from .worker import ROLLOUT_CONCURRENCY_GROUP_CONTROL, RolloutConfig, RolloutWorker
 
 
 class SGLangWorker(RolloutWorker):
@@ -169,25 +169,31 @@ class SGLangWorker(RolloutWorker):
             {"input_ids": input_ids, "sampling_params": sampling_params, "stream": False, "return_logprob": True},
         )
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def offload(self):
         """Offloads the model weights and KV cache."""
         self.flush_cache()
         return self._make_request("release_memory_occupation")
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_weights(self):
         """Onloads the model weights by waking up the model."""
         return self._make_request("resume_memory_occupation", {"tags": ["weights"]})
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_kvcache(self):
         return self._make_request("resume_memory_occupation", {"tags": ["kv_cache"]})
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def pause_generation(self):
         # SGLang PauseGeneration支持三种模式（https://github.com/sgl-project/sglang/blob/8d27ce7371da617a671f62e78dde66d64b7ad6cb/python/sglang/srt/managers/io_struct.py#L1353）：
         # abort    = 丢弃 waiting 和 running 请求，
         # retract  = 保留waiting请求和running请求（保留已生成 token），释放 KV，恢复时重算 KV 后继续
         # in_place = 保留waiting请求和running请求（保留已生成 token）、已生成 token、KV，恢复时直接继续
+        self.receive_abort_request.set()
         return self._make_request("pause_generation", {"mode": "abort"})
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def continue_generation(self):
         # 恢复生成时必须清掉上一轮 abort 标志，否则新请求会在发送前被本地直接标成 ABORTED。
         self.receive_abort_request.clear()

--- a/xtuner/v1/rl/rollout/utils.py
+++ b/xtuner/v1/rl/rollout/utils.py
@@ -10,7 +10,7 @@ import ray
 from ray import ObjectRef as RayObjectRef
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status
-from xtuner.v1.rl.utils import asyncio_run, clear_rollout_response_for_rerun, free_object_refs
+from xtuner.v1.rl.utils import asyncio_run, clear_rollout_response_for_rerun
 from xtuner.v1.utils import get_logger
 
 
@@ -327,8 +327,6 @@ class PartialRolloutHandler:
             # 处理routed experts
             history_routed_experts = rollout_state.routed_experts or None
             if history_routed_experts is not None and routed_experts is not None:
-                history_routed_experts_ref = history_routed_experts
-                cur_routed_experts_ref = routed_experts
                 start_time = time.time()
                 history_routed_experts, cur_routed_experts = await asyncio.gather(
                     _resolve_routed_experts(history_routed_experts),
@@ -344,13 +342,13 @@ class PartialRolloutHandler:
                 cur_routed_experts = cur_routed_experts[history_routed_experts_len:]
                 concat_routed_experts = history_routed_experts + cur_routed_experts
                 rollout_state.routed_experts = ray.put(concat_routed_experts)
-                free_object_refs(
-                    [
-                        ref
-                        for ref in (history_routed_experts_ref, cur_routed_experts_ref)
-                        if isinstance(ref, RayObjectRef)
-                    ]
-                )
+                # free_object_refs(
+                #     [
+                #         ref
+                #         for ref in (history_routed_experts_ref, cur_routed_experts_ref)
+                #         if isinstance(ref, RayObjectRef)
+                #     ]
+                # )
                 end_time = time.time()
                 self.logger.debug(
                     f"[PartialRolloutHandler] Postprocess routed_experts concatenation time: {end_time - start_time:.4f} seconds"

--- a/xtuner/v1/rl/rollout/utils.py
+++ b/xtuner/v1/rl/rollout/utils.py
@@ -6,17 +6,16 @@ from collections import OrderedDict
 from itertools import cycle
 from typing import TYPE_CHECKING, Any, Optional
 
-import httpx
 import ray
 from ray import ObjectRef as RayObjectRef
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status
-from xtuner.v1.rl.utils import asyncio_run, clear_rollout_response_for_rerun
+from xtuner.v1.rl.utils import asyncio_run, clear_rollout_response_for_rerun, free_object_refs
 from xtuner.v1.utils import get_logger
 
 
 if TYPE_CHECKING:
-    from .controller import RolloutControllerProxy, WorkerInfo
+    from .controller import WorkerInfo
     from .worker import RolloutConfig, RolloutWorker
 
 ROLLOUT_RAY_GET_TIMEOUT = int(os.getenv("XTUNER_ROLLOUT_RAY_GET_TIMEOUT", str(5 * 3600)))  # default 5 hours
@@ -165,15 +164,15 @@ class RolloutHealthChecker:
                     rank: (info.actor, info.url, info.is_active) for rank, info in self._workers_info.items()
                 }
 
+        workers_to_check = [
+            (rank, actor, url, is_active) for rank, (actor, url, is_active) in workers_snapshot.items() if is_active
+        ]
+        if not workers_to_check:
+            return
+
         tasks = [
-            check_worker_health(
-                actor,
-                rank,
-                url,
-                is_active,
-                self._check_failure_threshold,
-            )
-            for rank, (actor, url, is_active) in workers_snapshot.items()
+            check_worker_health(actor, rank, url, is_active, self._check_failure_threshold)
+            for rank, actor, url, is_active in workers_to_check
         ]
 
         async def _run_checks() -> list[bool]:
@@ -181,7 +180,7 @@ class RolloutHealthChecker:
 
         check_results = asyncio_run(_run_checks())
         inactive_workers = []
-        for rank, is_healthy in zip(workers_snapshot.keys(), check_results):
+        for (rank, _, _, _), is_healthy in zip(workers_to_check, check_results):
             if not is_healthy:
                 logger.warning(f"Worker {rank} failed health check. Marking as inactive.")
                 if self._worker_infos_lock is None:
@@ -201,6 +200,10 @@ class RolloutHealthChecker:
         for rank, inactive_worker in inactive_workers:
             try:
                 ray.get(inactive_worker.offload.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            except Exception as e:
+                logger.error(f"Exception while offloading worker {rank}: {e}")
+
+            try:
                 ray.get(inactive_worker.shutdown.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
             except Exception as e:
                 logger.error(f"Exception while shutting down worker {rank}: {e}")
@@ -221,42 +224,6 @@ class RolloutHealthChecker:
 
             if self._stop_event.wait(self._check_interval):
                 break
-
-
-async def send_abort_request(client: httpx.AsyncClient, url: str, timeout: float = 60.0) -> tuple[str, bool]:
-    worker_url = f"{url}/abort_request"
-    try:
-        response = await client.post(worker_url, json={"abort_all": True}, timeout=timeout)
-        response.raise_for_status()
-        logger.debug(f"Successfully sent abort request to {url}")
-        return url, True
-    except Exception as e:
-        logger.error(f"Failed to send abort request to {url}: {e}")
-        return url, False
-
-
-async def pause_generation(rollout_ctl: "RolloutControllerProxy", pause_time_out: float = 60.0) -> None:
-    await rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
-    rollout_ctl_metadata = await rollout_ctl.get_rollout_metadata.remote()  # type: ignore[attr-defined]
-    infer_server_url = list(rollout_ctl_metadata["server_url_dict"].values())
-    async with httpx.AsyncClient() as client:
-        tasks = [send_abort_request(client, url, timeout=pause_time_out) for url in infer_server_url]
-        results = await asyncio.gather(*tasks)
-
-    failed_workers = [url for url, success in results if not success]
-    succeeded_count = len(infer_server_url) - len(failed_workers)
-
-    if failed_workers:
-        logger.warning(
-            f"Abort requests completed. Succeeded: {succeeded_count}, "
-            f"Failed: {len(failed_workers)}. Failed workers: {failed_workers}"
-        )
-    else:
-        logger.info(f"All {succeeded_count} abort requests sent successfully.")
-
-
-async def continue_generation(rollout_ctl: "RolloutControllerProxy") -> None:
-    return await rollout_ctl.continue_generation.remote()  # type: ignore[attr-defined]
 
 
 async def check_worker_health(
@@ -360,6 +327,8 @@ class PartialRolloutHandler:
             # 处理routed experts
             history_routed_experts = rollout_state.routed_experts or None
             if history_routed_experts is not None and routed_experts is not None:
+                history_routed_experts_ref = history_routed_experts
+                cur_routed_experts_ref = routed_experts
                 start_time = time.time()
                 history_routed_experts, cur_routed_experts = await asyncio.gather(
                     _resolve_routed_experts(history_routed_experts),
@@ -375,9 +344,13 @@ class PartialRolloutHandler:
                 cur_routed_experts = cur_routed_experts[history_routed_experts_len:]
                 concat_routed_experts = history_routed_experts + cur_routed_experts
                 rollout_state.routed_experts = ray.put(concat_routed_experts)
-                # free_object_refs(
-                #     [ref for ref in (history_routed_experts_ref, cur_routed_experts_ref) if isinstance(ref, ray.ObjectRef)]
-                # )
+                free_object_refs(
+                    [
+                        ref
+                        for ref in (history_routed_experts_ref, cur_routed_experts_ref)
+                        if isinstance(ref, RayObjectRef)
+                    ]
+                )
                 end_time = time.time()
                 self.logger.debug(
                     f"[PartialRolloutHandler] Postprocess routed_experts concatenation time: {end_time - start_time:.4f} seconds"

--- a/xtuner/v1/rl/rollout/vllm.py
+++ b/xtuner/v1/rl/rollout/vllm.py
@@ -15,7 +15,7 @@ from vllm.utils import FlexibleArgumentParser
 from xtuner.v1.data_proto.rl_data import RolloutState, Status, update_status_from_finish_reason
 from xtuner.v1.utils.device import get_device, get_torch_device_module
 
-from .worker import RolloutConfig, RolloutWorker
+from .worker import ROLLOUT_CONCURRENCY_GROUP_CONTROL, RolloutConfig, RolloutWorker
 
 
 DEVICE = get_device()
@@ -254,21 +254,26 @@ class vLLMWorker(RolloutWorker):
         assert response.status_code == 200, response.status_code
         return response.text
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def pause_generation(self):
-        pass
+        self.receive_abort_request.set()
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def continue_generation(self):
         # 恢复生成时必须清掉上一轮 abort 标志，否则新请求会在发送前被本地直接标成 ABORTED。
         self.receive_abort_request.clear()
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_weights(self):
         """Onloads the model weights by waking up the model."""
         return self.wake_up(tags=["weights"])
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def onload_kvcache(self):
         """Onloads the KV cache by waking up the model."""
         return self.wake_up(tags=["kv_cache"])
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def offload(self):
         """Offloads the model weights and KV cache."""
         return self.sleep(level=2)

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -1,9 +1,11 @@
 import asyncio
 import copy
 import json
+import math
 import multiprocessing
 import os
 import socket
+import threading
 import time
 import traceback
 from abc import abstractmethod
@@ -40,6 +42,8 @@ if TYPE_CHECKING:
 
 
 infer_group = Group("inference", help="Inference worker configuration.")
+ROLLOUT_CONCURRENCY_GROUP_GENERATE = "generate"
+ROLLOUT_CONCURRENCY_GROUP_CONTROL = "control"
 
 
 class RolloutConfig(BaseModel):
@@ -343,6 +347,29 @@ class RolloutConfig(BaseModel):
         else:
             return 1
 
+    def get_controller_concurrency(self, placement_group: "PlacementGroup") -> tuple[int, int]:
+        num_rollout_workers = len(placement_group.bundle_specs)
+        num_gpus_per_engine = self.expert_parallel_size if self.expert_parallel_size > 1 else self.tensor_parallel_size
+        nodes_per_engine = (
+            1
+            if self.rollout_cross_node_comm or num_gpus_per_engine < self.gpus_per_node
+            else num_gpus_per_engine // self.gpus_per_node
+        )
+        active_worker_count = max(
+            1,
+            int((num_rollout_workers // num_gpus_per_engine) * nodes_per_engine * self.server_urls_per_engine),
+        )
+        control_max_concurrency = active_worker_count
+        assert self.rollout_max_batch_size_per_instance is not None, (
+            "rollout_max_batch_size_per_instance must be set before building RolloutController."
+        )
+        concurrency_per_worker = max(
+            1,
+            math.ceil(self.rollout_max_batch_size_per_instance * self.allow_over_concurrency_ratio),
+        )
+        generate_max_concurrency = active_worker_count * concurrency_per_worker
+        return generate_max_concurrency, control_max_concurrency
+
     def model_post_init(self, __context: Any) -> None:
         if self.model_name is None:
             model_name_from_config = None
@@ -413,11 +440,14 @@ class RolloutConfig(BaseModel):
             name="rollout_controller",
             cpu_resources=CPUResourcesConfig(num_workers=num_workers),
         )
-        return (
-            ray.remote(RolloutController)
-            .options(max_concurrency=int(os.environ.get("RAY_MAX_CONCURRENCY", 1000)), num_cpus=num_workers)
-            .remote(self, placement_group)
-        )
+        generate_max_concurrency, control_max_concurrency = self.get_controller_concurrency(placement_group)
+        return ray.remote(
+            max_concurrency=generate_max_concurrency,
+            concurrency_groups={
+                ROLLOUT_CONCURRENCY_GROUP_GENERATE: generate_max_concurrency,
+                ROLLOUT_CONCURRENCY_GROUP_CONTROL: control_max_concurrency,
+            },
+        )(RolloutController).remote(self, placement_group)
 
 
 class RolloutWorker(SingleAcceleratorWorker):
@@ -464,7 +494,6 @@ class RolloutWorker(SingleAcceleratorWorker):
         http_concurrency = config.rollout_max_batch_size_per_instance * config.allow_over_concurrency_ratio
         limits = httpx.Limits(max_connections=http_concurrency, max_keepalive_connections=100)
         self.client = httpx.AsyncClient(limits=limits, timeout=self.config.rollout_timeout)
-        self.paused = False
         self.server_task = None
         self.engine_bundle_idxs: list[int] = []
         self.server_process: Optional[multiprocessing.Process] = None
@@ -477,13 +506,16 @@ class RolloutWorker(SingleAcceleratorWorker):
         eos_token = get_eos_token(self.config.model_path)
         self.logger.info(f"Using eos_token: {eos_token} for model at {self.config.model_path}")
         self.eos_token: List[int] = [eos_token] if isinstance(eos_token, int) else eos_token
-        self.receive_abort_request = asyncio.Event()
-        self.abort_timeout = 5.0
+        self.receive_abort_request = threading.Event()
+        # Keep abort handling aligned with httpx's default timeout instead of the long rollout request timeout.
+        # This is also the grace window for an in-flight rollout request to return after an abort signal.
+        self.abort_timeout = 10.0
         self.dist_init_addr: str = ""
         self.serverl_url: str = ""
         self.partial_rollout_handler = PartialRolloutHandler()
         self.enable_partial_rollout: bool = False
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def set_enable_partial_rollout(self, enable: bool) -> None:
         self.enable_partial_rollout = enable
 
@@ -559,14 +591,34 @@ class RolloutWorker(SingleAcceleratorWorker):
             self.logger.debug(f"Worker {self.rank} server process and its children terminated.")
             return
 
-    def pause_generation(self):
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
+    async def pause_generation(self):
         """Pause the worker's generation process."""
-        self.paused = True
+        self.receive_abort_request.set()
+        return await self._send_abort_request()
 
+    async def _send_abort_request(self) -> bool:
+        url = f"{self.server_url}/abort_request"
+        try:
+            async with httpx.AsyncClient(timeout=self.abort_timeout) as client:
+                response = await client.post(url, json={"abort_all": True})
+            response.raise_for_status()
+            self.logger.debug(f"Successfully sent abort request to {self.server_url}")
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to send abort request to {self.server_url}: {e}")
+            return False
+
+    async def _wait_abort_request(self) -> None:
+        while not self.receive_abort_request.is_set():
+            await asyncio.sleep(0.001)
+
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def continue_generation(self):
         """Resume the worker's generation process."""
         self.receive_abort_request.clear()
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def check_health(self) -> bool:
         """Check the health of the worker's server.
 
@@ -589,6 +641,7 @@ class RolloutWorker(SingleAcceleratorWorker):
     async def _decode_routed_experts(self, routed_experts: Any) -> Any:
         return routed_experts
 
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     async def generate(self, rollout_state: RolloutState) -> RolloutState:
         # TODO(@duanyanhui):
         # 1. support claude format input
@@ -829,6 +882,8 @@ class RolloutWorker(SingleAcceleratorWorker):
             raise TimeoutError("Server failed to start within the timeout period.")
 
     async def _safe_post_request(self, url, headers, payload) -> HttpRequestResult:
+        send_task = None
+        abort_task = None
         try:
             if self.receive_abort_request.is_set():
                 self.logger.debug(f"Request to {url} was cancelled before sending due to an abort signal.")
@@ -839,14 +894,49 @@ class RolloutWorker(SingleAcceleratorWorker):
                 headers=headers,
                 json=payload,
             )
-            r = await self.client.send(req)
+            send_task = asyncio.create_task(self.client.send(req))
+            abort_task = asyncio.create_task(self._wait_abort_request())
+            done, _ = await asyncio.wait(
+                {send_task, abort_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if send_task in done:
+                r = await send_task
+            else:
+                try:
+                    r = await asyncio.wait_for(asyncio.shield(send_task), timeout=self.abort_timeout)
+                except asyncio.TimeoutError:
+                    self.logger.debug(
+                        f"Request to {url} did not return within {self.abort_timeout:.2f}s after abort signal."
+                    )
+                    send_task.cancel()
+                    await asyncio.gather(send_task, return_exceptions=True)
+                    return HttpRequestResult(
+                        error_type=HttpRequestErrorType.REQUEST_ABORTED,
+                        url=url,
+                        payload=payload,
+                    )
             r.raise_for_status()
             return HttpRequestResult(response=r)
 
+        except asyncio.CancelledError:
+            self.logger.debug(f"Request to {url} was cancelled while waiting for the response.")
+            if send_task is not None and not send_task.done():
+                send_task.cancel()
+                await asyncio.gather(send_task, return_exceptions=True)
+            if abort_task is not None and not abort_task.done():
+                abort_task.cancel()
+                await asyncio.gather(abort_task, return_exceptions=True)
+            self.receive_abort_request.set()
+            return HttpRequestResult(error_type=HttpRequestErrorType.REQUEST_ABORTED, url=url, payload=payload)
         except Exception as e:
             error_type = HttpRequestErrorType.from_exception(e)
             result = HttpRequestResult(error_type=error_type, exception=e, url=url, payload=payload)
             return result
+        finally:
+            if abort_task is not None and not abort_task.done():
+                abort_task.cancel()
+                await asyncio.gather(abort_task, return_exceptions=True)
 
     async def _safe_handle_response(self, rollout_state: RolloutState, http_response: httpx.Response) -> RolloutState:
         uid = rollout_state.message_uid
@@ -878,11 +968,6 @@ class RolloutWorker(SingleAcceleratorWorker):
                         )
                     rollout_state.error_msg = "Missing finish_reason in response meta_info"
                     return rollout_state
-
-                if finish_reason == "abort" and self.receive_abort_request.is_set() is False:
-                    self.receive_abort_request.set()
-                    self.logger.info(f"Setting receive_abort_request to True for rank {self.rank}")
-
                 returned_response = response.get("text", "")
                 # 获取response_ids && respoonse_ids
                 if (

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -27,6 +27,7 @@ from xtuner.v1.rl.utils import (
     AutoAcceleratorWorkers,
     CPUResourcesConfig,
     SingleAcceleratorWorker,
+    cancel_and_drain,
     find_master_addr_and_port,
     get_eos_token,
     register_cpu_resources,
@@ -899,6 +900,7 @@ class RolloutWorker(SingleAcceleratorWorker):
     async def _safe_post_request(self, url, headers, payload) -> HttpRequestResult:
         send_task = None
         abort_task = None
+
         try:
             if self.receive_abort_request.is_set():
                 self.logger.debug(f"Request to {url} was cancelled before sending due to an abort signal.")
@@ -924,8 +926,7 @@ class RolloutWorker(SingleAcceleratorWorker):
                     self.logger.debug(
                         f"Request to {url} did not return within {self.abort_timeout:.2f}s after abort signal."
                     )
-                    send_task.cancel()
-                    await asyncio.gather(send_task, return_exceptions=True)
+                    await cancel_and_drain(send_task)
                     return HttpRequestResult(
                         error_type=HttpRequestErrorType.REQUEST_ABORTED,
                         url=url,
@@ -934,14 +935,19 @@ class RolloutWorker(SingleAcceleratorWorker):
             r.raise_for_status()
             return HttpRequestResult(response=r)
 
+        except asyncio.CancelledError:
+            self.logger.debug(f"Request to {url} was cancelled while waiting for the response.")
+            await cancel_and_drain(send_task)
+            await cancel_and_drain(abort_task)
+            self.receive_abort_request.set()
+            return HttpRequestResult(error_type=HttpRequestErrorType.REQUEST_ABORTED, url=url, payload=payload)
         except Exception as e:
             error_type = HttpRequestErrorType.from_exception(e)
             result = HttpRequestResult(error_type=error_type, exception=e, url=url, payload=payload)
             return result
         finally:
             if abort_task is not None and not abort_task.done():
-                abort_task.cancel()
-                await asyncio.gather(abort_task, return_exceptions=True)
+                await cancel_and_drain(abort_task)
 
     async def _safe_handle_response(self, rollout_state: RolloutState, http_response: httpx.Response) -> RolloutState:
         uid = rollout_state.message_uid

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -347,18 +347,29 @@ class RolloutConfig(BaseModel):
         else:
             return 1
 
-    def get_controller_concurrency(self, placement_group: "PlacementGroup") -> tuple[int, int]:
-        num_rollout_workers = len(placement_group.bundle_specs)
-        num_gpus_per_engine = self.expert_parallel_size if self.expert_parallel_size > 1 else self.tensor_parallel_size
+    @property
+    def num_gpus_per_engine(self) -> int:
+        return self.expert_parallel_size if self.expert_parallel_size > 1 else self.tensor_parallel_size
+
+    def get_active_servers_count(self, num_rollout_workers: int) -> tuple[int, int]:
+        """Calculate the number of active servers and nodes per engine."""
+        # NOTE: Since different inference engines have different launch methods,
+        # the number of nodes contained in each engine is not consistent.
+        # For example, sglang requires starting an inference engine for each node,
+        # while lmdeploy and vllm do not. Therefore, calculate active servers from the rollout config.
         nodes_per_engine = (
             1
-            if self.rollout_cross_node_comm or num_gpus_per_engine < self.gpus_per_node
-            else num_gpus_per_engine // self.gpus_per_node
+            if self.rollout_cross_node_comm or self.num_gpus_per_engine < self.gpus_per_node
+            else self.num_gpus_per_engine // self.gpus_per_node
         )
-        active_worker_count = max(
+        active_servers_count = max(
             1,
-            int((num_rollout_workers // num_gpus_per_engine) * nodes_per_engine * self.server_urls_per_engine),
+            int((num_rollout_workers // self.num_gpus_per_engine) * nodes_per_engine * self.server_urls_per_engine),
         )
+        return active_servers_count, nodes_per_engine
+
+    def get_controller_concurrency(self, placement_group: "PlacementGroup") -> tuple[int, int]:
+        active_worker_count, _ = self.get_active_servers_count(len(placement_group.bundle_specs))
         control_max_concurrency = active_worker_count
         assert self.rollout_max_batch_size_per_instance is not None, (
             "rollout_max_batch_size_per_instance must be set before building RolloutController."
@@ -441,6 +452,10 @@ class RolloutConfig(BaseModel):
             cpu_resources=CPUResourcesConfig(num_workers=num_workers),
         )
         generate_max_concurrency, control_max_concurrency = self.get_controller_concurrency(placement_group)
+        get_logger().info(
+            f"Calculated RolloutController concurrency - generate: {generate_max_concurrency}, "
+            f"control: {control_max_concurrency}"
+        )
         return ray.remote(
             max_concurrency=generate_max_concurrency,
             concurrency_groups={
@@ -507,8 +522,8 @@ class RolloutWorker(SingleAcceleratorWorker):
         self.logger.info(f"Using eos_token: {eos_token} for model at {self.config.model_path}")
         self.eos_token: List[int] = [eos_token] if isinstance(eos_token, int) else eos_token
         self.receive_abort_request = threading.Event()
-        # Keep abort handling aligned with httpx's default timeout instead of the long rollout request timeout.
-        # This is also the grace window for an in-flight rollout request to return after an abort signal.
+        # After an abort signal, wait this long for an in-flight rollout request to return before cancelling the
+        # client-side request task.
         self.abort_timeout = 10.0
         self.dist_init_addr: str = ""
         self.serverl_url: str = ""
@@ -611,7 +626,7 @@ class RolloutWorker(SingleAcceleratorWorker):
 
     async def _wait_abort_request(self) -> None:
         while not self.receive_abort_request.is_set():
-            await asyncio.sleep(0.001)
+            await asyncio.sleep(1)
 
     @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_CONTROL)
     def continue_generation(self):
@@ -919,16 +934,6 @@ class RolloutWorker(SingleAcceleratorWorker):
             r.raise_for_status()
             return HttpRequestResult(response=r)
 
-        except asyncio.CancelledError:
-            self.logger.debug(f"Request to {url} was cancelled while waiting for the response.")
-            if send_task is not None and not send_task.done():
-                send_task.cancel()
-                await asyncio.gather(send_task, return_exceptions=True)
-            if abort_task is not None and not abort_task.done():
-                abort_task.cancel()
-                await asyncio.gather(abort_task, return_exceptions=True)
-            self.receive_abort_request.set()
-            return HttpRequestResult(error_type=HttpRequestErrorType.REQUEST_ABORTED, url=url, payload=payload)
         except Exception as e:
             error_type = HttpRequestErrorType.from_exception(e)
             result = HttpRequestResult(error_type=error_type, exception=e, url=url, payload=payload)

--- a/xtuner/v1/rl/utils/__init__.py
+++ b/xtuner/v1/rl/utils/__init__.py
@@ -1,5 +1,6 @@
 from .async_utils import (
     asyncio_run,
+    cancel_and_drain,
     create_task,
     handle_task_exception,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "bind_train_rollout",
     "handle_task_exception",
     "create_task",
+    "cancel_and_drain",
     "QueryNode",
     "ConditionNode",
     "ScalarNode",

--- a/xtuner/v1/rl/utils/__init__.py
+++ b/xtuner/v1/rl/utils/__init__.py
@@ -1,4 +1,8 @@
-from .async_utils import asyncio_run, create_task, handle_task_exception
+from .async_utils import (
+    asyncio_run,
+    create_task,
+    handle_task_exception,
+)
 from .misc import (
     BetweenNode,
     BetweenOperator,

--- a/xtuner/v1/rl/utils/async_utils.py
+++ b/xtuner/v1/rl/utils/async_utils.py
@@ -58,6 +58,19 @@ def create_task(
     return task
 
 
+async def cancel_and_drain(task: Task | None) -> None:
+    """Cancel a task and consume its terminal exception.
+
+    Use this when a parent coroutine handles cancellation itself but owns child tasks that must not keep running in the
+    background.
+    """
+    if task is None:
+        return
+    if not task.done():
+        task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
 def _get_default_asyncio_loop() -> AbstractEventLoop:
     """Get a module-level event loop reused by ``asyncio_run``."""
     global _ASYNCIO_RUN_LOOP

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
 import os
 import random
 import re
+import time
 from pathlib import Path
 from shutil import rmtree
 from typing import Any, List, cast
@@ -35,7 +37,7 @@ from xtuner.v1.rl.replay_buffer import (
 )
 from xtuner.v1.rl.rollout.controller import RolloutControllerProxy
 from xtuner.v1.rl.rollout.worker import RolloutConfig
-from xtuner.v1.rl.trainer.controller import TrainingController
+from xtuner.v1.rl.trainer.controller import ColateItem, TrainingController
 from xtuner.v1.rl.trainer.worker import WorkerConfig, WorkerLogItem
 from xtuner.v1.rl.utils import (
     AcceleratorResourcesConfig,
@@ -88,6 +90,7 @@ def _parse_debug_rollout_step(path: Path) -> int:
 
 
 class TrainInfo(TypedDict, total=False):
+    data_batches: list[ColateItem]
     data_info: dict[str, float]
     workers_log_item: list[WorkerLogItem]
 
@@ -704,6 +707,7 @@ class BaseRLTrainer:
             train_step=1,
             model_step=0,
         )
+        await self.eval_agent_loop_manager.pause_produce(use_global_progress=False)
         if XTUNER_DETERMINISTIC:
             eval_produce_result.rollout_states = sort_rollout_state_for_deterministic(
                 eval_produce_result.rollout_states
@@ -713,14 +717,12 @@ class BaseRLTrainer:
         tb_scores = {f"eval/{k}": v for k, v in eval_metrics.items()}
         self._exp_tracker.add_scalars(tag_scalar_dict=tb_scores, global_step=0)
 
-    def _train_one_batch(
+    def _prepare_train_batch(
         self,
         train_batch: list[list[RolloutState]],
         train_step: int,
         step_timer_dict: dict,
         *,
-        offload_rollout_before_train: bool = False,
-        onload_train_before_train: bool = False,
         raw_rewards_sum: float = 0.0,
         raw_rewards_count: int = 0,
     ) -> TrainInfo:
@@ -733,14 +735,6 @@ class BaseRLTrainer:
         self._save_trajectories(train_batch, train_trajectory_path)
         self.logger.info(f"Train step {train_step} train trajectories saved to {train_trajectory_path}")
 
-        # 共卡需要先释放 rollout，再把训练 worker onload；非共卡不走这两个动作。
-        if offload_rollout_before_train:
-            ray.get(self.rollout_controller.offload.remote())
-        if onload_train_before_train:
-            with timer("onload", step_timer_dict):
-                self.train_controller.onload(target="all")
-                self.logger.info("Training controller loaded")
-
         with timer("prepare_data", step_timer_dict):
             data_batches, data_info = self._prepare_train_data(
                 train_batch,
@@ -749,17 +743,43 @@ class BaseRLTrainer:
                 raw_rewards_count=raw_rewards_count,
             )
         self.logger.info(f"Prepared {len(data_batches)} training data batches")
+        return {"data_batches": data_batches, "data_info": data_info}
 
-        with timer("training", step_timer_dict):
-            workers_log_item: list[WorkerLogItem] = self.train_controller.fit(
-                data_batches,
-                pack_max_length=self._train_worker_cfg.pack_max_length,
-                rollout_idx=train_step,
+    async def _prepare_train_batch_and_await_pause(
+        self,
+        train_batch: list[list[RolloutState]],
+        train_step: int,
+        step_timer_dict: dict,
+        *,
+        use_global_progress: bool,
+        raw_rewards_sum: float = 0.0,
+        raw_rewards_count: int = 0,
+    ) -> tuple[TrainInfo, float]:
+        overlap_start = time.perf_counter()
+
+        async def pause_produce_once() -> float:
+            with timer("pause_produce", step_timer_dict):
+                return await self.agent_loop_manager.pause_produce(use_global_progress=use_global_progress)
+
+        pause_task = asyncio.create_task(pause_produce_once())
+        await asyncio.sleep(0)
+        try:
+            prepared_train_info = self._prepare_train_batch(
+                train_batch,
+                train_step,
+                step_timer_dict,
+                raw_rewards_sum=raw_rewards_sum,
+                raw_rewards_count=raw_rewards_count,
             )
-        return {
-            "data_info": data_info,
-            "workers_log_item": workers_log_item,
-        }
+        except BaseException:
+            pause_task.cancel()
+            await asyncio.gather(pause_task, return_exceptions=True)
+            raise
+        pause_time_s = await pause_task
+        overlap_time_s = time.perf_counter() - overlap_start
+        step_timer_dict["prepare_and_pause"] = overlap_time_s
+        self.logger.info(f"Prepared train batch and paused production in {overlap_time_s:.2f}s.")
+        return prepared_train_info, pause_time_s
 
     async def _run_evaluation(self, train_step: int) -> dict[str, float]:
         eval_produce_result = await self.eval_agent_loop_manager.produce_batch(
@@ -767,6 +787,7 @@ class BaseRLTrainer:
             train_step=1,
             model_step=0,
         )
+        await self.eval_agent_loop_manager.pause_produce(use_global_progress=False)
         if XTUNER_DETERMINISTIC:
             eval_produce_result.rollout_states = sort_rollout_state_for_deterministic(
                 eval_produce_result.rollout_states
@@ -1218,15 +1239,31 @@ class RLColocateTrainer(BaseRLTrainer):
                 )
 
                 if not self._debug_rollout:
-                    train_log_info = self._train_one_batch(
-                        train_batch,
-                        train_step,
-                        step_timer_dict,
-                        offload_rollout_before_train=True,
-                        onload_train_before_train=True,
-                        raw_rewards_sum=produce_result.raw_rewards_sum,
-                        raw_rewards_count=produce_result.raw_rewards_count,
+                    prepared_train_info, pause_time_s = asyncio_run(
+                        self._prepare_train_batch_and_await_pause(
+                            train_batch,
+                            train_step,
+                            step_timer_dict,
+                            use_global_progress=False,
+                            raw_rewards_sum=produce_result.raw_rewards_sum,
+                            raw_rewards_count=produce_result.raw_rewards_count,
+                        )
                     )
+                    produce_result.group_gen_pause_time_s = pause_time_s
+                    ray.get(self.rollout_controller.offload.remote())
+                    with timer("onload", step_timer_dict):
+                        self.train_controller.onload(target="all")
+                        self.logger.info("Training controller loaded")
+                    with timer("training", step_timer_dict):
+                        workers_log_item: list[WorkerLogItem] = self.train_controller.fit(
+                            prepared_train_info["data_batches"],
+                            pack_max_length=self._train_worker_cfg.pack_max_length,
+                            rollout_idx=train_step,
+                        )
+                    train_log_info: TrainInfo = {
+                        "data_info": prepared_train_info["data_info"],
+                        "workers_log_item": workers_log_item,
+                    }
 
                     weights_synced = self._sync_weights_and_save(train_step, step_timer_dict)
                     if weights_synced:
@@ -1237,6 +1274,13 @@ class RLColocateTrainer(BaseRLTrainer):
                         with timer("evaluation", step_timer_dict):
                             eval_log_info.update(asyncio_run(self._run_evaluation(train_step)))
                 else:
+                    with timer("pause", step_timer_dict):
+                        pause_time_s = asyncio_run(
+                            self.agent_loop_manager.pause_produce(
+                                use_global_progress=False,
+                            )
+                        )
+                        produce_result.group_gen_pause_time_s = pause_time_s
                     self._save_debug_rollout_batch(train_batch, train_step)
                     train_log_info = {}
                     eval_log_info = {}
@@ -1252,13 +1296,21 @@ class RLColocateTrainer(BaseRLTrainer):
             with timer("step", step_timer_dict):
                 with timer("load_debug_rollout", step_timer_dict):
                     train_batch = self._load_debug_rollout_batch(train_step)
-                train_log_info = self._train_one_batch(
+                prepared_train_info = self._prepare_train_batch(
                     train_batch,
                     train_step,
                     step_timer_dict,
-                    offload_rollout_before_train=False,
-                    onload_train_before_train=False,
                 )
+                with timer("training", step_timer_dict):
+                    workers_log_item: list[WorkerLogItem] = self.train_controller.fit(
+                        prepared_train_info["data_batches"],
+                        pack_max_length=self._train_worker_cfg.pack_max_length,
+                        rollout_idx=train_step,
+                    )
+                train_log_info: TrainInfo = {
+                    "data_info": prepared_train_info["data_info"],
+                    "workers_log_item": workers_log_item,
+                }
                 eval_log_info: dict[str, float] = {}
                 produce_result = ProduceBatchResult(rollout_states=train_batch)
 
@@ -1408,22 +1460,56 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
                             "RLDisaggregatedTrainer expects get_batch() to return non-empty rollout_states "
                             "unless status is EXPIRED_BATCH."
                         )
-                        train_log_info = self._train_one_batch(
-                            train_batch,
-                            train_step,
-                            step_timer_dict,
-                            raw_rewards_sum=produce_result.raw_rewards_sum,
-                            raw_rewards_count=produce_result.raw_rewards_count,
-                        )
+                        if need_sync:
+                            prepared_train_info, pause_time_s = await self._prepare_train_batch_and_await_pause(
+                                train_batch,
+                                train_step,
+                                step_timer_dict,
+                                use_global_progress=True,
+                                raw_rewards_sum=produce_result.raw_rewards_sum,
+                                raw_rewards_count=produce_result.raw_rewards_count,
+                            )
+                            produce_result.group_gen_pause_time_s = pause_time_s
+                            with timer("training", step_timer_dict):
+                                workers_log_item: list[WorkerLogItem] = self.train_controller.fit(
+                                    prepared_train_info["data_batches"],
+                                    pack_max_length=self._train_worker_cfg.pack_max_length,
+                                    rollout_idx=train_step,
+                                )
+                            train_log_info = {
+                                "data_info": prepared_train_info["data_info"],
+                                "workers_log_item": workers_log_item,
+                            }
+                        else:
+                            prepared_train_info = self._prepare_train_batch(
+                                train_batch,
+                                train_step,
+                                step_timer_dict,
+                                raw_rewards_sum=produce_result.raw_rewards_sum,
+                                raw_rewards_count=produce_result.raw_rewards_count,
+                            )
+                            with timer("training", step_timer_dict):
+                                workers_log_item = self.train_controller.fit(
+                                    prepared_train_info["data_batches"],
+                                    pack_max_length=self._train_worker_cfg.pack_max_length,
+                                    rollout_idx=train_step,
+                                )
+                            train_log_info = {
+                                "data_info": prepared_train_info["data_info"],
+                                "workers_log_item": workers_log_item,
+                            }
                     else:
                         self.logger.info(
                             "Skip train step because rollout model is expired; prioritize weight sync first."
                         )
 
                     if need_sync:
-                        # 同步前先暂停后台 producer，避免 save/sync 时还有 pending rollout 继续写 buffer。
-                        with timer("pause_produce", step_timer_dict):
-                            await self.agent_loop_manager.pause_produce(use_global_progress=True)
+                        if produce_result.status == ProduceBatchStatus.EXPIRED_BATCH:
+                            # expired batch 没有训练侧 CPU 准备可以并行，仍需先收口后台 producer。
+                            with timer("pause_produce", step_timer_dict):
+                                await self.agent_loop_manager.pause_produce(
+                                    use_global_progress=True,
+                                )
 
                         await self._sync_weights_and_save(train_step, step_timer_dict)
 

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -758,8 +758,7 @@ class BaseRLTrainer:
         overlap_start = time.perf_counter()
 
         async def pause_produce_once() -> float:
-            with timer("pause_produce", step_timer_dict):
-                return await self.agent_loop_manager.pause_produce(use_global_progress=use_global_progress)
+            return await self.agent_loop_manager.pause_produce(use_global_progress=use_global_progress)
 
         pause_task = asyncio.create_task(pause_produce_once())
         await asyncio.sleep(0)

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -761,6 +761,9 @@ class BaseRLTrainer:
             return await self.agent_loop_manager.pause_produce(use_global_progress=use_global_progress)
 
         pause_task = asyncio.create_task(pause_produce_once())
+        # Let pause_produce submit the Ray abort request before the local event loop is blocked by synchronous
+        # batch preparation. The Ray actor handles abort in another process; local pending-task collection resumes
+        # only after _prepare_train_batch returns.
         await asyncio.sleep(0)
         try:
             prepared_train_info = self._prepare_train_batch(


### PR DESCRIPTION
  ## Summary

  This PR improves rollout pause/abort behavior and reduces the chance that generation traffic blocks rollout control operations.

  - Route rollout `generate` and control operations through separate Ray concurrency groups on the rollout controller and workers.
  - Move abort handling into rollout workers so `pause_generation` sets the local abort flag and sends backend abort requests through the control lane.
  - Rework producer pending-task handling so aborted rollout tasks are collected and written back instead of being force-cancelled from the producer side.
  - Overlap rollout pause with CPU-side training batch preparation to reduce sync-step latency.

  ## Main Changes

  - Add rollout concurrency groups:
    - **`generate` for rollout generation requests.**
    - **`control` for pause/continue/offload/onload/health/metadata operations.**
  - Compute rollout controller concurrency from active server count, `rollout_max_batch_size_per_instance`, and `allow_over_concurrency_ratio`.
  - Make worker-side abort handling deterministic:
    - set abort flag before sending backend abort requests;
    - wait briefly for in-flight HTTP requests to return after abort;
    - mark client-side requests as aborted if they do not return within the abort timeout.
  - Share pending-task tracking between sync and async producers. @jayhenry 
  - Collect completed or aborted pending rollout tasks after pause and persist their states into the replay buffer.
  - Avoid producer-side force cancellation of rollout tasks after abort; remaining tasks are left to finish through rollout worker request timeout.
  - In colocated and disaggregated trainers, prepare train data while waiting for rollout pause when a sync is needed.
  - Pause evaluation/debug rollout production explicitly before consuming the produced batch.


## 时序图
### Worker
<img width="5667" height="5085" alt="image" src="https://github.com/user-attachments/assets/f97f8868-d00b-47e2-8386-f9a298dfe231" />

### ProduceStrategy
<img width="8192" height="5016" alt="image" src="https://github.com/user-attachments/assets/1b1910f3-3b67-4dc3-b880-ff3574f9067b" />

## 测试结果
### 模拟128个CPU Worker测试 tests/rl/test_rollout_pause_simulation.py
main:         total_pause_s: 32.984s
fix_abort:  total_pause_s: 12.245s