### PR TITLE
feat: add rank0 async HF save logs

### DIFF
--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -318,11 +318,12 @@ class TrainEngine:
         save_dtype: torch.dtype = torch.bfloat16,
         cleanup_hf_dirs: Sequence[str | Path] = (),
     ) -> AsyncHFSaveHandle:
-        return self.model.async_save_hf(
-            hf_dir=hf_dir,
-            save_dtype=save_dtype,
-            cleanup_hf_dirs=cleanup_hf_dirs,
-        )
+        with profile_time_and_memory(f"[Async saving HF to {hf_dir} launch cost]"):
+            return self.model.async_save_hf(
+                hf_dir=hf_dir,
+                save_dtype=save_dtype,
+                cleanup_hf_dirs=cleanup_hf_dirs,
+            )
 
     def wait_async_hf(self, handle: AsyncHFSaveHandle | None = None) -> Path | None:
         return self.model.wait_async_hf(handle)

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -762,6 +762,14 @@ class BaseModel(nn.Module):
         cleanup_done_path: Path,
         rank: int,
     ) -> None:
+        writer_start = time.time()
+        log_hf_dir = (
+            tmp_hf_dir.with_name(tmp_hf_dir.name[: -len(".incomplete")])
+            if tmp_hf_dir.name.endswith(".incomplete")
+            else tmp_hf_dir
+        )
+        if rank == 0:
+            logger.info(f"[Async saving HF to {log_hf_dir} writer] started")
         try:
             set_async_save_process_qos()
             self._cleanup_async_hf_dirs_before_write(
@@ -775,7 +783,13 @@ class BaseModel(nn.Module):
                 weight_map=weight_map,
                 status_path=status_path,
             )
+            if rank == 0:
+                elapsed = time.time() - writer_start
+                logger.info(f"[Async saving HF to {log_hf_dir} writer] finished in {elapsed:.2f}s")
         except Exception as exc:
+            if rank == 0:
+                elapsed = time.time() - writer_start
+                logger.error(f"[Async saving HF to {log_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -762,8 +762,7 @@ class BaseModel(nn.Module):
         cleanup_done_path: Path,
         rank: int,
     ) -> None:
-        if rank == 0:
-            logger.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
+        log_rank0.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
         try:
             set_async_save_process_qos()
             self._cleanup_async_hf_dirs_before_write(
@@ -777,11 +776,9 @@ class BaseModel(nn.Module):
                 weight_map=weight_map,
                 status_path=status_path,
             )
-            if rank == 0:
-                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished")
+            log_rank0.info(f"[Async saving HF to {tmp_hf_dir} writer] finished")
         except Exception as exc:
-            if rank == 0:
-                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed: {exc}")
+            log_rank0.error(f"[Async saving HF to {tmp_hf_dir} writer] failed: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -763,13 +763,8 @@ class BaseModel(nn.Module):
         rank: int,
     ) -> None:
         writer_start = time.time()
-        log_hf_dir = (
-            tmp_hf_dir.with_name(tmp_hf_dir.name[: -len(".incomplete")])
-            if tmp_hf_dir.name.endswith(".incomplete")
-            else tmp_hf_dir
-        )
         if rank == 0:
-            logger.info(f"[Async saving HF to {log_hf_dir} writer] started")
+            logger.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
         try:
             set_async_save_process_qos()
             self._cleanup_async_hf_dirs_before_write(
@@ -785,11 +780,11 @@ class BaseModel(nn.Module):
             )
             if rank == 0:
                 elapsed = time.time() - writer_start
-                logger.info(f"[Async saving HF to {log_hf_dir} writer] finished in {elapsed:.2f}s")
+                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished in {elapsed:.2f}s")
         except Exception as exc:
             if rank == 0:
                 elapsed = time.time() - writer_start
-                logger.error(f"[Async saving HF to {log_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
+                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -762,7 +762,6 @@ class BaseModel(nn.Module):
         cleanup_done_path: Path,
         rank: int,
     ) -> None:
-        writer_start = time.time()
         if rank == 0:
             logger.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
         try:
@@ -779,12 +778,10 @@ class BaseModel(nn.Module):
                 status_path=status_path,
             )
             if rank == 0:
-                elapsed = time.time() - writer_start
-                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished in {elapsed:.2f}s")
+                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished")
         except Exception as exc:
             if rank == 0:
-                elapsed = time.time() - writer_start
-                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
+                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))

--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -260,13 +260,8 @@ class BaseComposeModel(BaseModel):
         rank: int,
     ) -> None:
         writer_start = time.time()
-        log_hf_dir = (
-            tmp_hf_dir.with_name(tmp_hf_dir.name[: -len(".incomplete")])
-            if tmp_hf_dir.name.endswith(".incomplete")
-            else tmp_hf_dir
-        )
         if rank == 0:
