### PR TITLE
Harden rollout abort and routed experts handling

### DIFF
--- a/tests/rl/test_multi_task_agent_loop_manager.py
+++ b/tests/rl/test_multi_task_agent_loop_manager.py
@@ -227,7 +227,6 @@ def _fake_agent_loop():
     rollout_ctl = MagicMock()
     rollout_ctl.continue_generation.remote = AsyncMock()
     rollout_ctl.pause_generation.remote = AsyncMock()
-    rollout_ctl.cleanup_after_pause.remote = AsyncMock()
     rollout_ctl.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
     agent_loop = MagicMock()
     agent_loop.rollout_ctl = rollout_ctl

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -37,7 +37,10 @@ class MockRolloutState:
     def __init__(self, id, seq_staleness=1, status=Status.COMPLETED, reward_score=None):
         self.id = id
         self.uid = id
+        self.message_uid = None
+        self.session_uid = None
         self.status = status
+        self.finish_reason = "abort" if status == Status.ABORTED else "stop"
         self.seq_staleness = seq_staleness
         self.response_ids = []
         self.extra_fields = {}
@@ -87,8 +90,12 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         mock_agent_loop = MagicMock()
         mock_agent_loop.rollout_ctl.continue_generation.remote = AsyncMock(return_value=None)
         mock_agent_loop.rollout_ctl.pause_generation.remote = AsyncMock(return_value=None)
-        mock_agent_loop.rollout_ctl.cleanup_after_pause.remote = AsyncMock(return_value=None)
         mock_agent_loop.rollout_ctl.get_rollout_metadata.remote = AsyncMock(return_value={"server_url_dict": {}})
+
+        async def mock_pause():
+            await mock_agent_loop.rollout_ctl.pause_generation.remote()
+
+        mock_agent_loop.pause = mock_pause
 
         sleep_by_id = sleep_by_id or {}
 
@@ -626,7 +633,6 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         expired = await self.replay_buffer.count(task_name, Status.EXPIRED)
         self.assertEqual(completed + aborted + expired, 3)
         self.assertEqual(mock_agent_loop.rollout_ctl.pause_generation.remote.await_count, 1)
-        self.assertEqual(mock_agent_loop.rollout_ctl.cleanup_after_pause.remote.await_count, 1)
 
     async def test_async_produce_strategy_pause_produce_collects_without_cancelling(self):
         # 验证 pending task 在 pause 等待窗口内完成时会被收集，而不是直接取消丢失结果。
@@ -657,7 +663,6 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         expired = await self.replay_buffer.count(task_name, Status.EXPIRED)
         self.assertEqual(completed + aborted + expired, 3)
         self.assertEqual(mock_agent_loop.rollout_ctl.pause_generation.remote.await_count, 1)
-        self.assertEqual(mock_agent_loop.rollout_ctl.cleanup_after_pause.remote.await_count, 1)
 
     async def test_async_produce_strategy_returns_update_abort_without_sampling(self):
         # 验证 update_event 已设置时策略立即返回 UPDATE_WEIGHT_AND_ABORT，不再采样新 rollout。

--- a/tests/rl/test_rollout_worker.py
+++ b/tests/rl/test_rollout_worker.py
@@ -4,7 +4,6 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xtuner.v1.data_proto.rl_data import Status
-from xtuner.v1.rl.rollout.lmdeploy import LMDeployWorker
 from xtuner.v1.rl.rollout.sglang import SGLangWorker
 from xtuner.v1.rl.rollout.worker import RolloutWorker
 from xtuner.v1.utils.httpx_utils import HttpRequestErrorType
@@ -61,13 +60,6 @@ class TestRolloutWorker(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(worker.receive_abort_request.is_set())
         worker._send_abort_request.assert_awaited_once_with()
 
-    async def test_cleanup_after_pause_is_noop_by_default(self):
-        worker = RolloutWorker.__new__(RolloutWorker)
-
-        result = await worker.cleanup_after_pause()
-
-        self.assertIsNone(result)
-
     async def test_send_abort_request_uses_abort_timeout(self):
         worker = RolloutWorker.__new__(RolloutWorker)
         worker.server_url = "http://test"
@@ -91,28 +83,6 @@ class TestRolloutWorker(unittest.IsolatedAsyncioTestCase):
             "http://test/abort_request",
             json={"abort_all": True},
         )
-
-    async def test_lmdeploy_cleanup_after_pause_clears_shared_store_when_routed_experts_enabled(self):
-        worker = LMDeployWorker.__new__(LMDeployWorker)
-        worker.enable_return_routed_experts = True
-        worker.logger = MagicMock()
-        lmdeploy_actor = MagicMock()
-        lmdeploy_actor.clear.remote = AsyncMock(return_value=None)
-
-        with patch("xtuner.v1.rl.rollout.lmdeploy.ray.get_actor", return_value=lmdeploy_actor) as get_actor:
-            await worker.cleanup_after_pause()
-
-        get_actor.assert_called_once_with("shared_store", namespace="lmdeploy")
-        lmdeploy_actor.clear.remote.assert_awaited_once_with()
-
-    async def test_lmdeploy_cleanup_after_pause_skips_without_routed_experts(self):
-        worker = LMDeployWorker.__new__(LMDeployWorker)
-        worker.enable_return_routed_experts = False
-
-        with patch("xtuner.v1.rl.rollout.lmdeploy.ray.get_actor") as get_actor:
-            await worker.cleanup_after_pause()
-
-        get_actor.assert_not_called()
 
     async def test_safe_post_request_returns_aborted_on_cancellation(self):
         worker = RolloutWorker.__new__(RolloutWorker)

--- a/xtuner/v1/data_proto/rl_data.py
+++ b/xtuner/v1/data_proto/rl_data.py
@@ -173,7 +173,7 @@ def reset_rollout_response(rollout_state: RolloutState) -> RolloutState:
         from ray import ObjectRef as RayObjectRef
 
         if isinstance(routed_experts, RayObjectRef):
