### PR TITLE
Refactor async HF writer status files

### DIFF
--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -705,14 +705,16 @@ class BaseModel(nn.Module):
         if isinstance(hf_dir, str):
             hf_dir = Path(hf_dir)
         tmp_hf_dir = hf_dir.with_name(f"{hf_dir.name}.incomplete")
+        status_dir = tmp_hf_dir.parent / f".{tmp_hf_dir.name}.async-hf-writer-status"
         if rank == 0:
             if tmp_hf_dir.exists():
                 rmtree(tmp_hf_dir)
+            if status_dir.exists():
+                rmtree(status_dir)
             tmp_hf_dir.mkdir(parents=True, exist_ok=True)
+            status_dir.mkdir(parents=True, exist_ok=True)
 
-        status_path = (
-            tmp_hf_dir.parent / f"{tmp_hf_dir.name}.{self._async_hf_writer_status_filename(rank, world_size)}"
-        )
+        status_path = status_dir / self._async_hf_writer_status_filename(rank, world_size)
         cleanup_done_path = tmp_hf_dir.parent / f"{tmp_hf_dir.name}.cleanup-done"
         if rank == 0:
             cleanup_done_path.unlink(missing_ok=True)
@@ -874,11 +876,12 @@ class BaseModel(nn.Module):
 
         if rank == 0:
             self._write_hf_index_and_config(hf_dir=tmp_hf_dir, weight_map=merged_weight_map)
-        if dist.is_initialized():
-            dist.barrier()
         status_path.unlink(missing_ok=True)
         cleanup_done_path.unlink(missing_ok=True)
+        if dist.is_initialized():
+            dist.barrier()
         if rank == 0:
+            rmtree(status_path.parent, ignore_errors=True)
             if hf_dir.exists():
                 rmtree(hf_dir)
             tmp_hf_dir.rename(hf_dir)

--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -192,14 +192,16 @@ class BaseComposeModel(BaseModel):
         if isinstance(hf_dir, str):
             hf_dir = Path(hf_dir)
         tmp_hf_dir = hf_dir.with_name(f"{hf_dir.name}.incomplete")
+        status_dir = tmp_hf_dir.parent / f".{tmp_hf_dir.name}.async-hf-writer-status"
         if rank == 0:
             if tmp_hf_dir.exists():
                 rmtree(tmp_hf_dir)
+            if status_dir.exists():
+                rmtree(status_dir)
             tmp_hf_dir.mkdir(parents=True, exist_ok=True)
+            status_dir.mkdir(parents=True, exist_ok=True)
 
-        status_path = (
-            tmp_hf_dir.parent / f"{tmp_hf_dir.name}.{self._async_hf_writer_status_filename(rank, world_size)}"
-        )
+        status_path = status_dir / self._async_hf_writer_status_filename(rank, world_size)
         cleanup_done_path = tmp_hf_dir.parent / f"{tmp_hf_dir.name}.cleanup-done"
         if rank == 0:
             cleanup_done_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- move async HF writer status JSON files into a per-save status directory
- clean up the status directory during successful async HF finalization
- keep the change independent from PR #1845

## Validation
- ruff check xtuner/v1/model/base.py xtuner/v1/model/compose/base.py
- python3 -m py_compile xtuner/v1/model/base.py xtuner/v1/model/compose/base.py
- git diff --check