-            logger.info(f"[Async saving HF to {log_hf_dir} writer] started")
+            logger.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
         try:
             set_async_save_process_qos()
             self._cleanup_async_hf_dirs_before_write(
@@ -281,11 +276,11 @@ class BaseComposeModel(BaseModel):
                 f.write(json.dumps(status, indent=2))
             if rank == 0:
                 elapsed = time.time() - writer_start
-                logger.info(f"[Async saving HF to {log_hf_dir} writer] finished in {elapsed:.2f}s")
+                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished in {elapsed:.2f}s")
         except Exception as exc:
             if rank == 0:
                 elapsed = time.time() - writer_start
-                logger.error(f"[Async saving HF to {log_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
+                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))

--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -1,5 +1,6 @@
 import json
 import multiprocessing as py_mp
+import time
 from pathlib import Path
 from shutil import rmtree
 from typing import Callable, Self, Sequence

--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -258,8 +258,7 @@ class BaseComposeModel(BaseModel):
         cleanup_done_path: Path,
         rank: int,
     ) -> None:
-        if rank == 0:
-            logger.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
+        log_rank0.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
         try:
             set_async_save_process_qos()
             self._cleanup_async_hf_dirs_before_write(
@@ -272,11 +271,9 @@ class BaseComposeModel(BaseModel):
             status = {"rank": rank, "ok": True, "error": "", "weight_map": merged_weight_map}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))
-            if rank == 0:
-                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished")
+            log_rank0.info(f"[Async saving HF to {tmp_hf_dir} writer] finished")
         except Exception as exc:
-            if rank == 0:
-                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed: {exc}")
+            log_rank0.error(f"[Async saving HF to {tmp_hf_dir} writer] failed: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))

--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -258,6 +258,14 @@ class BaseComposeModel(BaseModel):
         cleanup_done_path: Path,
         rank: int,
     ) -> None:
+        writer_start = time.time()
+        log_hf_dir = (
+            tmp_hf_dir.with_name(tmp_hf_dir.name[: -len(".incomplete")])
+            if tmp_hf_dir.name.endswith(".incomplete")
+            else tmp_hf_dir
+        )
+        if rank == 0:
+            logger.info(f"[Async saving HF to {log_hf_dir} writer] started")
         try:
             set_async_save_process_qos()
             self._cleanup_async_hf_dirs_before_write(
@@ -270,7 +278,13 @@ class BaseComposeModel(BaseModel):
             status = {"rank": rank, "ok": True, "error": "", "weight_map": merged_weight_map}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))
+            if rank == 0:
+                elapsed = time.time() - writer_start
+                logger.info(f"[Async saving HF to {log_hf_dir} writer] finished in {elapsed:.2f}s")
         except Exception as exc:
+            if rank == 0:
+                elapsed = time.time() - writer_start
+                logger.error(f"[Async saving HF to {log_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))

--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -1,6 +1,5 @@
 import json
 import multiprocessing as py_mp
-import time
 from pathlib import Path
 from shutil import rmtree
 from typing import Callable, Self, Sequence
@@ -259,7 +258,6 @@ class BaseComposeModel(BaseModel):
         cleanup_done_path: Path,
         rank: int,
     ) -> None:
-        writer_start = time.time()
         if rank == 0:
             logger.info(f"[Async saving HF to {tmp_hf_dir} writer] started")
         try:
@@ -275,12 +273,10 @@ class BaseComposeModel(BaseModel):
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))
             if rank == 0:
-                elapsed = time.time() - writer_start
-                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished in {elapsed:.2f}s")
+                logger.info(f"[Async saving HF to {tmp_hf_dir} writer] finished")
         except Exception as exc:
             if rank == 0:
-                elapsed = time.time() - writer_start
-                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed after {elapsed:.2f}s: {exc}")
+                logger.error(f"[Async saving HF to {tmp_hf_dir} writer] failed: {exc}")
             status = {"rank": rank, "ok": False, "error": str(exc), "weight_map": {}}
             with status_path.open("w") as f:
                 f.write(json.dumps(status, indent=2))


### PR DESCRIPTION
## Summary

This PR adds lightweight async HF logging in the default path:

- logs foreground async_save_hf launch cost through XTuner profile_time_and_memory
- logs rank0 background async HF writer start/end timing
- logs rank0 writer failure timing before preserving the existing status-file error path

It intentionally does not add per-rank diagnostic JSON, rank0 summary JSON, handle config propagation, or trainer-side diagnostic plumbing.

## Validation

- python3 -m py_compile xtuner/v1/engine/train_engine.py xtuner/v1/model/base.py xtuner/v1/model/compose/base.py
- git diff --check

Note: local ruff command is not available in this environment.