-            ray.internal.free([routed_experts])
+            ray.internal.free([routed_experts], local_only=False)
         rollout_state.routed_experts = None
     prompt_ids = getattr(rollout_state, "prompt_ids", None)
     rollout_state.tokens = list(prompt_ids) if prompt_ids is not None else None

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from abc import ABC, abstractmethod
 from typing import TypeAlias, cast
 
@@ -40,6 +41,13 @@ class AgentLoopConfig(ABC, BaseModel):
                 logger=logger,
             )
 
+        get_generate_concurrency = rollout_controller.get_generate_concurrency
+        if hasattr(get_generate_concurrency, "remote"):
+            total_generate_concurrency = ray.get(get_generate_concurrency.remote())
+        else:
+            total_generate_concurrency = get_generate_concurrency()
+        concurrency = max(1, math.ceil(total_generate_concurrency / self.cpu_resources.num_workers))
+
         register_cpu_resources(
             name=f"agent_loop:{self.__class__.__name__}",
             cpu_resources=self.cpu_resources,
@@ -49,12 +57,14 @@ class AgentLoopConfig(ABC, BaseModel):
             return self._build_router(
                 rollout_controller=rollout_controller,
                 cpu_resources=self.cpu_resources,
+                concurrency=concurrency,
                 judger=judger,
                 logger=logger,
             )
         return self._build_ray_actor(
             rollout_controller=rollout_controller,
             cpu_resources=self.cpu_resources,
+            concurrency=concurrency,
             judger=judger,
             logger=logger,
         )
@@ -71,14 +81,20 @@ class AgentLoopConfig(ABC, BaseModel):
         self,
         rollout_controller: RolloutController,
         cpu_resources: CPUResourcesConfig,
+        concurrency: int,
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
         logger=None,
     ) -> RayAgentLoopProxy:
