### PR TITLE
docker: support custom FLA source install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,6 +248,14 @@ RUN pip install .[all] -v --no-cache-dir -i ${DEFAULT_PYPI_URL}
 
 WORKDIR ${CODESPACE}
 
+# use custom fla
+ARG FLA_URL
+RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
+    if [ -n "${FLA_URL}" ]; then \
+        pip uninstall -y fla-core flash-linear-attention && \
+        pip install --no-cache-dir --no-deps --no-build-isolation "git+${FLA_URL}" -i ${DEFAULT_PYPI_URL}; \
+    fi
+
 # nccl update for torch 2.6.0
 # RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 RUN if [ "x${TORCH_VERSION}" = "x2.6.0" ]; then \

--- a/image_build.sh
+++ b/image_build.sh
@@ -9,6 +9,7 @@ export GROUPED_GEMM_URL=https://github.com/InternLM/GroupedGEMM@aa5ffb21cb626d6c
 export DEEP_EP_URL=https://github.com/deepseek-ai/DeepEP@9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee # v1.2.1
 export DEEP_GEMM_URL=https://github.com/deepseek-ai/DeepGEMM@c9f8b34dcdacc20aa746b786f983492c51072870 # v2.1.1.post3
 export CAUSAL_CONV1D_URL=https://github.com/Dao-AILab/causal-conv1d@da6dbaa9fd5a919967f14d3fd031da1288ad5025 # v1.6.0
+export FLA_URL="${FLA_URL-https://github.com/HAOCHENYE/flash-linear-attention@tmp-tensor-cache}"
 
 export TORCH_VERSION=${TORCH_VERSION:-"2.9.1"}
 # export LMDEPLOY_VERSION="0.13.0dev"
@@ -34,6 +35,7 @@ docker build . \
   --build-arg FLASH_ATTN_URL=$FLASH_ATTN_URL \
   --build-arg GROUPED_GEMM_URL=$GROUPED_GEMM_URL \
   --build-arg CAUSAL_CONV1D_URL=$CAUSAL_CONV1D_URL \
+  --build-arg FLA_URL="$FLA_URL" \
   --build-arg DEEP_EP_URL=$DEEP_EP_URL \
   --build-arg DEEP_GEMM_URL=$DEEP_GEMM_URL \
   --build-arg XTUNER_URL=$XTUNER_URL \
@@ -47,6 +49,7 @@ docker build . \
   --label "FLASH_ATTN_URL=${FLASH_ATTN_URL/@/\/tree\/}" \
   --label "GROUPED_GEMM_URL=${GROUPED_GEMM_URL/@/\/tree\/}" \
   --label "CAUSAL_CONV1D_URL=${CAUSAL_CONV1D_URL/@/\/tree\/}" \
+  --label "FLA_URL=${FLA_URL/@/\/tree\/}" \
   --label "DEEP_EP_URL=${DEEP_EP_URL/@/\/tree\/}" \
   --label "DEEP_GEMM_URL=${DEEP_GEMM_URL/@/\/tree\/}" \
   --label "LMDEPLOY_URL=${LMDEPLOY_URL/@/\/tree\/}"


### PR DESCRIPTION
## Summary
- Add a Docker build arg `FLA_URL` to install a custom flash-linear-attention source after xtuner dependencies are installed.
- Default image builds to `HAOCHENYE/flash-linear-attention@tmp-tensor-cache` while allowing `FLA_URL=""` to skip the custom install.
- Uninstall `fla-core` and `flash-linear-attention` before source install to avoid mixing the split PyPI packages with the source checkout package layout.

## Tests
- `bash -n image_build.sh`
- `git diff --check -- Dockerfile image_build.sh`