### PR TITLE
rolloutstate tensor to np 

### DIFF
--- a/xtuner/v1/data_proto/rl_data.py
+++ b/xtuner/v1/data_proto/rl_data.py
@@ -61,7 +61,7 @@ class Status(Enum):
 class MultimodalInfo(TypedDict):
     # 使用TypedDict给出pixel_values的类型提示
     pixel_values: NotRequired[np.ndarray | RayObjectRef | None]
-    image_grid_thw: NotRequired[np.ndarray]
+    image_grid_thw: NotRequired[np.ndarray | None]
 
 
 class RolloutFunctionCall(BaseModel):

--- a/xtuner/v1/data_proto/rl_data.py
+++ b/xtuner/v1/data_proto/rl_data.py
@@ -61,7 +61,7 @@ class Status(Enum):
 class MultimodalInfo(TypedDict):
     # 使用TypedDict给出pixel_values的类型提示
     pixel_values: NotRequired[np.ndarray | RayObjectRef | None]
-    image_grid_thw: NotRequired[np.ndarray | None]
+    image_grid_thw: NotRequired[np.ndarray]
 
 
 class RolloutFunctionCall(BaseModel):

--- a/xtuner/v1/data_proto/rl_data.py
+++ b/xtuner/v1/data_proto/rl_data.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import numpy as np
-import torch
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import NotRequired, TypedDict
 
@@ -62,7 +61,7 @@ class Status(Enum):
 class MultimodalInfo(TypedDict):
     # 使用TypedDict给出pixel_values的类型提示
     pixel_values: NotRequired[np.ndarray | RayObjectRef | None]
-    image_grid_thw: NotRequired[torch.Tensor]
+    image_grid_thw: NotRequired[np.ndarray | None]
 
 
 class RolloutFunctionCall(BaseModel):
@@ -124,7 +123,7 @@ class RolloutState(BaseModel):
     task_name: str | None = None
     status: Status = Status.INIT
     error_msg: str | None = None
-    position_ids: torch.Tensor | None = None
+    position_ids: np.ndarray | None = None
     extra_fields: dict[str, Any] = {}
 
 

--- a/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
@@ -128,7 +128,7 @@ class RLQwen3VLTokenizeFunction(Qwen3VLTokenizeFunction):
                 num_tokens=data["num_tokens"],
                 proxy_attn_flops=data.get("proxy_attn_flops", float(data["num_tokens"])),
                 prompt_ids=prompt_token_ids,
-                position_ids=_tensor_to_numpy(data.get("position_ids")),
+                position_ids=_tensor_to_numpy(data["position_ids"]),
                 data_source=mapped_judger_name_and_weight,
                 reward_model=item.get("reward_model", {}),
                 mm_info=mm_info,

--- a/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
@@ -8,6 +8,12 @@ from ..data_item import CacheItem
 from ..mllm_tokenize_fn.qwen3_vl_tokenize_fn import Qwen3VLTokenizeFnConfig, Qwen3VLTokenizeFunction, QwenVL3DataItem
 
 
+def _tensor_to_numpy(value):
+    if value is None:
+        return None
+    return value.detach().cpu().numpy()
+
+
 def remove_consecutive_img_context_tokens(tokens: list[int], img_context_id: int) -> list[int]:
     if not tokens:
         return tokens
@@ -104,9 +110,9 @@ class RLQwen3VLTokenizeFunction(Qwen3VLTokenizeFunction):
             if not self.ignore_multimodal_info:
                 mm_info = MultimodalInfo()
                 if "pixel_values" in data:
-                    mm_info["pixel_values"] = data["pixel_values"].numpy()  # for ray put into shared memory
+                    mm_info["pixel_values"] = _tensor_to_numpy(data["pixel_values"])  # for ray put into shared memory
                 if "image_grid_thw" in data:
-                    mm_info["image_grid_thw"] = data["image_grid_thw"]
+                    mm_info["image_grid_thw"] = _tensor_to_numpy(data["image_grid_thw"])
 
             data_source = item.get("data_source")
             assert data_source is not None, "data_source is required in item"
@@ -122,7 +128,7 @@ class RLQwen3VLTokenizeFunction(Qwen3VLTokenizeFunction):
                 num_tokens=data["num_tokens"],
                 proxy_attn_flops=data.get("proxy_attn_flops", float(data["num_tokens"])),
                 prompt_ids=prompt_token_ids,
-                position_ids=data["position_ids"],
+                position_ids=_tensor_to_numpy(data.get("position_ids")),
                 data_source=mapped_judger_name_and_weight,
                 reward_model=item.get("reward_model", {}),
                 mm_info=mm_info,

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from shutil import rmtree
 from typing import Any, List, cast
 
+import numpy as np
 import ray
 import torch
 from mmengine.dist import get_rank
@@ -60,6 +61,13 @@ from xtuner.v1.utils.env_check import get_rollout_engine_version
 PG_READY_TIMEOUT = 30
 DEVICE = get_device()
 DEVICE_MODULE = get_torch_device_module()
+
+
+def _to_cpu_tensor(value: np.ndarray | None, *, dtype: torch.dtype | None = None) -> torch.Tensor | None:
+    if value is None:
+        return None
+    assert isinstance(value, np.ndarray), f"Expected np.ndarray, got {type(value)}"
+    return torch.as_tensor(value, dtype=dtype, device="cpu")
 
 
 def check_fa3():
@@ -150,11 +158,12 @@ class RLThroughputBenchmark:
 
 def get_train_seq_ctx(
     input_ids: torch.LongTensor,
-    position_ids: torch.Tensor | None = None,
+    position_ids: np.ndarray | None = None,
     multimodal_train_info: dict | None = None,
     len_response_ids: int = 0,
 ):
     seq_ctx = SequenceContext.from_input_ids((input_ids,), device="cpu")
+    position_ids = _to_cpu_tensor(position_ids, dtype=torch.long)
     if position_ids is not None and len(position_ids.shape) == 3:
         # qwen3vl 需要特殊处理，其余的不需要额外处理
         max_value = position_ids.max(dim=-1).values  # (3,1)
@@ -167,7 +176,7 @@ def get_train_seq_ctx(
 
     if multimodal_train_info:
         seq_ctx.pixel_values = multimodal_train_info.get("pixel_values")
-        seq_ctx.image_grid_thw = multimodal_train_info.get("image_grid_thw")
+        seq_ctx.image_grid_thw = _to_cpu_tensor(multimodal_train_info.get("image_grid_thw"), dtype=torch.long)
     return seq_ctx
 
 


### PR DESCRIPTION
目前实验发现，deepcopy(rolloutstate) 可能会导致程序卡死，初步定位和 tensor 的 deepcopy 有关系。因此目前保险方案是 rolloutstate 不允许存在 tensor 对象，全部用 numpy 对象代替。