+        ray_agent_loop = ray.remote(
+            concurrency_groups={
+                AGENT_LOOP_CONCURRENCY_GROUP_GENERATE: concurrency,
+            },
+        )(AgentLoopActor)
         return cast(
             "RayAgentLoopProxy",
             CPUActorLauncher.build_actor(
-                RayAgentLoop,
+                ray_agent_loop,
                 self,
                 rollout_controller,
                 judger,
@@ -94,15 +110,21 @@ class AgentLoopConfig(ABC, BaseModel):
         self,
         rollout_controller: RolloutController,
         cpu_resources: CPUResourcesConfig,
+        concurrency: int,
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
         logger=None,
         start_bundle_idx: int = 0,
     ) -> list[RayAgentLoopProxy]:
+        ray_agent_loop = ray.remote(
+            concurrency_groups={
+                AGENT_LOOP_CONCURRENCY_GROUP_GENERATE: concurrency,
+            },
+        )(AgentLoopActor)
         return cast(
             list["RayAgentLoopProxy"],
             CPUActorLauncher.build_actors(
-                RayAgentLoop,
+                ray_agent_loop,
                 self,
                 rollout_controller,
                 judger,
@@ -119,6 +141,7 @@ class AgentLoopConfig(ABC, BaseModel):
         self,
         rollout_controller: RolloutController,
         cpu_resources: CPUResourcesConfig,
+        concurrency: int,
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
         logger=None,
@@ -128,6 +151,7 @@ class AgentLoopConfig(ABC, BaseModel):
             workers=self._build_ray_actors(
                 rollout_controller=rollout_controller,
                 cpu_resources=cpu_resources,
+                concurrency=concurrency,
                 pg=pg,
                 judger=judger,
                 logger=logger,

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -4,6 +4,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import TypeAlias, cast
 
+import ray
 from pydantic import BaseModel, ConfigDict
 from ray.actor import ActorClass, ActorProxy
 from ray.util.placement_group import PlacementGroup
@@ -19,6 +20,10 @@ from xtuner.v1.rl.utils import (
 )
 from xtuner.v1.utils import get_logger, ray_method
 from xtuner.v1.utils.processing_utils import load_processor, load_tokenizer
+
+
+AGENT_LOOP_CONCURRENCY_GROUP_GENERATE = "generate"
+DEFAULT_JUDGER_CANCEL_TIMEOUT_S = 5.0
 
 
 class AgentLoopConfig(ABC, BaseModel):
@@ -73,7 +78,7 @@ class AgentLoopConfig(ABC, BaseModel):
         return cast(
             "RayAgentLoopProxy",
             CPUActorLauncher.build_actor(
-                AgentLoopActor,
+                RayAgentLoop,
                 self,
                 rollout_controller,
                 judger,
@@ -97,7 +102,7 @@ class AgentLoopConfig(ABC, BaseModel):
         return cast(
             list["RayAgentLoopProxy"],
             CPUActorLauncher.build_actors(
-                AgentLoopActor,
+                RayAgentLoop,
                 self,
                 rollout_controller,
                 judger,
@@ -165,6 +170,20 @@ class AgentLoop(ABC):
         group_samples = await generated_samples
         return group_samples
 
+    async def pause(self) -> None:
+        # Base AgentLoop only pauses rollout generation.
+        #
+        # We intentionally do not define generic judger pause behavior in the
+        # Judger base class. Judger subclasses can implement judge() in very
+        # different ways, and one base pause implementation cannot cover all of
+        # them. Requiring users to follow a base-class pause protocol would also
+        # increase the mental overhead of writing a new judge() implementation.
+        #
+        # For now, only SingleTurnAgentLoop defines how to pause an in-flight
+        # judger call. Other AgentLoop subclasses should override pause() if
+        # they need their own judger pause semantics.
+        await self.rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
+
 
 class RouterAgentLoop:
     def __init__(self, workers: list[RayAgentLoopProxy], rollout_ctl: RolloutController):
@@ -204,6 +223,11 @@ class RouterAgentLoop:
     def get_worker_status(self) -> dict[str, int]:
         return {str(worker): load for worker, load in self._worker_loads.items()}
 
+    async def pause(self) -> None:
+        await asyncio.gather(
+            *(worker.pause.remote() for worker in self.workers),
+        )
+
 
 async def get_agent_loop_rollout_ctl(agent_loop: AgentLoopSpec) -> RolloutController:
     rollout_ctl = getattr(agent_loop, "rollout_ctl", None)
@@ -230,11 +254,11 @@ class AgentLoopActor:
             logger=logger,
         )
 
-    @ray_method
+    @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState:
         return await self.agent_loop.generate_sample(rollout_state, **kwargs)
 
-    @ray_method
+    @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
     async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
         return await self.agent_loop.generate_group(rollout_state, **kwargs)
 
@@ -242,7 +266,18 @@ class AgentLoopActor:
     async def get_rollout_ctl(self):
         return self.agent_loop.rollout_ctl
 
+    @ray_method
+    async def pause(self) -> None:
+        return await self.agent_loop.pause()
 
-RayAgentLoop = cast(ActorClass[AgentLoopActor], CPUActorLauncher.to_actor_class(AgentLoopActor))
+
+RayAgentLoop = cast(
+    ActorClass[AgentLoopActor],
+    ray.remote(
+        concurrency_groups={
+            AGENT_LOOP_CONCURRENCY_GROUP_GENERATE: 1000,
+        },
+    )(AgentLoopActor),
+)
 RayAgentLoopProxy: TypeAlias = ActorProxy[AgentLoopActor]
 AgentLoopSpec: TypeAlias = AgentLoop | RayAgentLoopProxy | RouterAgentLoop

--- a/xtuner/v1/rl/agent_loop/single_turn_agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/single_turn_agent_loop.py
@@ -1,11 +1,12 @@
 import asyncio
+from typing import overload
 
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
-from xtuner.v1.rl.utils import create_task
+from xtuner.v1.rl.utils import cancel_and_drain, create_task
 
-from .agent_loop import AgentLoop, AgentLoopConfig
+from .agent_loop import DEFAULT_JUDGER_CANCEL_TIMEOUT_S, AgentLoop, AgentLoopConfig
 
 
 class SingleTurnAgentLoopConfig(AgentLoopConfig):
@@ -62,6 +63,51 @@ class SingleTurnAgentLoop(AgentLoop):
     ):
         super().__init__(rollout_ctl, sample_params, hf_checkpoint, judger, logger)
         self.enable_batch_judge = enable_batch_judge
+        self._pause_event = asyncio.Event()
+
+    @overload
+    async def run_judger(self, rollout_state: RolloutState) -> RolloutState: ...
+
+    @overload
+    async def run_judger(self, rollout_state: list[RolloutState]) -> list[RolloutState]: ...
+
+    async def run_judger(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:
+        assert self.judger is not None
+        judge_task = create_task(self.judger.judge(rollout_state))
+        pause_task = create_task(self._pause_event.wait())
+        try:
+            done, _ = await asyncio.wait({judge_task, pause_task}, return_when=asyncio.FIRST_COMPLETED)
+            if judge_task in done:
+                return await judge_task
+            try:
+                return await asyncio.wait_for(
+                    asyncio.shield(judge_task),
+                    timeout=DEFAULT_JUDGER_CANCEL_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                await cancel_and_drain([judge_task])
+                for sample in rollout_state if isinstance(rollout_state, list) else [rollout_state]:
+                    sample.status = Status.ABORTED
+                    sample.finish_reason = "abort"
+                    sample.reward = None
+                return rollout_state
+        except asyncio.CancelledError:
+            await cancel_and_drain([judge_task])
+            for sample in rollout_state if isinstance(rollout_state, list) else [rollout_state]:
+                sample.status = Status.ABORTED
+                sample.finish_reason = "abort"
+                sample.reward = None
+            return rollout_state
+        finally:
+            await cancel_and_drain([pause_task])
+
+    async def pause(self) -> None:
+        self._pause_event.set()
+        # TODO: Decide whether Judger needs an explicit pause API for resources not owned by SingleTurnAgentLoop.
+        try:
+            await super().pause()
+        finally:
+            self._pause_event.clear()
 
     async def generate_sample(
         self,
@@ -78,7 +124,7 @@ class SingleTurnAgentLoop(AgentLoop):
             return rollout_state
         if self.judger is not None and not self.enable_batch_judge:
             # 如果开启了批量打分，则在 generate_group 里统一打分，不在这里逐条打分
-            rollout_state = await self.judger.judge(rollout_state)
+            rollout_state = await self.run_judger(rollout_state)
         return rollout_state
 
     async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
@@ -90,6 +136,7 @@ class SingleTurnAgentLoop(AgentLoop):
         generated_samples = asyncio.gather(*pending_tasks)
         group_samples = await generated_samples
         if self.judger is not None and self.enable_batch_judge:
-            # 批量打分
-            group_samples = await self.judger.judge(group_samples)
+            if not any(sample.status == Status.ABORTED for sample in group_samples):
+                # 批量打分
+                group_samples = await self.run_judger(group_samples)
         return group_samples

--- a/xtuner/v1/rl/agent_loop_manager/producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/producer.py
@@ -19,10 +19,11 @@ from xtuner.v1.data_proto.rl_data import (
     RolloutState,
     Status,
     get_group_status,
+    reset_rollout_response,
 )
-from xtuner.v1.rl.agent_loop import AgentLoopSpec, get_agent_loop_rollout_ctl
+from xtuner.v1.rl.agent_loop import AgentLoopSpec
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
-from xtuner.v1.rl.utils import calculate_seq_staleness, create_task
+from xtuner.v1.rl.utils import calculate_seq_staleness, cancel_and_drain, create_task
 from xtuner.v1.utils import get_logger
 
 from .sampler import Sampler
@@ -360,6 +361,7 @@ class ProduceContext:
     async def put_generated_group(self, group: list[RolloutState]) -> bool:
         # 只有完整生成的 group 才需要业务有效性过滤；ABORTED / EXPIRED 保留原状态供重试或统计。
         is_completed = get_group_status(group) == Status.COMPLETED
+        produced_tokens = sum(len(item.response_ids) for item in group if item.response_ids is not None)
         if is_completed:
             rewards_sum = 0.0
             rewards_count = 0
@@ -376,6 +378,7 @@ class ProduceContext:
             if not is_valid:
                 for item in group:
                     item.status = Status.FILTERED
+                    reset_rollout_response(item)
         await self.replay_buffer.put(
             group,
             self.task_name,
@@ -383,12 +386,6 @@ class ProduceContext:
             current_train_step=self.consumer_step,
             stale_threshold=self.stale_threshold,
         )
-        produced_tokens = 0
-        for item in group:
-            response_ids = getattr(item, "response_ids", None)
-            if response_ids is None:
-                continue
-            produced_tokens += int(response_ids.numel()) if hasattr(response_ids, "numel") else len(response_ids)
         self.progress.add_produced(self.task_name, samples=len(group), tokens=produced_tokens)
         # replay_buffer.put 可能把 stale group 转为 EXPIRED，返回前重新判断是否仍可训练。
         is_completed = get_group_status(group) == Status.COMPLETED
@@ -597,9 +594,10 @@ class _PendingTasks:
 
     async def cancel_all(self) -> int:
         tasks = await self._claim_all()
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        if not tasks:
+            return 0
+        logger.warning(f"Cancelling {len(tasks)} pending rollout tasks.")
+        await cancel_and_drain(list(tasks))
         return len(tasks)
 
 
@@ -656,7 +654,8 @@ class SyncProduceStrategy(ProduceStrategy):
 
 
 class AsyncProduceStrategy(ProduceStrategy):
-    PENDING_TASK_COLLECT_TIMEOUT_S = 300.0
+    PENDING_TASK_COLLECT_TIMEOUT_S = 60.0
+    PERIODIC_ABORT_INTERVAL_S = 5.0
 
     def __init__(
         self,
@@ -706,64 +705,79 @@ class AsyncProduceStrategy(ProduceStrategy):
     ) -> None:
         completed_count = 0
         for task in claimed_tasks:
-            is_completed = await ctx.put_generated_group(task.result())
+            items = task.result()
+            is_completed = await ctx.put_generated_group(items)
             if is_completed:
                 completed_count += 1
             if is_completed and available_base is not None and progress_displayer is not None:
                 progress_displayer.update(available_base + completed_count)
+
+    async def _pause_agent_loop(self, ctx: ProduceContext) -> None:
+        pause_request_start = time.perf_counter()
+        if isinstance(ctx.agent_loop, ray.actor.ActorHandle):
+            pause_future = ctx.agent_loop.pause.remote()
+        else:
+            pause_future = ctx.agent_loop.pause()
+        try:
+            await asyncio.wait_for(pause_future, timeout=10.0)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Agent loop pause timed out: task={ctx.task_name}, timeout_s=10.0, "
+                f"elapsed={time.perf_counter() - pause_request_start:.2f}s, "
+                f"pending={self._pending_tasks.count()}"
+            )
+        except Exception:
+            logger.exception(
+                f"Agent loop pause failed: task={ctx.task_name}, "
+                f"elapsed={time.perf_counter() - pause_request_start:.2f}s, "
+                f"pending={self._pending_tasks.count()}"
+            )
 
     async def pause_produce(self, ctx: ProduceContext) -> float:
         pause_start = time.perf_counter()
         if self._pending_tasks.count() == 0:
             return 0.0
 
-        rollout_ctl = await get_agent_loop_rollout_ctl(ctx.agent_loop)
-        await rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
+        pending_pause_tasks = {create_task(self._pause_agent_loop(ctx))}
+        initial_pending_count = self._pending_tasks.count()
 
         logger.info(
-            f"Pause signal sent for task {ctx.task_name}. Waiting for {self._pending_tasks.count()} pending tasks to complete..."
+            f"Pause signal loop started for task {ctx.task_name}. "
+            f"Waiting for {initial_pending_count} pending tasks to complete. "
+            f"periodic_abort_interval_s={self.PERIODIC_ABORT_INTERVAL_S}, "
+            f"pending_collect_timeout_s={self.PENDING_TASK_COLLECT_TIMEOUT_S}"
         )
         cleanup_start_time = time.perf_counter()
-        aborted_count = 0
-        aborted_tokens_sum = 0
-        aborted_zero_token_count = 0
+        next_periodic_abort_time = cleanup_start_time + self.PERIODIC_ABORT_INTERVAL_S
         while True:
             elapsed_time = time.perf_counter() - cleanup_start_time
             if elapsed_time > self.PENDING_TASK_COLLECT_TIMEOUT_S:
+                # 超时强制取消所有pending的任务
                 cancelled_count = await self._pending_tasks.cancel_all()
                 logger.warning(
                     f"Cleanup timeout of {self.PENDING_TASK_COLLECT_TIMEOUT_S}s reached. "
-                    f"Forcefully cancelling {cancelled_count} remaining tasks."
+                    f"Forcefully cancelling {cancelled_count} remaining tasks. "
+                    f"task={ctx.task_name}"
                 )
                 break
 
             if self._pending_tasks.count() == 0:
                 break
+            current_time = time.perf_counter()
+            pending_pause_tasks = {task for task in pending_pause_tasks if not task.done()}
+
+            # 定时发送 pause 信号
+            if self.PERIODIC_ABORT_INTERVAL_S > 0 and current_time >= next_periodic_abort_time:
+                pending_pause_tasks.add(create_task(self._pause_agent_loop(ctx)))
+                next_periodic_abort_time += self.PERIODIC_ABORT_INTERVAL_S
 
             claimed_done = await self._pending_tasks.wait_and_claim(timeout_s=1)
             for task in claimed_done:
                 paused_items = task.result()
-                for item in paused_items:
-                    if item.status == Status.ABORTED:
-                        token_count = len(item.response_ids or [])
-                        aborted_count += 1
-                        aborted_tokens_sum += token_count
-                        if token_count == 0:
-                            aborted_zero_token_count += 1
-                    logger.debug(
-                        f"[{self.__class__.__name__}] Task {ctx.task_name} | "
-                        f"Collecting paused sample (uid: {item.uid}, status: {item.status}, "
-                        f"length: {len(item.response_ids or [])}) after pausing generation."
-                    )
                 await ctx.put_generated_group(paused_items)
-        await rollout_ctl.cleanup_after_pause.remote()  # type: ignore[attr-defined]
+        await cancel_and_drain(list(pending_pause_tasks))
         pause_time = time.perf_counter() - pause_start
-        aborted_tokens_mean = aborted_tokens_sum / aborted_count if aborted_count > 0 else 0.0
-        logger.info(
-            f"pause_produce completed for task {ctx.task_name} within {pause_time}s. "
-            f"aborted_count={aborted_count}, aborted_tokens_mean={aborted_tokens_mean:.1f}, "
-            f"aborted_zero_token_count={aborted_zero_token_count}."
-        )
+        logger.info(f"pause_produce completed for task {ctx.task_name} within {pause_time}s.")
         return pause_time
 
     async def produce_batch(self, ctx: ProduceContext) -> ProduceBatchStatus:

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -20,7 +20,11 @@ from .parser.factory import build_reasoning_parser, build_tool_call_parser
 from .parser.reasoning_parser import ReasoningParser
 from .parser.tool_parser import ToolCallParser
 from .utils import ROLLOUT_RAY_GET_TIMEOUT, RolloutHealthChecker, SessionRouter
-from .worker import ROLLOUT_CONCURRENCY_GROUP_GENERATE, RolloutConfig, RolloutWorker
+from .worker import (
+    ROLLOUT_CONCURRENCY_GROUP_GENERATE,
+    RolloutConfig,
+    RolloutWorker,
+)
 
 
 if TYPE_CHECKING:
@@ -183,6 +187,17 @@ class RolloutController:
             "total_workers": total_workers,
         }
 
+    def get_generate_concurrency(self) -> int:
+        assert self.config.rollout_max_batch_size_per_instance is not None, (
+            "rollout_max_batch_size_per_instance must be set before building AgentLoop."
+        )
+        concurrency_per_worker = math.ceil(
+            self.config.rollout_max_batch_size_per_instance * self.config.allow_over_concurrency_ratio
+        )
+        with self.worker_info_lock:
+            active_workers = sum(1 for info in self.rank2info.values() if info.is_active)
+        return active_workers * concurrency_per_worker
+
     @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     async def generate(self, rollout_state: RolloutState) -> RolloutState:
         if XTUNER_DETERMINISTIC:
@@ -208,7 +223,10 @@ class RolloutController:
             self._apply_output_parsers(response_rollout_state)
             return response_rollout_state
         except asyncio.TimeoutError:
-            self.logger.error(f"Rollout timeout for worker {worker}. Skipping sample.")
+            self.logger.error(
+                f"RolloutController.generate timed out waiting for worker: session_id={session_id}, "
+                f"timeout={self.config.rollout_timeout * self.timeout_multiplier}"
+            )
             rollout_state.status = Status.FAILED
             rollout_state.error_msg = (
                 f"Rollout request timed out after {self.config.rollout_timeout * self.timeout_multiplier} seconds."
@@ -238,10 +256,22 @@ class RolloutController:
 
     def pause_generation(self):
         self.health_checker.pause()
-        self._broadcast_to_active_workers("pause_generation")
-
-    def cleanup_after_pause(self):
-        self._broadcast_to_active_workers("cleanup_after_pause")
+        with self.worker_info_lock:
+            active_workers = [info for info in self.rank2info.values() if info.is_active]
+        futures = [info.actor.pause_generation.remote() for info in active_workers]  # type: ignore[attr-defined]
+        try:
+            results = ray.get(futures, timeout=ROLLOUT_RAY_GET_TIMEOUT)
+        except Exception:
+            self.logger.exception(
+                f"RolloutController pause_generation failed for {len(active_workers)} active workers."
+            )
+            raise
+        succeeded_worker_urls = [info.url for info, result in zip(active_workers, results) if result is not False]
+        failed_worker_urls = [info.url for info, result in zip(active_workers, results) if result is False]
+        if succeeded_worker_urls:
+            self.logger.info(f"Abort request sent successfully: count={len(succeeded_worker_urls)}")
+        if failed_worker_urls:
+            self.logger.warning(f"Abort request failed: worker_urls={failed_worker_urls}")
 
     def continue_generation(self):
         self.health_checker.resume()

--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -193,17 +193,6 @@ class LMDeployWorker(RolloutWorker):
             return ray.put(np.asarray(routed_experts_data))
         return np.asarray(routed_experts)
 
-    async def cleanup_after_pause(self) -> None:
-        if not self.enable_return_routed_experts:
-            return
-        try:
-            lmdeploy_actor = ray.get_actor(SHARED_STORE, namespace=SHARED_STORE_NAMESPACE)
-            await lmdeploy_actor.clear.remote()
-        except ValueError:
-            self.logger.debug("LMDeploy shared_store actor is not available, skip cleanup after pause.")
-        except Exception as e:
-            self.logger.warning(f"Failed to clear LMDeploy shared_store after pause: {e}")
-
     def _transform_rollout_config_to_server_configs(self) -> Namespace:
         """Transform the RolloutConfig into a Namespace suitable for the
         LMDeploy server.

--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -118,8 +118,15 @@ class LMDeployWorker(RolloutWorker):
                 text_prompt = self.tokenizer.apply_chat_template(message, tokenize=False, add_generation_prompt=True)
                 prompt_token_ids = self.tokenizer(text_prompt, add_special_tokens=False)["input_ids"]
                 payload["input_ids"] = prompt_token_ids
-            sample_params.return_routed_experts = True if self.enable_return_routed_experts else False
-            lmdeploy_sample_params = self._transform_sample_params(sample_params)
+            lmdeploy_sample_params = self._transform_sample_params(
+                sample_params.model_copy(
+                    update={
+                        "return_routed_experts": (
+                            self.enable_return_routed_experts and sample_params.return_routed_experts
+                        )
+                    }
+                )
+            )
             payload.update(lmdeploy_sample_params)
         else:
             payload = {

--- a/xtuner/v1/rl/rollout/sglang.py
+++ b/xtuner/v1/rl/rollout/sglang.py
@@ -54,7 +54,11 @@ class SGLangWorker(RolloutWorker):
         sglang_extra_params = self._transform_extra_params(sample_params.model_dump())
         payload.update(sglang_extra_params)
 
-        if self.enable_return_routed_experts and not rollout_state.extra_fields.get("disable_routed_experts", False):
+        if (
+            self.enable_return_routed_experts
+            and sample_params.return_routed_experts
+            and not rollout_state.extra_fields.get("disable_routed_experts", False)
+        ):
             payload["return_routed_experts"] = True
 
         if sample_params.return_token_ids:
@@ -100,7 +104,11 @@ class SGLangWorker(RolloutWorker):
         payload = {"model": self.model_name}
         sglang_sample_params = self._transform_sample_params(sample_params)
         sglang_extra_params = self._transform_extra_params(extra_params)
-        if self.enable_return_routed_experts and not extra_params.get("disable_routed_experts", False):
+        if (
+            self.enable_return_routed_experts
+            and sample_params.get("return_routed_experts", False)
+            and not extra_params.get("disable_routed_experts", False)
+        ):
             sglang_extra_params["return_routed_experts"] = True
 
         payload.update(sglang_extra_params)

--- a/xtuner/v1/rl/rollout/vllm.py
+++ b/xtuner/v1/rl/rollout/vllm.py
@@ -212,6 +212,9 @@ class vLLMWorker(RolloutWorker):
             payload["input_ids"] = extra_info["train_prompt_ids"]
 
         vllm_sample_params = self._transform_sample_params(sample_params, extra_params)
+        vllm_sample_params["return_routed_experts"] = self.enable_return_routed_experts and sample_params.get(
+            "return_routed_experts", False
+        )
         payload.update(vllm_sample_params)
 
         return await self._safe_post_request(url, headers, payload)
@@ -376,6 +379,7 @@ class vLLMWorker(RolloutWorker):
         last_token_ids: list[int] = []
         last_logprobs: list[float] = []
         routed_experts = None
+        should_return_routed_experts = self.enable_return_routed_experts and sample_params.return_routed_experts
 
         response_json = response.json()
         response_choice = response_json["choices"][0]
@@ -395,7 +399,7 @@ class vLLMWorker(RolloutWorker):
             self.receive_abort_request.set()
             self.logger.info(f"Setting receive_abort_request to True for rank {self.rank}")
 
-        if self.enable_return_routed_experts:
+        if should_return_routed_experts:
             routed_experts = response_choice.get("routed_experts", response_json.get("routed_experts"))
             if routed_experts is not None:
                 if isinstance(routed_experts, str):
@@ -416,7 +420,7 @@ class vLLMWorker(RolloutWorker):
                 validation_errors.append("missing logprobs")
             if not last_trajectory:
                 validation_errors.append("empty response text")
-            if self.enable_return_routed_experts and routed_experts is None:
+            if should_return_routed_experts and routed_experts is None:
                 validation_errors.append("missing routed_experts")
 
             if validation_errors:

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -509,7 +509,7 @@ class RolloutWorker(SingleAcceleratorWorker):
         assert config.rollout_max_batch_size_per_instance, (
             "rollout_max_batch_size_per_instance must be set in RolloutConfig"
         )
-        http_concurrency = config.rollout_max_batch_size_per_instance * config.allow_over_concurrency_ratio
+        http_concurrency = math.ceil(config.rollout_max_batch_size_per_instance * config.allow_over_concurrency_ratio)
         limits = httpx.Limits(max_connections=http_concurrency, max_keepalive_connections=100)
         self.client = httpx.AsyncClient(limits=limits, timeout=self.config.rollout_timeout)
         self.server_task = None
@@ -613,20 +613,14 @@ class RolloutWorker(SingleAcceleratorWorker):
         self.receive_abort_request.set()
         return await self._send_abort_request()
 
-    async def cleanup_after_pause(self) -> None:
-        """Run backend-specific cleanup after paused requests are drained."""
-        return None
-
     async def _send_abort_request(self) -> bool:
         url = f"{self.server_url}/abort_request"
         try:
             async with httpx.AsyncClient(timeout=self.abort_timeout) as client:
                 response = await client.post(url, json={"abort_all": True})
             response.raise_for_status()
-            self.logger.debug(f"Successfully sent abort request to {self.server_url}")
             return True
-        except Exception as e:
-            self.logger.error(f"Failed to send abort request to {self.server_url}: {e}")
+        except Exception:
             return False
 
     async def _wait_abort_request(self) -> None:
@@ -726,6 +720,10 @@ class RolloutWorker(SingleAcceleratorWorker):
             if http_result.response:
                 # Case 1.1: Valid rollout response
                 rollout_state = await self._safe_handle_response(rollout_state, http_result.response)
+                if self.receive_abort_request.is_set():
+                    rollout_state.finish_reason = "abort"
+                    rollout_state.status = Status.ABORTED
+                    return rollout_state
                 if rollout_state.status in [Status.COMPLETED, Status.ABORTED]:
                     return rollout_state
 
@@ -906,7 +904,6 @@ class RolloutWorker(SingleAcceleratorWorker):
 
         try:
             if self.receive_abort_request.is_set():
-                self.logger.debug(f"Request to {url} was cancelled before sending due to an abort signal.")
                 return HttpRequestResult(error_type=HttpRequestErrorType.REQUEST_ABORTED, url=url, payload=payload)
             req = self.client.build_request(
                 "POST",
@@ -926,9 +923,6 @@ class RolloutWorker(SingleAcceleratorWorker):
                 try:
                     r = await asyncio.wait_for(asyncio.shield(send_task), timeout=self.abort_timeout)
                 except asyncio.TimeoutError:
-                    self.logger.debug(
-                        f"Request to {url} did not return within {self.abort_timeout:.2f}s after abort signal."
-                    )
                     await cancel_and_drain([send_task])
                     return HttpRequestResult(
                         error_type=HttpRequestErrorType.REQUEST_ABORTED,
@@ -939,7 +933,6 @@ class RolloutWorker(SingleAcceleratorWorker):
             return HttpRequestResult(response=r)
 
         except asyncio.CancelledError:
-            self.logger.debug(f"Request to {url} was cancelled while waiting for the response.")
             await cancel_and_drain([send_task, abort_task])
             self.receive_abort_request.set()
             return HttpRequestResult(error_type=HttpRequestErrorType.REQUEST_ABORTED, url=url, payload=payload)
@@ -952,6 +945,7 @@ class RolloutWorker(SingleAcceleratorWorker):
 
     async def _safe_handle_response(self, rollout_state: RolloutState, http_response: httpx.Response) -> RolloutState:
         uid = rollout_state.message_uid
+
         sample_params = rollout_state.sample_params
         is_token_out = sample_params.return_token_ids
         response = http_response.json()

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -961,6 +961,7 @@ class RolloutWorker(SingleAcceleratorWorker):
             logprobs: list[float] = []
             routed_experts = None
             returned_response = ""
+            should_return_routed_experts = self.enable_return_routed_experts and sample_params.return_routed_experts
             try:
                 meta_info = response.get("meta_info") or {}
                 finish_reason_info = meta_info.get("finish_reason") or {}
@@ -991,9 +992,8 @@ class RolloutWorker(SingleAcceleratorWorker):
                 else:
                     num_return_tokens = response["meta_info"].get("completion_tokens", 0)
                     response_ids = response["output_ids"][-num_return_tokens:] if num_return_tokens > 0 else []
-
                 # 获取 routed_experts
-                if self.enable_return_routed_experts:
+                if should_return_routed_experts:
                     assert "routed_experts" in response["meta_info"], (
                         "enable_return_routed_experts is True, but routed_experts is not in meta_info"
                     )
@@ -1019,7 +1019,7 @@ class RolloutWorker(SingleAcceleratorWorker):
                     if sample_params.return_logprob and not logprobs:
                         validation_errors.append("missing logprobs")
 
-                    if self.enable_return_routed_experts and routed_experts is None:
+                    if should_return_routed_experts and routed_experts is None:
                         validation_errors.append("missing routed_experts")
 
                     if validation_errors:

--- a/xtuner/v1/rl/trainer/controller.py
+++ b/xtuner/v1/rl/trainer/controller.py
@@ -7,6 +7,7 @@ import torch
 
 from xtuner.v1.data_proto.sequence_context import SequenceContext
 from xtuner.v1.model.compose.base import BaseComposeConfig
+from xtuner.v1.rl.utils import free_object_refs
 from xtuner.v1.train.trainer import LoadCheckpointConfig
 from xtuner.v1.utils import get_logger
 
@@ -263,8 +264,8 @@ class TrainingController:
             for data in packed_data_batches:
                 if data["seq_ctx"].pixel_values is not None:
                     free_pixel_value_refs.extend(data["seq_ctx"].pixel_values)
-            # if len(free_pixel_value_refs) > 0:
-            # free_object_refs(free_pixel_value_refs)
+            if len(free_pixel_value_refs) > 0:
+                free_object_refs(free_pixel_value_refs)
             del packed_data_batches
         return log_infos
 

--- a/xtuner/v1/rl/utils/async_utils.py
+++ b/xtuner/v1/rl/utils/async_utils.py
@@ -58,7 +58,7 @@ def create_task(
     return task
 
 
-async def cancel_and_drain(tasks: list[Task | None]) -> None:
+async def cancel_and_drain(tasks: list[Task | None], *, timeout: float = 5.0) -> None:
     """Cancel tasks and consume their terminal exceptions.
 
     Use this when a parent coroutine handles cancellation itself but owns child tasks that must not keep running in the
@@ -71,7 +71,10 @@ async def cancel_and_drain(tasks: list[Task | None]) -> None:
         if task.done():
             continue
         task.cancel()
-    await asyncio.gather(*tasks_to_drain, return_exceptions=True)
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks_to_drain, return_exceptions=True), timeout=timeout)
+    except asyncio.TimeoutError:
+        return
 
 
 def _get_default_asyncio_loop() -> AbstractEventLoop:

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import random
 import re
@@ -513,6 +514,7 @@ class BaseRLTrainer:
         self._init_train_state(cfg)
         self._init_train_worker_config(cfg, log_dir)
         self._init_rollout_config(cfg, log_dir)
+        self._ensure_rollout_http_concurrency(cfg)
         self._init_runtime_flags(cfg)
         self._advantage_estimator = cfg.advantage_estimator_config.build()
         self._cpu_resource_manager: CPUResourceManager | None = None
@@ -595,6 +597,49 @@ class BaseRLTrainer:
                 f"Skip load rollout weights due to resume from checkpoint {self._load_checkpoint_cfg.checkpoint_path}"
             )
         self._rollout_config = cfg.rollout_config
+
+    def _ensure_rollout_http_concurrency(self, cfg: BaseRLTrainerConfig) -> None:
+        rollout_max_batch_size = cfg.rollout_config.rollout_max_batch_size_per_instance
+        if rollout_max_batch_size is None or rollout_max_batch_size <= 0:
+            return
+
+        if isinstance(cfg, RLDisaggregatedTrainerConfig):
+            rollout_worker_count = cfg.rollout_resources.num_workers
+        elif isinstance(cfg, RLColocateTrainerConfig):
+            rollout_worker_count = cfg.resources.num_workers
+        else:
+            rollout_worker_count = 1
+        active_rollout_worker_count, _ = cfg.rollout_config.get_active_servers_count(rollout_worker_count)
+        if active_rollout_worker_count <= 0:
+            return
+
+        tasks = cfg.agent_loop_manager_cfg.tasks
+        task_cfgs = tasks if isinstance(tasks, list) else [tasks]
+        total_weight = sum(task.weight for task in task_cfgs)
+        if total_weight <= 0:
+            return
+
+        scheduled_http_requests = 0.0
+        for task in task_cfgs:
+            task_batch_size = cfg.train_batch_size * task.weight / total_weight
+            over_sample_threshold = float(getattr(task.produce_strategy_config, "over_sample_threshold", 0.0))
+            scheduled_http_requests += (
+                task_batch_size * task.sampler_config.prompt_repeat_k * (1 + over_sample_threshold)
+            )
+
+        required_http_concurrency = math.ceil(scheduled_http_requests / active_rollout_worker_count)
+        current_http_concurrency = math.ceil(rollout_max_batch_size * cfg.rollout_config.allow_over_concurrency_ratio)
+        if current_http_concurrency >= required_http_concurrency:
+            return
+
+        new_ratio = required_http_concurrency / rollout_max_batch_size
+        cfg.rollout_config.allow_over_concurrency_ratio = new_ratio
+        self.logger.warning(
+            "Increasing rollout_config.allow_over_concurrency_ratio because httpx max_connections is smaller "
+            "than the expected per-worker rollout request concurrency: "
+            f"max_connections={current_http_concurrency}, "
+            f"required_connections={required_http_concurrency}"
+        )
 
     def _init_runtime_flags(self, cfg: BaseRLTrainerConfig) -> None:
         self._enable_evaluate = cfg.enable_evaluate

--- a/xtuner/v1/utils/type_helper.py
+++ b/xtuner/v1/utils/type_helper.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, ParamSpec, Protocol, TypeVar, overload
 
 from typing_extensions import Concatenate
 
@@ -32,12 +32,24 @@ class RemoteMethod(Generic[P, T]):
     def bind(self, *args: P.args, **kwargs: P.kwargs) -> Any: ...
 
 
+class RayMethodDecorator(Protocol):
+    @overload
+    def __call__(self, f: Callable[Concatenate[C, P], Awaitable[T]]) -> RemoteMethod[P, T]: ...
+
+    @overload
+    def __call__(self, f: Callable[Concatenate[C, P], T]) -> RemoteMethod[P, T]: ...
+
+
 @overload
 def ray_method(f: Callable[Concatenate[C, P], Awaitable[T]]) -> RemoteMethod[P, T]: ...
 
 
 @overload
 def ray_method(f: Callable[Concatenate[C, P], T]) -> RemoteMethod[P, T]: ...
+
+
+@overload
+def ray_method(*, num_returns: int = 1, concurrency_group: str | None = None) -> RayMethodDecorator: ...
 
 
 def ray_method(f=None, *, num_returns=1, concurrency_group=None):


### PR DESCRIPTION

  这个 PR 主要修复 rollout pause/abort 在高并发异步 RL 训练中的收尾问题，并拆成三类改动：

  1. **增强 `abort_request` 的可靠性**
     - 在 RL trainer 初始化阶段根据 `train_batch_size * prompt_repeat_k * (1 + over_sample_threshold) / rollout_workers` 检查所需 **HTTP 并发**，**如果当前 `allow_over_concurrency_ratio` 不足，会自动调大并打印 warning**。
     - rollout worker 收到 abort 后，如果已有 HTTP response 返回，不再直接丢弃 response，而是正常解析 response，然后把 `status` 和 `finish_reason` 标记为 `ABORTED`，避免 abort 后完成的 response 被误当成 completed sample，然后继续 judge
     - 对 abort 后仍未返回的 HTTP client task 增加 cancel/drain timeout，避免本地 cancel 卡住。
     - producer cleanup 超时后会强制 cancel 剩余 pending rollout tasks，并用 drain timeout 收口，避免 pause 卡死。
     - producer 在等待 pending tasks 回收期间周期性补发 abort，覆盖 abort 后才到达 LMDeploy 的少量请求。
     - 对 HTTP client task、pending rollout task、judger pause 都加 timeout/drain，避免任何一个环节无限阻塞 pause。

  2. **支持 judger abort**
     - `AgentLoop.pause()` 统一触发 rollout pause 和 judger pause。
     - 如果 group 中存在 aborted sample，会跳过 judge，避免 abort 后的样本继续进入 batch judge 导致 pause 尾部卡住。
     **- 新的修复：不在Judger中定义pause方法，如果在基类写pause方法，没办法做到每个judger都能用，为了简化judger的用法，所以在 `SingleTurnAgentLoop`中将调用judger作为可取消的** 

  3. **修复 routed experts 的返回与清理**
     - `return_routed_experts` 改为同时受全局 `enable_return_routed_experts` 和 request-level `sample_params.return_routed_experts` 控制，**评估请求关闭 routed experts 返回**。
     - filtered sample 入 replay buffer 前会清理 response/routed experts，减少无效样本持有大对象。
