### PR TITLE
test: add async HF fake engine cleanup hook

### DIFF
--- a/tests/train/test_trainer_async_hf.py
+++ b/tests/train/test_trainer_async_hf.py
@@ -79,6 +79,9 @@ class FakeAsyncHFEngine:
         self.grad_norm_calls += 1
         return torch.tensor(1.0)
 
+    def destroy_async_checkpoint_pg(self) -> None:
+        pass
+
     def _cleanup_hf_dirs(self, cleanup_hf_dirs):
         for cleanup_hf_dir in cleanup_hf_dirs:
             cleanup_hf_dir = Path(cleanup_hf_dir)


### PR DESCRIPTION
## Summary
- add a no-op destroy_async_checkpoint_pg method to FakeAsyncHFEngine
- keep the async HF trainer test fake engine aligned with Trainer.fit lifecycle cleanup

## Test
- python3 -m py_compile tests/train/test_trainer_async_hf.py
- targeted pytest not run locally: pytest is not installed in this environment