### PR TITLE
Refactor judger

### DIFF
--- a/docs/en/rl/tutorial/rl_grpo_trainer.md
+++ b/docs/en/rl/tutorial/rl_grpo_trainer.md
@@ -122,11 +122,11 @@ judger_config = GSM8KJudgerConfig(
 ```
 
 **Usage Instructions**:
-- `"openai/gsm8k"`: Dataset identifier, needs to match the `data_source` field in your dataset
+- `"openai/gsm8k"`: Logical judge name. With a single `JudgerConfig`, samples are sent directly to this judge. With `ComposedJudgerConfig`, `RolloutState.data_source` routes samples to branches, and string values or dict keys must match `branches`.
 - `GSM8KJudgerConfig()`: Judge specifically for GSM8K math problems, will check if the numerical answer is correct
 - `cpu_resources`: Runs the judge in PG-external Ray CPU actor(s). If omitted, the judge runs locally.
 
-💡 **Extended Functionality**: XTuner also supports multiple judgment methods (functional, API service) and custom Judgers, related tutorials coming soon.
+💡 **Extended Functionality**: XTuner supports functional reward handlers, API-service reward handlers, custom Judgers, and composed Judgers for routing or multi-judge scoring.
 
 ## 2. Trainer Config (Training Configuration)
 

--- a/docs/zh_cn/rl/advanced_tutorial/agent_loop.md
+++ b/docs/zh_cn/rl/advanced_tutorial/agent_loop.md
@@ -8,7 +8,7 @@
 Sampler -> list[RolloutState]
   -> AgentLoop.generate_group()
   -> RolloutController.generate()
-  -> Judger.judge()
+  -> Judger.judge() / Judger.batch_judge()
   -> ReplayBuffer
   -> RLTrainer._prepare_train_data()
 ```
@@ -58,7 +58,7 @@ async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> l
     ...
 ```
 
-`generate_sample()` 处理单条样本；默认 `generate_group()` 会并发调用多次 `generate_sample()`，并在调用前把 `self.sample_params` 写到组内每条样本上。需要组级逻辑时，例如批量打分、组内共享环境、组内排序过滤，可以覆盖 `generate_group()`。
+`generate_sample()` 处理单条样本；默认 `generate_group()` 会并发调用多次 `generate_sample()`，并在调用前把 `self.sample_params` 写到组内每条样本上。若配置了 `enable_batch_judge=True`，默认 `generate_group()` 会在组内样本生成完成后调用一次 `self.run_judger(group_samples)`。需要其他组级逻辑时，例如组内共享环境、组内排序过滤，可以覆盖 `generate_group()`。
 
 ## 输入输出约定
 
@@ -108,7 +108,7 @@ generate_sample(state)
   -> await rollout_ctl.generate.remote(state)
   -> PartialRolloutHandler.postprocess(state)
   -> 如果 state.status != COMPLETED，直接返回，不触发 Judger
-  -> 如果配置了 judger，调用 judger.judge(state)
+  -> 如果配置了 judger，调用 self.run_judger(state)
 ```
 
 典型配置：
@@ -129,7 +129,7 @@ agent_loop_config = SingleTurnAgentLoopConfig(
 )
 ```
 
-`SingleTurnAgentLoop` 还支持批量打分：
+`AgentLoopConfig` 还支持批量打分：
 
 ```python
 agent_loop_config = SingleTurnAgentLoopConfig(
@@ -139,7 +139,7 @@ agent_loop_config = SingleTurnAgentLoopConfig(
 )
 ```
 
-开启后，`generate_sample()` 不会逐条调用 Judger；`generate_group()` 会在组内样本全部生成完成后调用一次 `judger.judge(group_samples)`。只有当前 Judger 明确支持 `list[RolloutState]` 输入时才应开启。
+开启后，`generate_sample()` 不会逐条调用 Judger；`generate_group()` 会在组内样本全部生成完成后调用一次 `self.run_judger(group_samples)`，内部会转到 `judger.batch_judge(group_samples)`。只有当前 Judger 明确实现 `batch_judge()` 时才应开启。
 
 ## 自定义 AgentLoop
 
@@ -147,8 +147,10 @@ agent_loop_config = SingleTurnAgentLoopConfig(
 
 1. 继承 `AgentLoop`，实现 `generate_sample()`。
 2. 在 `generate_sample()` 中维护 `tokens`、`sample_params`、`response_ids`、`response`、`logprobs`、`response_mask`、`status`。
-3. 需要打分时，在 response 可用后调用 `self.judger.judge(...)`。
+3. 需要打分时，在 response 可用后调用 `self.run_judger(...)`。
 4. 继承 `AgentLoopConfig`，实现 `build_local()`，这样才能接入 `TaskSpecConfig.agent_loop_config`，并复用 Ray actor 构建逻辑。
+
+`self.run_judger(...)` 会根据输入形态调用 `judger.judge()` 或 `judger.batch_judge()`，并统一处理 pause/cancel。若自定义 AgentLoop 支持 `enable_batch_judge=True`，`generate_sample()` 中的单条打分需要用 `not self.enable_batch_judge` 保护，避免默认 `generate_group()` 再次批量打分。若自定义 AgentLoop 需要覆盖 `pause()`，应在实现中调用 `await super().pause()`，否则正在执行的 Judger 任务无法复用基类的中断逻辑。
 
 ### 最小单轮实现
 
@@ -170,8 +172,8 @@ class CustomAgentLoop(AgentLoop):
         if rollout_state.status != Status.COMPLETED:
             return rollout_state
 
-        if self.judger is not None:
-            rollout_state = await self.judger.judge(rollout_state)
+        if self.judger is not None and not self.enable_batch_judge:
+            rollout_state = await self.run_judger(rollout_state)
         return rollout_state
 
 
@@ -242,8 +244,8 @@ class ToolAgentLoop(AgentLoop):
         assert len(rollout_state.response_ids) == len(rollout_state.logprobs)
         assert len(rollout_state.response_ids) == len(rollout_state.response_mask)
 
-        if rollout_state.status == Status.COMPLETED and self.judger is not None:
-            rollout_state = await self.judger.judge(rollout_state)
+        if rollout_state.status == Status.COMPLETED and self.judger is not None and not self.enable_batch_judge:
+            rollout_state = await self.run_judger(rollout_state)
         return rollout_state
 ```
 
@@ -260,9 +262,8 @@ class ToolAgentLoop(AgentLoop):
 async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
     samples = await super().generate_group(rollout_state, **kwargs)
 
-    # 例：Judger 支持批量输入时，在组级统一打分。
-    if self.judger is not None:
-        samples = await self.judger.judge(samples)
+    # 例：在默认并发生成和可选 batch judge 之后，继续执行组级过滤或排序。
+    samples = self.filter_or_sort_group(samples)
     return samples
 ```
 
@@ -341,6 +342,6 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
 - 每次调用 `rollout_ctl.generate.remote()` 前是否设置了本轮 `sample_params`。
 - 返回训练前，`response_ids`、`response`、`logprobs`、`response_mask` 是否完整且长度一致。
 - 非模型生成 token 是否在 `response_mask` 中置为 `0`。
-- 需要 Judger 时，是否只对可评分的样本调用 `judger.judge()`。
+- 需要 Judger 时，是否通过 `self.run_judger(...)` 调用打分，以复用 pause/cancel 处理。
 - 若使用 `_prepare_train_data()`，是否保证最终有 `reward["score"]`。
 - 若使用 async partial rollout，是否正确处理 `enable_partial_rollout` 和历史 response 合并。

--- a/docs/zh_cn/rl/advanced_tutorial/judger.md
+++ b/docs/zh_cn/rl/advanced_tutorial/judger.md
@@ -2,16 +2,17 @@
 
 `Judger` 是 XTuner RL 中负责给 rollout 结果打分的组件。它接收 `RolloutState`，读取模型生成结果和标签，计算 reward，并把分数写回 `rollout_state.reward`。后续的 advantage 计算、训练数据构建和默认评测逻辑都会依赖这个字段。
 
-在典型流程中，`AgentLoop` 先调用推理引擎生成 `response_ids`，再把 token 解码成文本形式的 `response`，最后调用 `judger.judge(rollout_state)`。
+在典型流程中，`AgentLoop` 先调用推理引擎生成 `response_ids`，再把 token 解码成文本形式的 `response`，最后通过 `run_judger()` 调用 `judger.judge(rollout_state)` 或 `judger.batch_judge(rollout_states)`。
 
 ## Judger 类型
 
-`xtuner/v1/rl/judger/native.py` 中定义了 Judger 的基础类型。可以先把它理解成两层：第一层是所有 Judger 统一实现的 `judge()` 接口；第二层是不同运行形态，决定这个 `judge()` 在本地执行、在 Ray actor 中执行，还是组合多个子 Judger 一起执行。
+`xtuner/v1/rl/judger/native.py` 中定义了 Judger 的基础类型。可以先把它理解成两层：第一层是所有 Judger 统一实现的 `judge()` 和 `batch_judge()` 接口；第二层是不同运行形态，决定打分逻辑在本地执行、在 Ray actor 中执行，还是组合多个子 Judger 一起执行。
 
 ```text
                                   ┌─────────────────────────────┐
                                   │        Judger (ABC)          │
                                   │  async judge(RolloutState)   │
+                                  │  async batch_judge(list)      │
                                   └──────────────┬──────────────┘
                                                  │
                  ┌───────────────────────────────┼───────────────────────────────┐
@@ -48,10 +49,10 @@
                          │                       │                       │
                          └───────────────────────┼───────────────────────┘
                                                  ▼
-                         select_fn 选择 branch，merge_fn 合并 reward dict
+                         data_source 选择 branch，merge_fn 合并 reward dict
 ```
 
-`RemoteJudger` 的作用是给 Ray actor 形式的 Judger 提供一个对外统一接口。它本身不实现具体打分逻辑，而是持有 `JudgerActor` 的 actor proxy，并在自己的 `judge()` 中调用 `actor.judge.remote(...)`。这样上层代码只需要面向 `Judger.judge()` 编程，不需要关心当前 Judger 是本地对象、Ray actor，还是多副本池中的一个远程副本。
+`RemoteJudger` 的作用是给 Ray actor 形式的 Judger 提供一个对外统一接口。它本身不实现具体打分逻辑，而是持有 `JudgerActor` 的 actor proxy。`judge()` 或 `batch_judge()` 会先在 driver 侧把 `RolloutState` 转成轻量 payload，再调用 `actor.judge_payload.remote(...)`，因此 Ray 序列化的是 payload，而不是完整 `RolloutState`。这样上层代码只需要面向 `Judger` 接口编程，不需要关心当前 Judger 是本地对象、Ray actor，还是多副本池中的一个远程副本。
 
 构建时有两条入口：
 
@@ -71,7 +72,7 @@ ComposedJudgerConfig
   └─ ComposedJudger
        ├─ branches["a"] -> JudgerConfig 或 ComposedJudgerConfig
        ├─ branches["b"] -> JudgerConfig 或 ComposedJudgerConfig
-       └─ select_fn + merge_fn 控制路由和合并
+       └─ RolloutState.data_source + merge_fn 控制路由和合并
 ```
 
 普通 `JudgerConfig` 根据 `cpu_resources` 决定执行模式。`cpu_resources` 表示 PG 外 Ray CPU worker 的资源需求，类型为 `CPUResourcesConfig`：
@@ -84,7 +85,7 @@ ComposedJudgerConfig
 
 `CPUResourcesConfig.cpu_memory_per_worker` 默认是 `1024**3`，通常不需要额外配置。PG 外 CPU actor 资源会注册到全局 `CPUResourceManager`，资源不足时会在组件构建阶段报错，避免 Ray actor 长时间 pending。
 
-`ComposedJudgerConfig` 用于多分支场景：一个样本可以按 `select_fn` 路由到不同 Judger，也可以同时运行多个 Judger，再用 `merge_fn` 合并结果。
+`ComposedJudgerConfig` 用于多分支场景：样本通过 `RolloutState.data_source` 路由到一个或多个 Judger。`data_source` 为字符串时选择一个 branch；为字典时使用字典 key 同时选择多个 branch，并用 `merge_fn` 合并结果。
 
 ## 输入输出约定
 
@@ -94,7 +95,7 @@ ComposedJudgerConfig
 Sampler -> RolloutState
   -> SingleTurnAgentLoop.generate_group()
   -> RolloutController.generate()
-  -> Judger.judge()
+  -> Judger.judge() / Judger.batch_judge()
   -> ReplayBuffer
   -> RLTrainer._prepare_train_data()
 ```
@@ -104,9 +105,12 @@ Judger 本身统一暴露异步接口：
 ```python
 async def judge(self, rollout_state: RolloutState) -> RolloutState:
     ...
+
+async def batch_judge(self, rollout_states: list[RolloutState]) -> list[RolloutState]:
+    ...
 ```
 
-接口类型上也允许批量输入，但内置 `NativeJudger` 默认按单条样本调用 `reward_handler`。只有自定义 Judger 明确支持 `list[RolloutState]` 时，才应打开 `SingleTurnAgentLoopConfig(enable_batch_judge=True)`。
+`judge()` 只处理单条样本；批量打分使用 `batch_judge()`。内置 `NativeJudger` 和 `CompassVerifierV2` 默认不支持批量打分，会在 `batch_judge()` 入口直接报错。只有当前 Judger 明确实现 `batch_judge()` 时，才应打开 `SingleTurnAgentLoopConfig(enable_batch_judge=True)`。
 
 ### Judger 输入
 
@@ -153,7 +157,7 @@ rollout_state.reward = {
 
 其他 reward 字段可以按任务需要扩展，例如 `acc`、`format`、`tool_ok`、`reason` 等。
 
-如果使用 `ComposedJudger` 的默认 `merge_fn`，输出不会自动生成总分，而是按 branch 名称保存各分支分数：
+如果使用 `ComposedJudger` 且 `data_source` 只选择一个 branch，输出会直接使用该 branch 的 reward。若 `data_source` 选择多个 branch，必须提供自定义 `merge_fn`，因为通用逻辑无法知道业务上应该如何聚合多个分数。例如：
 
 ```python
 rollout_state.reward = {
@@ -162,11 +166,11 @@ rollout_state.reward = {
 }
 ```
 
-如果训练或评测需要 `reward["score"]`，需要提供自定义 `merge_fn`。
+如果训练或评测需要 `reward["score"]`，`merge_fn` 必须生成这个字段。
 
-## select_fn 与 merge_fn
+## data_source 与 merge_fn
 
-`ComposedJudgerConfig` 的核心是 `branches`、`select_fn` 和 `merge_fn`：
+`ComposedJudgerConfig` 的核心是 `branches` 和 `merge_fn`，路由固定读取 `RolloutState.data_source`：
 
 ```python
 from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig
@@ -176,32 +180,24 @@ judger_config = ComposedJudgerConfig(
         "gsm8k": JudgerConfig(judger_name="gsm8k", reward_handler=gsm8k_reward),
         "format": JudgerConfig(judger_name="format", reward_handler=format_reward),
     },
-    select_fn=lambda state, branches: ["gsm8k", "format"],
     merge_fn=merge_rewards,
 )
 ```
 
-`select_fn` 负责选择要运行哪些分支：
+`data_source` 的含义：
 
-```python
-def select_fn(state: RolloutState, branches: dict[str, Judger]) -> str | list[str] | None:
-    ...
-```
-
-返回值含义：
-
-- `str`：运行一个 branch。
-- `list[str]`：运行多个 branch。
-- `None`：走 `default_key` 或单分支 fallback。
-
-默认 `select_fn` 会用 `rollout_state.data_source` 匹配 `branches` 的 key；匹配不到时返回 `None`。
+- `str`：必须等于某个 branch 名称，运行这一个 branch。
+- `dict`：key 必须都是 branch 名称，运行这些 branches。
+- `None`、空 dict、未知 branch、非字符串 key 或其他类型都会在 `ComposedJudger` 入口报错。
 
 `merge_fn` 负责把多个子 Judger 的输出合并回一个 `RolloutState`：
 
 ```python
+from xtuner.v1.rl.judger import JudgerOutput
+
 def merge_fn(
     original: RolloutState | list[RolloutState],
-    judged: dict[str, RolloutState | list[RolloutState]],
+    judged: dict[str, JudgerOutput | list[JudgerOutput]],
 ) -> RolloutState | list[RolloutState]:
     ...
 ```
@@ -216,19 +212,18 @@ def weight_fn(branch_name: str) -> float:
     }[branch_name]
 
 def merge_rewards(original, judged):
-    merged = original.model_copy(deep=True)
     branch_scores = {
-        name: state.reward["score"]
-        for name, state in judged.items()
+        name: output["score"]
+        for name, output in judged.items()
     }
-    merged.reward = {
+    original.reward = {
         "score": sum(weight_fn(name) * score for name, score in branch_scores.items()),
         **branch_scores,
     }
-    return merged
+    return original
 ```
 
-批量输入时，`merge_fn` 也需要返回同样长度的 `list[RolloutState]`。默认 `merge_fn` 已支持单条和批量输入，但只会生成 `{branch_name: score}`，不会额外生成 `score` 总分。
+批量输入时，`merge_fn` 的第一个参数是 `list[RolloutState]`，`judged` 中每个 branch 的值是同样长度的 `list[JudgerOutput]`，返回值也必须是同样长度的 `list[RolloutState]`。框架不提供默认 merge；多 branch 场景必须显式传入 `merge_fn`。
 
 ## 自定义 Judger
 

--- a/docs/zh_cn/rl/tutorial/rl_grpo_trainer.md
+++ b/docs/zh_cn/rl/tutorial/rl_grpo_trainer.md
@@ -114,7 +114,7 @@ judger_config = GSM8KJudgerConfig(
 )
 ```
 
-`judger_name` 需要和样本中的 `data_source` 对应。`cpu_resources` 表示该 Judger 使用 PG 外 Ray CPU actor 执行打分；如果不配置 `cpu_resources`，Judger 会在本地执行。打分后，训练流程会从 `RolloutState.reward["score"]` 读取分数并计算 advantage。
+`judger_name` 是该 Judger 的逻辑名称。使用单个 `JudgerConfig` 时，样本会直接交给这个 Judger 打分；使用 `ComposedJudgerConfig` 时，`RolloutState.data_source` 会用于选择 branch，字符串值或字典 key 需要和 `branches` 中的名称对应。`cpu_resources` 表示该 Judger 使用 PG 外 Ray CPU actor 执行打分；如果不配置 `cpu_resources`，Judger 会在本地执行。打分后，训练流程会从 `RolloutState.reward["score"]` 读取分数并计算 advantage。
 
 ### 1.4 AgentLoopConfig 和 AgentLoopManagerConfig
 

--- a/tests/rl/test_judger.py
+++ b/tests/rl/test_judger.py
@@ -13,10 +13,10 @@ from xtuner.v1.rl.utils import (
 )
 from xtuner.v1.data_proto.rl_data import RolloutState
 
-MODEL_PATH = os.environ["ROLLOUT_MODEL_PATH"]
-DATA_PATH = os.environ["ROLLOUT_DATA_PATH"]
-GEO_ROLLOUT_DATA_PATH = os.environ["GEO_ROLLOUT_DATA_PATH"]
-VERL_ROLLOUT_DATA_PATH = os.environ["VERL_ROLLOUT_DATA_PATH"]
+MODEL_PATH = os.environ.get("ROLLOUT_MODEL_PATH")
+DATA_PATH = os.environ.get("ROLLOUT_DATA_PATH")
+GEO_ROLLOUT_DATA_PATH = os.environ.get("GEO_ROLLOUT_DATA_PATH")
+VERL_ROLLOUT_DATA_PATH = os.environ.get("VERL_ROLLOUT_DATA_PATH")
 DAPO_DATA_PATH = os.environ.get("ROLLOUT_DAPO_DATA_PATH")
 FAKE_JUDGER_INPUT_ITEM = RolloutState(
     message=[{
@@ -31,7 +31,7 @@ def construct_gsm8k_judger_data(data_path) -> tuple[list[RolloutState], list[flo
     states = []
     history_reward = []
     if not data_path or not os.path.exists(data_path):
-        return states
+        return states, history_reward
     with open(data_path, 'r', encoding='utf-8') as f:
         for line in f:
             item = json.loads(line.strip())
@@ -52,12 +52,13 @@ def construct_geo3k_dapo_judger_data(data_path) -> tuple[list[RolloutState], lis
     states = []
     history_reward = []
     if not data_path or not os.path.exists(data_path):
-        return states
+        return states, history_reward
     with open(data_path, 'r', encoding='utf-8') as f:
         lines = f.readlines()
         for i in range(0, len(lines), 7):
             group = ''.join(lines[i:i + 7]).strip()
-            if not group: continue
+            if not group:
+                continue
             item = json.loads(group)
             states.append(
                 RolloutState(
@@ -67,7 +68,77 @@ def construct_geo3k_dapo_judger_data(data_path) -> tuple[list[RolloutState], lis
                 )
             )
             history_reward.append(item["reward"])
-    return states, history_reward   
+    return states, history_reward
+
+
+class TestComposedJudgerUnit(unittest.TestCase):
+
+    def _build_composed_judger_config(self, merge_fn=None):
+        from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig
+
+        def reward_a(response, label, extra_info):
+            return {"score": 1.0, "source": "a"}
+
+        def reward_b(response, label, extra_info):
+            return {"score": 0.25, "source": "b"}
+
+        return ComposedJudgerConfig(
+            branches={
+                "correctness": JudgerConfig(judger_name="correctness", reward_handler=reward_a),
+                "format": JudgerConfig(judger_name="format", reward_handler=reward_b),
+            },
+            merge_fn=merge_fn,
+        )
+
+    def _make_rollout_state(self, data_source):
+        rollout_state = FAKE_JUDGER_INPUT_ITEM.model_copy(deep=True)
+        rollout_state.data_source = data_source
+        return rollout_state
+
+    def test_composed_judger_single_branch_from_data_source(self):
+        judger = self._build_composed_judger_config().build()
+        rollout_state = asyncio.run(judger.judge(self._make_rollout_state("correctness")))
+
+        self.assertEqual(rollout_state.reward["score"], 1.0)
+        self.assertEqual(rollout_state.reward["source"], "a")
+
+    def test_composed_judger_config(self):
+        def merge_fn(original, judged):
+            original.reward = {
+                "correctness": judged["correctness"]["score"],
+                "format": judged["format"]["score"],
+            }
+            return original
+
+        judger = self._build_composed_judger_config(merge_fn=merge_fn).build()
+        rollout_state = self._make_rollout_state({"correctness": 1.0, "format": 1.0})
+        rollout_state = asyncio.run(judger.judge(rollout_state))
+
+        self.assertEqual(rollout_state.reward["correctness"], 1.0)
+        self.assertEqual(rollout_state.reward["format"], 0.25)
+
+    def test_composed_judger_requires_merge_fn_for_multiple_branches(self):
+        judger = self._build_composed_judger_config().build()
+        rollout_state = self._make_rollout_state({"correctness": 1.0, "format": 1.0})
+
+        with self.assertRaisesRegex(ValueError, "merge_fn is not provided"):
+            asyncio.run(judger.judge(rollout_state))
+
+    def test_composed_judger_data_source_validation(self):
+        judger = self._build_composed_judger_config().build()
+
+        with self.assertRaisesRegex(ValueError, "requires rollout_state.data_source"):
+            asyncio.run(judger.judge(self._make_rollout_state(None)))
+
+        with self.assertRaisesRegex(KeyError, "Unknown judger branch"):
+            asyncio.run(judger.judge(self._make_rollout_state("unknown")))
+
+        with self.assertRaisesRegex(ValueError, "must contain at least one judger branch"):
+            asyncio.run(judger.judge(self._make_rollout_state({})))
+
+        with self.assertRaisesRegex(KeyError, "Unknown judger branch"):
+            asyncio.run(judger.judge(self._make_rollout_state({"unknown": 1.0})))
+
 
 class TestJudgerController(unittest.TestCase):
 
@@ -85,6 +156,10 @@ class TestJudgerController(unittest.TestCase):
     async def _judger_batch(self, judger_router, states):
         return await asyncio.gather(*(judger_router.judge(s) for s in states))
     
+    @unittest.skipUnless(
+        VERL_ROLLOUT_DATA_PATH and os.path.exists(VERL_ROLLOUT_DATA_PATH),
+        "requires VERL_ROLLOUT_DATA_PATH",
+    )
     def test_gsm8k_judger(self):
         from xtuner.v1.rl.judger.gsm8k import GSM8KJudgerConfig
 
@@ -111,6 +186,10 @@ class TestJudgerController(unittest.TestCase):
         expected_avg_score = np.mean(history_reward)
         self.assertEqual(round(np.mean(rewards), 4), round(expected_avg_score, 4))
         
+    @unittest.skipUnless(
+        MODEL_PATH and DAPO_DATA_PATH and os.path.exists(DAPO_DATA_PATH),
+        "requires ROLLOUT_MODEL_PATH and ROLLOUT_DAPO_DATA_PATH",
+    )
     def test_dapo_batch_judge_score(self):
         # 测试 dapo judger + 1 个实例池 的评判分数是否正确
         from xtuner.v1.rl.judger.dapo_math import DapoMathJudgerConfig
@@ -138,6 +217,10 @@ class TestJudgerController(unittest.TestCase):
         expected_avg_score = np.mean(history_reward)
         self.assertEqual(round(np.mean(rewards), 4), round(expected_avg_score, 4))
 
+    @unittest.skipUnless(
+        GEO_ROLLOUT_DATA_PATH and os.path.exists(GEO_ROLLOUT_DATA_PATH),
+        "requires GEO_ROLLOUT_DATA_PATH",
+    )
     def test_geo_batch_judge_score(self):
         # 测试 geo judger + 4 个实例池的评判分数是否正确
         from xtuner.v1.rl.judger.geo3k import GEO3KJudgerConfig
@@ -154,6 +237,10 @@ class TestJudgerController(unittest.TestCase):
         # 验证Router中确实有4个Worker实例在运行
         self.assertEqual(len(router.get_worker_status()), 4)
 
+    @unittest.skipUnless(
+        VERL_ROLLOUT_DATA_PATH and os.path.exists(VERL_ROLLOUT_DATA_PATH),
+        "requires VERL_ROLLOUT_DATA_PATH",
+    )
     def test_multi_judger_router(self):
         import time
         from xtuner.v1.rl.judger.gsm8k import GSM8KJudgerConfig
@@ -196,29 +283,6 @@ class TestJudgerController(unittest.TestCase):
             self.assertEqual(res.reward["score"], 1.0)
         finally:
             server.stop()
-
-    def test_composed_judger_config(self):
-        from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig
-
-        def reward_a(response, label, extra_info):
-            return {"score": 1.0, "source": "a"}
-
-        def reward_b(response, label, extra_info):
-            return {"score": 0.25, "source": "b"}
-
-        judger_config = ComposedJudgerConfig(
-            branches={
-                "correctness": JudgerConfig(judger_name="correctness", reward_handler=reward_a),
-                "format": JudgerConfig(judger_name="format", reward_handler=reward_b),
-            },
-            select_fn=lambda state, branches: ["correctness", "format"],
-        )
-
-        judger = judger_config.build()
-        rollout_state = asyncio.run(judger.judge(FAKE_JUDGER_INPUT_ITEM.model_copy(deep=True)))
-
-        self.assertEqual(rollout_state.reward["correctness"], 1.0)
-        self.assertEqual(rollout_state.reward["format"], 0.25)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/rl/test_judger.py
+++ b/tests/rl/test_judger.py
@@ -130,6 +130,39 @@ class TestComposedJudgerUnit(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, "does not support batch_judge"):
             asyncio.run(judger.batch_judge([self._make_rollout_state("correctness")]))
 
+    def test_remote_judger_uses_driver_side_preprocess_judger(self):
+        from xtuner.v1.rl.judger import Judger, RemoteJudger
+
+        class CustomPreprocessJudger(Judger):
+            def preprocess(self, rollout_state):
+                return {"custom_value": rollout_state.extra_fields["custom_value"]}
+
+        class RemoteMethod:
+            def __init__(self):
+                self.payload = None
+
+            async def remote(self, payload):
+                self.payload = payload
+                return {"score": payload["custom_value"]}
+
+        class FakeActor:
+            def __init__(self):
+                self.judge_payload = RemoteMethod()
+
+        actor = FakeActor()
+        judger = RemoteJudger(
+            actor=actor,
+            judger_name="remote_custom_preprocess",
+            preprocess_judger=CustomPreprocessJudger(),
+        )
+        rollout_state = self._make_rollout_state("correctness")
+        rollout_state.extra_fields["custom_value"] = 7
+
+        judged_state = asyncio.run(judger.judge(rollout_state))
+
+        self.assertEqual(actor.judge_payload.payload, {"custom_value": 7})
+        self.assertEqual(judged_state.reward, {"score": 7})
+
     def test_composed_judger_config(self):
         def merge_fn(original, judged):
             original.reward = {

--- a/tests/rl/test_judger.py
+++ b/tests/rl/test_judger.py
@@ -102,6 +102,34 @@ class TestComposedJudgerUnit(unittest.TestCase):
         self.assertEqual(rollout_state.reward["score"], 1.0)
         self.assertEqual(rollout_state.reward["source"], "a")
 
+    def test_composed_judger_batch_single_branch_from_data_source(self):
+        from xtuner.v1.rl.judger import ComposedJudger, Judger
+
+        class BatchJudger(Judger):
+            async def judge_payload(self, payload):
+                if isinstance(payload, list):
+                    return [{"score": 1.0, "source": "a"} for _ in payload]
+                return {"score": 1.0, "source": "a"}
+
+        judger = ComposedJudger(branches={"correctness": BatchJudger()})
+        rollout_states = [
+            self._make_rollout_state("correctness"),
+            self._make_rollout_state("correctness"),
+        ]
+
+        rollout_states = asyncio.run(judger.batch_judge(rollout_states))
+
+        self.assertEqual([state.reward["score"] for state in rollout_states], [1.0, 1.0])
+        self.assertEqual([state.reward["source"] for state in rollout_states], ["a", "a"])
+
+    def test_native_judger_batch_judge_not_supported(self):
+        from xtuner.v1.rl.judger import JudgerConfig
+
+        judger = JudgerConfig(judger_name="native", reward_handler=lambda **kwargs: {"score": 1.0}).build()
+
+        with self.assertRaisesRegex(NotImplementedError, "does not support batch_judge"):
+            asyncio.run(judger.batch_judge([self._make_rollout_state("correctness")]))
+
     def test_composed_judger_config(self):
         def merge_fn(original, judged):
             original.reward = {

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -198,7 +198,7 @@ class AgentLoop(ABC):
         generated_samples = asyncio.gather(*pending_tasks)
         group_samples = await generated_samples
         if self.judger is not None and self.enable_batch_judge:
-            if group_samples and all(sample.status == Status.COMPLETED for sample in group_samples):
+            if not any(sample.status == Status.ABORTED for sample in group_samples):
                 group_samples = await self.run_judger(group_samples)
         return group_samples
 

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -3,19 +3,20 @@ from __future__ import annotations
 import asyncio
 import math
 from abc import ABC, abstractmethod
-from typing import TypeAlias, cast
+from typing import TypeAlias, cast, overload
 
 import ray
 from pydantic import BaseModel, ConfigDict
 from ray.actor import ActorClass, ActorProxy
 from ray.util.placement_group import PlacementGroup
 
-from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams
+from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
 from xtuner.v1.rl.utils import (
     CPUActorLauncher,
     CPUResourcesConfig,
+    cancel_and_drain,
     create_task,
     register_cpu_resources,
 )
@@ -32,6 +33,7 @@ class AgentLoopConfig(ABC, BaseModel):
     hf_checkpoint: str
     sample_params: SampleParams
     cpu_resources: CPUResourcesConfig | None = None
+    enable_batch_judge: bool = False
 
     def build(self, rollout_controller, judger: Judger | None = None, logger=None) -> AgentLoopSpec:
         if self.cpu_resources is None:
@@ -169,6 +171,7 @@ class AgentLoop(ABC):
         hf_checkpoint: str,
         judger: Judger | None = None,
         logger=None,
+        enable_batch_judge: bool = False,
     ) -> None:
         self.rollout_ctl = rollout_ctl
         self.hf_checkpoint = hf_checkpoint
@@ -176,10 +179,12 @@ class AgentLoop(ABC):
         self.processor = load_processor(hf_checkpoint, trust_remote_code=True)
         self.sample_params = sample_params
         self.judger = judger
+        self.enable_batch_judge = enable_batch_judge
         if logger is None:
             self.logger = get_logger()
         else:
             self.logger = logger
+        self._judger_pause_event = asyncio.Event()
 
     @abstractmethod
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState: ...
@@ -192,21 +197,56 @@ class AgentLoop(ABC):
             pending_tasks.append(task)
         generated_samples = asyncio.gather(*pending_tasks)
         group_samples = await generated_samples
+        if self.judger is not None and self.enable_batch_judge:
+            if group_samples and all(sample.status == Status.COMPLETED for sample in group_samples):
+                group_samples = await self.run_judger(group_samples)
         return group_samples
 
+    @overload
+    async def run_judger(self, rollout_state: RolloutState) -> RolloutState: ...
+
+    @overload
+    async def run_judger(self, rollout_state: list[RolloutState]) -> list[RolloutState]: ...
+
+    async def run_judger(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:
+        assert self.judger is not None
+        if isinstance(rollout_state, list):
+            judge_task = create_task(self.judger.batch_judge(rollout_state))
+        else:
+            judge_task = create_task(self.judger.judge(rollout_state))
+        pause_task = create_task(self._judger_pause_event.wait())
+        try:
+            done, _ = await asyncio.wait({judge_task, pause_task}, return_when=asyncio.FIRST_COMPLETED)
+            if judge_task in done:
+                return await judge_task
+            try:
+                return await asyncio.wait_for(
+                    asyncio.shield(judge_task),
+                    timeout=DEFAULT_JUDGER_CANCEL_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                await cancel_and_drain([judge_task])
+                for sample in rollout_state if isinstance(rollout_state, list) else [rollout_state]:
+                    sample.status = Status.ABORTED
+                    sample.finish_reason = "abort"
+                    sample.reward = None
+                return rollout_state
+        except asyncio.CancelledError:
+            await cancel_and_drain([judge_task])
+            for sample in rollout_state if isinstance(rollout_state, list) else [rollout_state]:
+                sample.status = Status.ABORTED
+                sample.finish_reason = "abort"
+                sample.reward = None
+            return rollout_state
+        finally:
+            await cancel_and_drain([pause_task])
+
     async def pause(self) -> None:
-        # Base AgentLoop only pauses rollout generation.
-        #
-        # We intentionally do not define generic judger pause behavior in the
-        # Judger base class. Judger subclasses can implement judge() in very
-        # different ways, and one base pause implementation cannot cover all of
-        # them. Requiring users to follow a base-class pause protocol would also
-        # increase the mental overhead of writing a new judge() implementation.
-        #
-        # For now, only SingleTurnAgentLoop defines how to pause an in-flight
-        # judger call. Other AgentLoop subclasses should override pause() if
-        # they need their own judger pause semantics.
-        await self.rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
+        self._judger_pause_event.set()
+        try:
+            await self.rollout_ctl.pause_generation.remote()  # type: ignore[attr-defined]
+        finally:
+            self._judger_pause_event.clear()
 
 
 class RouterAgentLoop:

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -14,12 +14,12 @@ from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
 from xtuner.v1.rl.utils import (
+    JUDGER_PAUSE_JUDGE_TASK_TIMEOUT_S,
     CPUActorLauncher,
     CPUResourcesConfig,
     cancel_and_drain,
     create_task,
     register_cpu_resources,
-    DEFAULT_JUDGER_CANCEL_TIMEOUT_S
 )
 from xtuner.v1.utils import get_logger, ray_method
 from xtuner.v1.utils.processing_utils import load_processor, load_tokenizer
@@ -222,7 +222,7 @@ class AgentLoop(ABC):
             try:
                 return await asyncio.wait_for(
                     asyncio.shield(judge_task),
-                    timeout=DEFAULT_JUDGER_CANCEL_TIMEOUT_S,
+                    timeout=JUDGER_PAUSE_JUDGE_TASK_TIMEOUT_S,
                 )
             except asyncio.TimeoutError:
                 await cancel_and_drain([judge_task])

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -19,6 +19,7 @@ from xtuner.v1.rl.utils import (
     cancel_and_drain,
     create_task,
     register_cpu_resources,
+    DEFAULT_JUDGER_CANCEL_TIMEOUT_S
 )
 from xtuner.v1.utils import get_logger, ray_method
 from xtuner.v1.utils.processing_utils import load_processor, load_tokenizer

--- a/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
+++ b/xtuner/v1/rl/agent_loop/gsm8k_with_tool.py
@@ -25,6 +25,7 @@ class GSM8KToolAgentLoopConfig(AgentLoopConfig):
             hf_checkpoint=self.hf_checkpoint,
             sample_params=self.sample_params,
             judger=judger,
+            enable_batch_judge=self.enable_batch_judge,
         )
 
 
@@ -43,9 +44,14 @@ class GSM8KToolAgentLoop(AgentLoop):
         hf_checkpoint: str,
         sample_params: SampleParams,
         judger: Judger | None = None,
+        enable_batch_judge: bool = False,
     ):
         super().__init__(
-            rollout_ctl=rollout_ctl, hf_checkpoint=hf_checkpoint, sample_params=sample_params, judger=judger
+            rollout_ctl=rollout_ctl,
+            hf_checkpoint=hf_checkpoint,
+            sample_params=sample_params,
+            judger=judger,
+            enable_batch_judge=enable_batch_judge,
         )
         self.max_turns = max_turns
         self.tool_call_pattern = re.compile(r"\n*<tool_call>(.*?)</tool_call>", re.DOTALL)
@@ -152,6 +158,6 @@ class GSM8KToolAgentLoop(AgentLoop):
         assert len(rollout_state.response_ids) == len(rollout_state.response_mask) == len(rollout_state.logprobs), (
             f"{len(rollout_state.response_ids)} vs {len(rollout_state.response_mask)} vs {len(rollout_state.logprobs)}"
         )
-        if self.judger is not None:
-            rollout_state = await self.judger.judge(rollout_state)
+        if self.judger is not None and not self.enable_batch_judge:
+            rollout_state = await self.run_judger(rollout_state)
         return rollout_state

--- a/xtuner/v1/rl/agent_loop/single_turn_agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/single_turn_agent_loop.py
@@ -1,12 +1,8 @@
-import asyncio
-from typing import overload
-
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
-from xtuner.v1.rl.utils import cancel_and_drain, create_task
 
-from .agent_loop import DEFAULT_JUDGER_CANCEL_TIMEOUT_S, AgentLoop, AgentLoopConfig
+from .agent_loop import AgentLoop, AgentLoopConfig
 
 
 class SingleTurnAgentLoopConfig(AgentLoopConfig):
@@ -38,8 +34,6 @@ class SingleTurnAgentLoopConfig(AgentLoopConfig):
         )
     """
 
-    enable_batch_judge: bool = False
-
     def build_local(self, rollout_controller, judger: Judger | None = None, logger=None) -> "SingleTurnAgentLoop":
         return SingleTurnAgentLoop(
             rollout_ctl=rollout_controller,
@@ -61,53 +55,14 @@ class SingleTurnAgentLoop(AgentLoop):
         logger=None,
         enable_batch_judge: bool = False,
     ):
-        super().__init__(rollout_ctl, sample_params, hf_checkpoint, judger, logger)
-        self.enable_batch_judge = enable_batch_judge
-        self._pause_event = asyncio.Event()
-
-    @overload
-    async def run_judger(self, rollout_state: RolloutState) -> RolloutState: ...
-
-    @overload
-    async def run_judger(self, rollout_state: list[RolloutState]) -> list[RolloutState]: ...
-
-    async def run_judger(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:
-        assert self.judger is not None
-        judge_task = create_task(self.judger.judge(rollout_state))
-        pause_task = create_task(self._pause_event.wait())
-        try:
-            done, _ = await asyncio.wait({judge_task, pause_task}, return_when=asyncio.FIRST_COMPLETED)
-            if judge_task in done:
-                return await judge_task
-            try:
-                return await asyncio.wait_for(
-                    asyncio.shield(judge_task),
-                    timeout=DEFAULT_JUDGER_CANCEL_TIMEOUT_S,
-                )
-            except asyncio.TimeoutError:
-                await cancel_and_drain([judge_task])
-                for sample in rollout_state if isinstance(rollout_state, list) else [rollout_state]:
-                    sample.status = Status.ABORTED
-                    sample.finish_reason = "abort"
-                    sample.reward = None
-                return rollout_state
-        except asyncio.CancelledError:
-            await cancel_and_drain([judge_task])
-            for sample in rollout_state if isinstance(rollout_state, list) else [rollout_state]:
-                sample.status = Status.ABORTED
-                sample.finish_reason = "abort"
-                sample.reward = None
-            return rollout_state
-        finally:
-            await cancel_and_drain([pause_task])
-
-    async def pause(self) -> None:
-        self._pause_event.set()
-        # TODO: Decide whether Judger needs an explicit pause API for resources not owned by SingleTurnAgentLoop.
-        try:
-            await super().pause()
-        finally:
-            self._pause_event.clear()
+        super().__init__(
+            rollout_ctl=rollout_ctl,
+            sample_params=sample_params,
+            hf_checkpoint=hf_checkpoint,
+            judger=judger,
+            logger=logger,
+            enable_batch_judge=enable_batch_judge,
+        )
 
     async def generate_sample(
         self,
@@ -126,17 +81,3 @@ class SingleTurnAgentLoop(AgentLoop):
             # 如果开启了批量打分，则在 generate_group 里统一打分，不在这里逐条打分
             rollout_state = await self.run_judger(rollout_state)
         return rollout_state
-
-    async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
-        pending_tasks = []
-        for state in rollout_state:
-            state.sample_params = self.sample_params
-            task = create_task(self.generate_sample(state, **kwargs))
-            pending_tasks.append(task)
-        generated_samples = asyncio.gather(*pending_tasks)
-        group_samples = await generated_samples
-        if self.judger is not None and self.enable_batch_judge:
-            if not any(sample.status == Status.ABORTED for sample in group_samples):
-                # 批量打分
-                group_samples = await self.run_judger(group_samples)
-        return group_samples

--- a/xtuner/v1/rl/judger/__init__.py
+++ b/xtuner/v1/rl/judger/__init__.py
@@ -14,6 +14,10 @@ from .gsm8k import GSM8KJudgerConfig
 from .native import (
     Judger,
     JudgerConfig,
+    JudgerOutput,
+    JudgerOutputBatch,
+    JudgerPayload,
+    JudgerPayloadBatch,
     JudgerPool,
     NativeJudger,
     RayJudger,

--- a/xtuner/v1/rl/judger/__init__.py
+++ b/xtuner/v1/rl/judger/__init__.py
@@ -2,8 +2,6 @@ from .compass_verifier_v2 import CompassVerifierV2Config
 from .composed import (
     ComposedJudger,
     ComposedJudgerConfig,
-    default_merge_fn,
-    default_select_fn,
 )
 from .dapo_math import DapoMathJudgerConfig
 from .factory import (

--- a/xtuner/v1/rl/judger/compass_verifier_v2.py
+++ b/xtuner/v1/rl/judger/compass_verifier_v2.py
@@ -44,6 +44,7 @@ class CompassVerifierV2(Judger):
         max_retries: int = 3,
         thinking_finish_words: list[str] | None = None,
     ):
+        super().__init__(judger_name="compass_verifier_v2")
         if not hosts:
             raise ValueError("CompassVerifierV2 requires at least one host.")
         self.hosts = hosts
@@ -55,7 +56,6 @@ class CompassVerifierV2(Judger):
             headers={"Authorization": "Bearer "},
             timeout=request_timeout,
         ).json()["data"][0]["id"]
-        self.judger_name = "compass_verifier_v2"
 
     def preprocess(self, rollout_state: RolloutState) -> JudgerPayload:
         if rollout_state.status != Status.COMPLETED or rollout_state.response is None:
@@ -116,9 +116,6 @@ class CompassVerifierV2(Judger):
                     await asyncio.sleep(1)
                     print(f"[Judger]: Error try {i}: {str(e)}")
         raise RuntimeError(f"Cannot connect to judger service for {self.max_retries} times.")
-
-    def get_judger_name(self) -> str:
-        return self.judger_name
 
 
 class CompassVerifierV2Config(JudgerConfig):

--- a/xtuner/v1/rl/judger/compass_verifier_v2.py
+++ b/xtuner/v1/rl/judger/compass_verifier_v2.py
@@ -37,6 +37,12 @@ Judging the correctness of the candidate's answer:
 
 
 class CompassVerifierV2(Judger):
+    """LLM-based verifier for single rollout samples.
+
+    ``CompassVerifierV2`` does not implement batch judging. Passing
+    ``list[RolloutState]`` to ``judge`` raises before payload construction.
+    """
+
     def __init__(
         self,
         hosts: list[str],

--- a/xtuner/v1/rl/judger/compass_verifier_v2.py
+++ b/xtuner/v1/rl/judger/compass_verifier_v2.py
@@ -5,7 +5,7 @@ import aiohttp
 import requests  # type: ignore[import-untyped]
 from pydantic import ConfigDict
 
-from xtuner.v1.data_proto.rl_data import Status
+from xtuner.v1.data_proto.rl_data import RolloutState, Status
 from xtuner.v1.rl.judger.native import Judger, JudgerConfig, JudgerOutputBatch, JudgerPayloadBatch
 
 
@@ -56,6 +56,11 @@ class CompassVerifierV2(Judger):
             headers={"Authorization": "Bearer "},
             timeout=request_timeout,
         ).json()["data"][0]["id"]
+
+    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState:
+        if isinstance(rollout_state, list):
+            raise NotImplementedError("CompassVerifierV2 does not support batch RolloutState input.")
+        return await super().judge(rollout_state)
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         if isinstance(payload, list):

--- a/xtuner/v1/rl/judger/compass_verifier_v2.py
+++ b/xtuner/v1/rl/judger/compass_verifier_v2.py
@@ -5,8 +5,8 @@ import aiohttp
 import requests  # type: ignore[import-untyped]
 from pydantic import ConfigDict
 
-from xtuner.v1.data_proto.rl_data import RolloutState, Status
-from xtuner.v1.rl.judger.native import Judger, JudgerConfig, JudgerOutputBatch, JudgerPayload, JudgerPayloadBatch
+from xtuner.v1.data_proto.rl_data import Status
+from xtuner.v1.rl.judger.native import Judger, JudgerConfig, JudgerOutputBatch, JudgerPayloadBatch
 
 
 verify_prompt = """
@@ -56,16 +56,6 @@ class CompassVerifierV2(Judger):
             headers={"Authorization": "Bearer "},
             timeout=request_timeout,
         ).json()["data"][0]["id"]
-
-    def preprocess(self, rollout_state: RolloutState) -> JudgerPayload:
-        if rollout_state.status != Status.COMPLETED or rollout_state.response is None:
-            return {
-                "response": rollout_state.response,
-                "label": None,
-                "message": rollout_state.message,
-                "status": rollout_state.status,
-            }
-        return super().preprocess(rollout_state)
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         if isinstance(payload, list):

--- a/xtuner/v1/rl/judger/compass_verifier_v2.py
+++ b/xtuner/v1/rl/judger/compass_verifier_v2.py
@@ -6,8 +6,7 @@ import requests  # type: ignore[import-untyped]
 from pydantic import ConfigDict
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status
-from xtuner.v1.rl.judger.native import Judger, JudgerConfig
-from xtuner.v1.utils.type_helper import ray_method
+from xtuner.v1.rl.judger.native import Judger, JudgerConfig, JudgerOutputBatch, JudgerPayload, JudgerPayloadBatch
 
 
 verify_prompt = """
@@ -58,14 +57,24 @@ class CompassVerifierV2(Judger):
         ).json()["data"][0]["id"]
         self.judger_name = "compass_verifier_v2"
 
-    @ray_method
-    async def judge(self, rollout_state: RolloutState) -> RolloutState:  # type: ignore[override]
+    def preprocess(self, rollout_state: RolloutState) -> JudgerPayload:
         if rollout_state.status != Status.COMPLETED or rollout_state.response is None:
-            rollout_state.reward = {"score": -1}
-            return rollout_state
+            return {
+                "response": rollout_state.response,
+                "label": None,
+                "message": rollout_state.message,
+                "status": rollout_state.status,
+            }
+        return super().preprocess(rollout_state)
 
-        question = rollout_state.message[-1]["content"]
-        model_answer = rollout_state.response.replace("<|im_end|>", "").strip()
+    async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
+        if isinstance(payload, list):
+            raise NotImplementedError("CompassVerifierV2 does not support batch payloads.")
+        if payload["status"] != Status.COMPLETED or payload["response"] is None:
+            return {"score": -1}
+
+        question = payload["message"][-1]["content"]
+        model_answer = payload["response"].replace("<|im_end|>", "").strip()
         for thinking_finish_word in self.thinking_finish_words:
             if thinking_finish_word in model_answer:
                 model_answer = model_answer.split(thinking_finish_word)[-1]
@@ -76,12 +85,9 @@ class CompassVerifierV2(Judger):
         if len(model_answer) > 1000:
             model_answer = model_answer[-1000:]
 
-        assert rollout_state.reward_model is not None and "ground_truth" in rollout_state.reward_model, (
-            "RolloutState must have reward_model with 'ground_truth' for CompassVerifierV2."
-        )
-        outcome_reward = await self._judge_with_llm(question, model_answer, rollout_state.reward_model["ground_truth"])
-        rollout_state.reward = {"score": outcome_reward}
-        return rollout_state
+        assert payload["label"] is not None, "Judger payload must contain label for CompassVerifierV2."
+        outcome_reward = await self._judge_with_llm(question, model_answer, payload["label"])
+        return {"score": outcome_reward}
 
     async def _judge_with_llm(self, question: str, model_response: str, label: str):
         headers = {"Content-Type": "application/json"}

--- a/xtuner/v1/rl/judger/compass_verifier_v2.py
+++ b/xtuner/v1/rl/judger/compass_verifier_v2.py
@@ -40,7 +40,7 @@ class CompassVerifierV2(Judger):
     """LLM-based verifier for single rollout samples.
 
     ``CompassVerifierV2`` does not implement batch judging. Passing
-    ``list[RolloutState]`` to ``judge`` raises before payload construction.
+    ``list[RolloutState]`` to ``batch_judge`` raises before payload construction.
     """
 
     def __init__(
@@ -63,10 +63,8 @@ class CompassVerifierV2(Judger):
             timeout=request_timeout,
         ).json()["data"][0]["id"]
 
-    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState:
-        if isinstance(rollout_state, list):
-            raise NotImplementedError("CompassVerifierV2 does not support batch RolloutState input.")
-        return await super().judge(rollout_state)
+    async def batch_judge(self, rollout_states: list[RolloutState]) -> list[RolloutState]:
+        raise NotImplementedError("CompassVerifierV2 does not support batch_judge.")
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         if isinstance(payload, list):

--- a/xtuner/v1/rl/judger/composed.py
+++ b/xtuner/v1/rl/judger/composed.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import Callable, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from xtuner.v1.data_proto.rl_data import RolloutState
 
-from .native import Judger, JudgerConfig
+from .native import Judger, JudgerConfig, JudgerOutput
 
 
 SelectedJudgerKeys: TypeAlias = str | list[str] | None
 JudgerSelectFn: TypeAlias = Callable[[RolloutState, dict[str, Judger]], SelectedJudgerKeys]
 JudgerMergeFn: TypeAlias = Callable[
-    [RolloutState | list[RolloutState], dict[str, RolloutState | list[RolloutState]]],
+    [RolloutState | list[RolloutState], dict[str, JudgerOutput | list[JudgerOutput]]],
     RolloutState | list[RolloutState],
 ]
 
@@ -37,14 +36,14 @@ def default_select_fn(rollout_state: RolloutState, branches: dict[str, Judger]) 
 
 def default_merge_fn(
     original: RolloutState | list[RolloutState],
-    judged: dict[str, RolloutState | list[RolloutState]],
+    judged: dict[str, JudgerOutput | list[JudgerOutput]],
 ) -> RolloutState | list[RolloutState]:
     """Default merger for ``ComposedJudgerConfig``.
 
     This merger intentionally does not combine multiple judger scores into a single aggregated value.
     It writes the merged reward as ``{branch_name: score}``, where ``branch_name`` is the selected
     key from ``ComposedJudgerConfig.branches`` and ``score`` is taken from each child judger's
-    ``reward["score"]``.
+    output ``["score"]``.
 
     Supports both single ``RolloutState`` and batched ``list[RolloutState]`` inputs. In the batch
     case, each element in the list represents a different response to the same prompt, and each
@@ -54,42 +53,41 @@ def default_merge_fn(
     their own ``merge_fn``.
     """
     if isinstance(original, list):
-        for name, state in judged.items():
-            if not isinstance(state, list):
+        for name, output in judged.items():
+            if not isinstance(output, list):
                 raise TypeError(
-                    f"default_merge_fn: branch {name!r} returned a single RolloutState "
+                    f"default_merge_fn: branch {name!r} returned a single output "
                     "but original is a list. All branches must return lists when input is a list."
                 )
-            if len(state) != len(original):
+            if len(output) != len(original):
                 raise ValueError(
-                    f"default_merge_fn: branch {name!r} returned {len(state)} states "
+                    f"default_merge_fn: branch {name!r} returned {len(output)} outputs "
                     f"but original has {len(original)} states."
                 )
         results: list[RolloutState] = []
         for i, orig in enumerate(original):
-            merged = orig.model_copy(deep=True)
-            merged.reward = {}
-            for name, states in judged.items():
-                assert isinstance(states, list)
-                state_i: RolloutState = states[i]
-                reward = state_i.reward
-                if reward is None or "score" not in reward:
-                    raise KeyError(f"Default merge_fn requires reward['score'] for branch {name!r}.")
-                merged.reward[name] = reward["score"]
-            results.append(merged)
+            merged_reward = {}
+            for name, outputs in judged.items():
+                assert isinstance(outputs, list)
+                output_i = outputs[i]
+                if "score" not in output_i:
+                    raise KeyError(f"Default merge_fn requires output['score'] for branch {name!r}.")
+                merged_reward[name] = output_i["score"]
+            orig.reward = merged_reward
+            results.append(orig)
         return results
     else:
-        merged = original.model_copy(deep=True)
-        merged.reward = {}
-        for name, state in judged.items():
-            if isinstance(state, list):
+        merged_reward = {}
+        for name, output in judged.items():
+            if isinstance(output, list):
                 raise TypeError(
                     f"default_merge_fn: branch {name!r} returned a list but original is a single RolloutState."
                 )
-            if state.reward is None or "score" not in state.reward:
-                raise KeyError(f"Default merge_fn requires reward['score'] for branch {name!r}.")
-            merged.reward[name] = state.reward["score"]
-        return merged
+            if "score" not in output:
+                raise KeyError(f"Default merge_fn requires output['score'] for branch {name!r}.")
+            merged_reward[name] = output["score"]
+        original.reward = merged_reward
+        return original
 
 
 class ComposedJudger(Judger):
@@ -135,11 +133,16 @@ class ComposedJudger(Judger):
     async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:  # type: ignore[override]
         selected_keys = self._resolve_selected_keys(rollout_state)
 
-        judged: dict[str, RolloutState | list[RolloutState]] = {}
+        judged: dict[str, JudgerOutput | list[JudgerOutput]] = {}
         for key in selected_keys:
             if key not in self.branches:
                 raise KeyError(f"Unknown judger branch: {key}, available={sorted(self.branches)}")
-            judged[key] = await self.branches[key].judge(deepcopy(rollout_state))
+            if isinstance(rollout_state, list):
+                payloads = [self.branches[key].preprocess(state) for state in rollout_state]
+                judged[key] = await self.branches[key].judge_payload(payloads)
+            else:
+                payload = self.branches[key].preprocess(rollout_state)
+                judged[key] = await self.branches[key].judge_payload(payload)
         return self.merge_fn(rollout_state, judged)
 
 

--- a/xtuner/v1/rl/judger/composed.py
+++ b/xtuner/v1/rl/judger/composed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Callable, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -9,140 +10,120 @@ from xtuner.v1.data_proto.rl_data import RolloutState
 from .native import Judger, JudgerConfig, JudgerOutput
 
 
-SelectedJudgerKeys: TypeAlias = str | list[str] | None
-JudgerSelectFn: TypeAlias = Callable[[RolloutState, dict[str, Judger]], SelectedJudgerKeys]
+# Merge function contract for multi-branch composed judging:
+# - The first argument is the original rollout state.
+# - The second argument maps each selected branch key to that branch's raw judger output.
+# - The function must return the same shape as the input rollout state with ``reward`` populated.
 JudgerMergeFn: TypeAlias = Callable[
     [RolloutState | list[RolloutState], dict[str, JudgerOutput | list[JudgerOutput]]],
     RolloutState | list[RolloutState],
 ]
 
 
-def default_select_fn(rollout_state: RolloutState, branches: dict[str, Judger]) -> SelectedJudgerKeys:
-    """Default branch selector for ``ComposedJudgerConfig``.
-
-    Selection order is intentionally simple:
-    1. If ``rollout_state.data_source`` is a string and matches a branch key, use it.
-    2. Otherwise return ``None`` and let ``default_key`` or the single-branch fallback decide.
-
-    Users with task-specific routing logic should pass a custom ``select_fn`` instead of extending
-    this default heuristic.
-    """
-    data_source = rollout_state.data_source
-    if isinstance(data_source, str) and data_source in branches:
-        return data_source
-
-    return None
-
-
-def default_merge_fn(
-    original: RolloutState | list[RolloutState],
-    judged: dict[str, JudgerOutput | list[JudgerOutput]],
-) -> RolloutState | list[RolloutState]:
-    """Default merger for ``ComposedJudgerConfig``.
-
-    This merger intentionally does not combine multiple judger scores into a single aggregated value.
-    It writes the merged reward as ``{branch_name: score}``, where ``branch_name`` is the selected
-    key from ``ComposedJudgerConfig.branches`` and ``score`` is taken from each child judger's
-    output ``["score"]``.
-
-    Supports both single ``RolloutState`` and batched ``list[RolloutState]`` inputs. In the batch
-    case, each element in the list represents a different response to the same prompt, and each
-    branch's judged result must be a list of the same length.
-
-    Users who need weighted sums, richer reward payloads, or custom post-processing should provide
-    their own ``merge_fn``.
-    """
-    if isinstance(original, list):
-        for name, output in judged.items():
-            if not isinstance(output, list):
-                raise TypeError(
-                    f"default_merge_fn: branch {name!r} returned a single output "
-                    "but original is a list. All branches must return lists when input is a list."
-                )
-            if len(output) != len(original):
-                raise ValueError(
-                    f"default_merge_fn: branch {name!r} returned {len(output)} outputs "
-                    f"but original has {len(original)} states."
-                )
-        results: list[RolloutState] = []
-        for i, orig in enumerate(original):
-            merged_reward = {}
-            for name, outputs in judged.items():
-                assert isinstance(outputs, list)
-                output_i = outputs[i]
-                if "score" not in output_i:
-                    raise KeyError(f"Default merge_fn requires output['score'] for branch {name!r}.")
-                merged_reward[name] = output_i["score"]
-            orig.reward = merged_reward
-            results.append(orig)
-        return results
-    else:
-        merged_reward = {}
-        for name, output in judged.items():
-            if isinstance(output, list):
-                raise TypeError(
-                    f"default_merge_fn: branch {name!r} returned a list but original is a single RolloutState."
-                )
-            if "score" not in output:
-                raise KeyError(f"Default merge_fn requires output['score'] for branch {name!r}.")
-            merged_reward[name] = output["score"]
-        original.reward = merged_reward
-        return original
-
-
 class ComposedJudger(Judger):
     def __init__(
         self,
         branches: dict[str, Judger],
-        select_fn: JudgerSelectFn = default_select_fn,
-        merge_fn: JudgerMergeFn = default_merge_fn,
-        default_key: str | None = "default",
+        merge_fn: JudgerMergeFn | None = None,
     ):
+        super().__init__()
         if not branches:
             raise ValueError("ComposedJudger requires at least one branch.")
         self.branches = branches
-        self.select_fn = select_fn
+        # ``merge_fn=None`` is only valid for routing mode, where each sample
+        # selects exactly one branch and that branch's reward is passed through.
+        # If ``data_source`` selects multiple branches, callers must provide an
+        # explicit merge function because reward aggregation is task-specific.
         self.merge_fn = merge_fn
-        self.default_key = default_key
+
+    def _select_keys_from_data_source(self, rollout_state: RolloutState) -> list[str]:
+        data_source = rollout_state.data_source
+        if data_source is None:
+            raise ValueError(
+                "ComposedJudger requires rollout_state.data_source to route judger branches. "
+                f"task_name={rollout_state.task_name!r}, available={sorted(self.branches)}"
+            )
+        if isinstance(data_source, str):
+            if data_source not in self.branches:
+                raise KeyError(
+                    f"Unknown judger branch from data_source: {data_source!r}, available={sorted(self.branches)}"
+                )
+            return [data_source]
+        if isinstance(data_source, dict):
+            if not data_source:
+                raise ValueError("ComposedJudger data_source dict must contain at least one judger branch.")
+            selected_keys = []
+            for key in data_source:
+                if not isinstance(key, str):
+                    raise TypeError(f"ComposedJudger data_source dict keys must be strings, got {key!r}.")
+                if key not in self.branches:
+                    raise KeyError(
+                        f"Unknown judger branch from data_source: {key!r}, available={sorted(self.branches)}"
+                    )
+                selected_keys.append(key)
+            return selected_keys
+
+        raise TypeError(
+            "ComposedJudger data_source must be a branch name string or a dict of branch names to weights, "
+            f"got {type(data_source).__name__}: {data_source!r}. "
+            f"task_name={rollout_state.task_name!r}, available={sorted(self.branches)}"
+        )
 
     def _resolve_selected_keys(self, rollout_state: RolloutState | list[RolloutState]) -> list[str]:
         if isinstance(rollout_state, list):
-            selected = self.select_fn(rollout_state[0], self.branches)
-        else:
-            selected = self.select_fn(rollout_state, self.branches)
+            if not rollout_state:
+                raise ValueError("ComposedJudger requires at least one RolloutState when input is a list.")
+            return self._select_keys_from_data_source(rollout_state[0])
+        return self._select_keys_from_data_source(rollout_state)
 
-        if selected is None:
-            selected_keys: list[str] = []
-        elif isinstance(selected, str):
-            selected_keys = [selected]
-        else:
-            selected_keys = list(dict.fromkeys(selected))
+    async def _judge_branch(
+        self,
+        key: str,
+        rollout_state: RolloutState | list[RolloutState],
+    ) -> tuple[str, JudgerOutput | list[JudgerOutput]]:
+        branch = self.branches[key]
+        if isinstance(rollout_state, list):  # batch samples judge
+            payloads = [branch.preprocess(state) for state in rollout_state]
+            return key, await branch.judge_payload(payloads)
+        # single sample judge
+        payload = branch.preprocess(rollout_state)
+        return key, await branch.judge_payload(payload)
 
-        if not selected_keys:
-            if self.default_key is not None and self.default_key in self.branches:
-                return [self.default_key]
-            if len(self.branches) == 1:
-                return [next(iter(self.branches))]
-            state = rollout_state[0] if isinstance(rollout_state, list) else rollout_state
-            raise KeyError(
-                f"ComposedJudger could not select a branch for task_name={state.task_name!r}, "
-                f"data_source={state.data_source!r}, available={sorted(self.branches)}"
-            )
-        return selected_keys
+    def _postprocess_single_branch(
+        self,
+        branch: Judger,
+        rollout_state: RolloutState | list[RolloutState],
+        output: JudgerOutput | list[JudgerOutput],
+    ) -> RolloutState | list[RolloutState]:
+        if isinstance(rollout_state, list):
+            if not isinstance(output, list):
+                raise TypeError("Single selected branch returned a single output for a rollout state list.")
+            if len(output) != len(rollout_state):
+                raise ValueError(
+                    f"Single selected branch returned {len(output)} outputs for {len(rollout_state)} states."
+                )
+            return [branch.postprocess(state, output_i) for state, output_i in zip(rollout_state, output)]
+
+        if isinstance(output, list):
+            raise TypeError("Single selected branch returned a list output for one RolloutState.")
+        return branch.postprocess(rollout_state, output)
 
     async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:  # type: ignore[override]
         selected_keys = self._resolve_selected_keys(rollout_state)
 
-        judged: dict[str, JudgerOutput | list[JudgerOutput]] = {}
-        for key in selected_keys:
-            if key not in self.branches:
-                raise KeyError(f"Unknown judger branch: {key}, available={sorted(self.branches)}")
-            if isinstance(rollout_state, list):
-                payloads = [self.branches[key].preprocess(state) for state in rollout_state]
-                judged[key] = await self.branches[key].judge_payload(payloads)
-            else:
-                payload = self.branches[key].preprocess(rollout_state)
-                judged[key] = await self.branches[key].judge_payload(payload)
+        if len(selected_keys) == 1:
+            # 处理每次只选择其中一个 branch 的情况
+            key = selected_keys[0]
+            _, output = await self._judge_branch(key, rollout_state)
+            return self._postprocess_single_branch(self.branches[key], rollout_state, output)
+
+        if self.merge_fn is None:
+            raise ValueError(
+                "ComposedJudger selected multiple branches but merge_fn is not provided. "
+                f"selected_keys={selected_keys!r}"
+            )
+
+        judged = dict(await asyncio.gather(*(self._judge_branch(key, rollout_state) for key in selected_keys)))
         return self.merge_fn(rollout_state, judged)
 
 
@@ -157,12 +138,9 @@ class ComposedJudgerConfig(BaseModel):
     Args:
         branches (dict[str, JudgerConfig | ComposedJudgerConfig]): Mapping from
             branch name to judger configuration.
-        select_fn (JudgerSelectFn): Function that selects which branch names to
-            execute for a rollout. Defaults to ``default_select_fn``.
-        merge_fn (JudgerMergeFn | None): Function that merges branch outputs
-            into the returned rollout state. Defaults to the built-in merger.
-        default_key (str | None): Fallback branch name used when ``select_fn``
-            returns None. Defaults to "default".
+        merge_fn (JudgerMergeFn | None): Function that merges multiple branch
+            outputs into the returned rollout state. Required when ``data_source``
+            may select more than one branch.
 
     **Examples:**
 
@@ -173,21 +151,18 @@ class ComposedJudgerConfig(BaseModel):
                 "math": GSM8KJudgerConfig(),
                 "format": JudgerConfig(judger_name="format", reward_handler=format_reward),
             },
-            select_fn=select_judger_branch,
         )
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     branches: dict[str, JudgerConfigLike]
-    # ``select_fn`` chooses which branch keys should be executed for one sample.
-    # Return a single string for single-judger routing, a list of strings for multi-judger execution,
-    # or ``None`` to fall back to ``default_key`` / single-branch implicit fallback.
-    select_fn: JudgerSelectFn = Field(default=default_select_fn, exclude=True)
-    # ``merge_fn`` merges the judged rollout states back into one rollout state.
-    # The default implementation does not aggregate scores; it writes ``{branch_name: score}``.
+    # Branch routing is fixed to ``RolloutState.data_source``:
+    # - str selects one branch.
+    # - dict keys select multiple branches.
+    # ``merge_fn=None`` means single-branch pass-through only. If data_source
+    # may select multiple branches, this must be set explicitly.
     merge_fn: JudgerMergeFn | None = Field(default=None, exclude=True)
-    default_key: str | None = "default"
 
     def build(self) -> Judger:
         from .factory import build_judger

--- a/xtuner/v1/rl/judger/composed.py
+++ b/xtuner/v1/rl/judger/composed.py
@@ -69,53 +69,47 @@ class ComposedJudger(Judger):
             f"task_name={rollout_state.task_name!r}, available={sorted(self.branches)}"
         )
 
-    def _resolve_selected_keys(self, rollout_state: RolloutState | list[RolloutState]) -> list[str]:
-        if isinstance(rollout_state, list):
-            if not rollout_state:
-                raise ValueError("ComposedJudger requires at least one RolloutState when input is a list.")
-            return self._select_keys_from_data_source(rollout_state[0])
-        return self._select_keys_from_data_source(rollout_state)
-
     async def _judge_branch(
         self,
         key: str,
-        rollout_state: RolloutState | list[RolloutState],
-    ) -> tuple[str, JudgerOutput | list[JudgerOutput]]:
+        rollout_state: RolloutState,
+    ) -> tuple[str, JudgerOutput]:
         branch = self.branches[key]
-        if isinstance(rollout_state, list):  # batch samples judge
-            payloads = [branch.preprocess(state) for state in rollout_state]
-            return key, await branch.judge_payload(payloads)
-        # single sample judge
         payload = branch.preprocess(rollout_state)
-        return key, await branch.judge_payload(payload)
+        output = await branch.judge_payload(payload)
+        if isinstance(output, list):
+            raise TypeError(f"Branch {key!r} returned a list output for one RolloutState.")
+        return key, output
 
-    def _postprocess_single_branch(
+    async def _batch_judge_branch(
+        self,
+        key: str,
+        rollout_states: list[RolloutState],
+    ) -> tuple[str, list[JudgerOutput]]:
+        branch = self.branches[key]
+        payloads = [branch.preprocess(state) for state in rollout_states]
+        outputs = await branch.judge_payload(payloads)
+        if not isinstance(outputs, list):
+            raise TypeError(f"Branch {key!r} returned a single output for a rollout state list.")
+        if len(outputs) != len(rollout_states):
+            raise ValueError(f"Branch {key!r} returned {len(outputs)} outputs for {len(rollout_states)} states.")
+        return key, outputs
+
+    def _postprocess_branch_batch(
         self,
         branch: Judger,
-        rollout_state: RolloutState | list[RolloutState],
-        output: JudgerOutput | list[JudgerOutput],
-    ) -> RolloutState | list[RolloutState]:
-        if isinstance(rollout_state, list):
-            if not isinstance(output, list):
-                raise TypeError("Single selected branch returned a single output for a rollout state list.")
-            if len(output) != len(rollout_state):
-                raise ValueError(
-                    f"Single selected branch returned {len(output)} outputs for {len(rollout_state)} states."
-                )
-            return [branch.postprocess(state, output_i) for state, output_i in zip(rollout_state, output)]
+        rollout_states: list[RolloutState],
+        outputs: list[JudgerOutput],
+    ) -> list[RolloutState]:
+        return [branch.postprocess(state, output) for state, output in zip(rollout_states, outputs)]
 
-        if isinstance(output, list):
-            raise TypeError("Single selected branch returned a list output for one RolloutState.")
-        return branch.postprocess(rollout_state, output)
-
-    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:  # type: ignore[override]
-        selected_keys = self._resolve_selected_keys(rollout_state)
+    async def judge(self, rollout_state: RolloutState) -> RolloutState:
+        selected_keys = self._select_keys_from_data_source(rollout_state)
 
         if len(selected_keys) == 1:
-            # 处理每次只选择其中一个 branch 的情况
             key = selected_keys[0]
             _, output = await self._judge_branch(key, rollout_state)
-            return self._postprocess_single_branch(self.branches[key], rollout_state, output)
+            return self.branches[key].postprocess(rollout_state, output)
 
         if self.merge_fn is None:
             raise ValueError(
@@ -126,7 +120,34 @@ class ComposedJudger(Judger):
         judged = dict[str, JudgerOutput | list[JudgerOutput]](
             await asyncio.gather(*(self._judge_branch(key, rollout_state) for key in selected_keys))
         )
-        return self.merge_fn(rollout_state, judged)
+        merged = self.merge_fn(rollout_state, judged)
+        if isinstance(merged, list):
+            raise TypeError("ComposedJudger merge_fn returned a list for judge.")
+        return merged
+
+    async def batch_judge(self, rollout_states: list[RolloutState]) -> list[RolloutState]:
+        if not rollout_states:
+            raise ValueError("ComposedJudger requires at least one RolloutState when input is a list.")
+        selected_keys = self._select_keys_from_data_source(rollout_states[0])
+
+        if len(selected_keys) == 1:
+            key = selected_keys[0]
+            _, outputs = await self._batch_judge_branch(key, rollout_states)
+            return self._postprocess_branch_batch(self.branches[key], rollout_states, outputs)
+
+        if self.merge_fn is None:
+            raise ValueError(
+                "ComposedJudger selected multiple branches but merge_fn is not provided. "
+                f"selected_keys={selected_keys!r}"
+            )
+
+        judged = dict[str, JudgerOutput | list[JudgerOutput]](
+            await asyncio.gather(*(self._batch_judge_branch(key, rollout_states) for key in selected_keys))
+        )
+        merged = self.merge_fn(rollout_states, judged)
+        if not isinstance(merged, list):
+            raise TypeError("ComposedJudger merge_fn returned a single RolloutState for batch_judge.")
+        return merged
 
 
 class ComposedJudgerConfig(BaseModel):

--- a/xtuner/v1/rl/judger/composed.py
+++ b/xtuner/v1/rl/judger/composed.py
@@ -123,24 +123,29 @@ class ComposedJudger(Judger):
                 f"selected_keys={selected_keys!r}"
             )
 
-        judged = dict(await asyncio.gather(*(self._judge_branch(key, rollout_state) for key in selected_keys)))
+        judged = dict[str, JudgerOutput | list[JudgerOutput]](
+            await asyncio.gather(*(self._judge_branch(key, rollout_state) for key in selected_keys))
+        )
         return self.merge_fn(rollout_state, judged)
 
 
 class ComposedJudgerConfig(BaseModel):
     """Configuration for composing multiple judgers.
 
-    ``ComposedJudgerConfig`` routes each rollout to one or more branch judgers
-    and merges the branch outputs back into a single ``RolloutState``. It is
-    useful when different samples in the same task require different reward
-    functions or when multiple rewards must be computed together.
+    ``ComposedJudgerConfig`` routes rollout states through
+    ``RolloutState.data_source``. A string value selects one branch and passes
+    that branch output through as ``RolloutState.reward``. A dict value selects
+    multiple branches by key and requires ``merge_fn`` to define the final
+    reward shape.
 
     Args:
         branches (dict[str, JudgerConfig | ComposedJudgerConfig]): Mapping from
-            branch name to judger configuration.
+            branch name to judger configuration. Branch names must match
+            ``RolloutState.data_source`` string values or dict keys.
         merge_fn (JudgerMergeFn | None): Function that merges multiple branch
             outputs into the returned rollout state. Required when ``data_source``
-            may select more than one branch.
+            may select more than one branch. Leave as ``None`` only when every
+            sample selects exactly one branch.
 
     **Examples:**
 
@@ -151,6 +156,7 @@ class ComposedJudgerConfig(BaseModel):
                 "math": GSM8KJudgerConfig(),
                 "format": JudgerConfig(judger_name="format", reward_handler=format_reward),
             },
+            merge_fn=merge_rewards,
         )
     """
 

--- a/xtuner/v1/rl/judger/composed.py
+++ b/xtuner/v1/rl/judger/composed.py
@@ -64,7 +64,7 @@ class ComposedJudger(Judger):
             return selected_keys
 
         raise TypeError(
-            "ComposedJudger data_source must be a branch name string or a dict of branch names to weights, "
+            "ComposedJudger data_source must be a branch name string or a dict of branch names "
             f"got {type(data_source).__name__}: {data_source!r}. "
             f"task_name={rollout_state.task_name!r}, available={sorted(self.branches)}"
         )

--- a/xtuner/v1/rl/judger/factory.py
+++ b/xtuner/v1/rl/judger/factory.py
@@ -46,7 +46,11 @@ def _build_remote_actor(config: JudgerConfig) -> RayJudgerProxy:
 
 
 def _build_remote_judger(config: JudgerConfig) -> Judger:
-    return RemoteJudger(_build_remote_actor(config), judger_name=config.judger_name)
+    return RemoteJudger(
+        _build_remote_actor(config),
+        judger_name=config.judger_name,
+        preprocess_judger=config.build_local(),
+    )
 
 
 def _build_remote_judgers(config: JudgerConfig) -> list[Judger]:

--- a/xtuner/v1/rl/judger/factory.py
+++ b/xtuner/v1/rl/judger/factory.py
@@ -1,16 +1,16 @@
-from xtuner.v1.rl.utils import register_cpu_resources
+from xtuner.v1.rl.utils import CPUActorLauncher, register_cpu_resources
 
-from .composed import ComposedJudger, ComposedJudgerConfig, JudgerConfigLike, default_merge_fn
-from .native import Judger, JudgerConfig, JudgerPool
+from .composed import ComposedJudger, ComposedJudgerConfig, JudgerConfigLike
+from .native import Judger, JudgerActor, JudgerConfig, JudgerPool, RayJudgerProxy, RemoteJudger
 
 
 #
 # Use ``JudgerConfig`` when one sample only needs one concrete judger implementation:
 # one reward handler, one judger_name, and one execution mode (local or Ray actors).
 #
-# Use ``ComposedJudgerConfig`` when one sample may need to be routed to different child
-# judgers by ``select_fn``, or when you want to run multiple child judgers and merge their
-# outputs with ``merge_fn``.
+# Use ``ComposedJudgerConfig`` when one sample may need to be routed to child
+# judgers by ``RolloutState.data_source``, or when you want to run multiple
+# child judgers and merge their outputs with ``merge_fn``.
 #
 def build_judger(config: JudgerConfigLike) -> Judger:
     if isinstance(config, ComposedJudgerConfig):
@@ -28,11 +28,30 @@ def _build_replicated_judger(config: JudgerConfig) -> Judger:
     )
 
     if config.cpu_resources.num_workers == 1:
-        return config._build_remote_judger(cpu_resources=config.cpu_resources)
+        return _build_remote_judger(config)
     return JudgerPool(
-        replicas=config._build_remote_judgers(cpu_resources=config.cpu_resources),
+        replicas=_build_remote_judgers(config),
         judger_name=config.judger_name,
     )
+
+
+def _build_remote_actor(config: JudgerConfig) -> RayJudgerProxy:
+    assert config.cpu_resources is not None
+    return CPUActorLauncher.build_actor(
+        JudgerActor,
+        config,
+        actor_num_cpus=config.cpu_resources.num_cpus_per_worker,
+        actor_memory=config.cpu_resources.cpu_memory_per_worker,
+    )
+
+
+def _build_remote_judger(config: JudgerConfig) -> Judger:
+    return RemoteJudger(_build_remote_actor(config), judger_name=config.judger_name)
+
+
+def _build_remote_judgers(config: JudgerConfig) -> list[Judger]:
+    assert config.cpu_resources is not None
+    return [_build_remote_judger(config) for _ in range(config.cpu_resources.num_workers)]
 
 
 def _build_composite_judger(config: ComposedJudgerConfig) -> Judger:
@@ -41,7 +60,5 @@ def _build_composite_judger(config: ComposedJudgerConfig) -> Judger:
         branches[key] = build_judger(branch_config)
     return ComposedJudger(
         branches=branches,
-        select_fn=config.select_fn,
-        merge_fn=config.merge_fn or default_merge_fn,
-        default_key=config.default_key,
+        merge_fn=config.merge_fn,
     )

--- a/xtuner/v1/rl/judger/factory.py
+++ b/xtuner/v1/rl/judger/factory.py
@@ -5,12 +5,12 @@ from .native import Judger, JudgerActor, JudgerConfig, JudgerPool, RayJudgerProx
 
 
 #
-# Use ``JudgerConfig`` when one sample only needs one concrete judger implementation:
-# one reward handler, one judger_name, and one execution mode (local or Ray actors).
+# Use ``JudgerConfig`` for one concrete reward handler. The built-in
+# ``NativeJudger`` path scores one rollout sample at a time.
 #
 # Use ``ComposedJudgerConfig`` when one sample may need to be routed to child
-# judgers by ``RolloutState.data_source``, or when you want to run multiple
-# child judgers and merge their outputs with ``merge_fn``.
+# judgers by ``RolloutState.data_source``. A data_source string selects one
+# branch; a data_source dict selects multiple branches and requires ``merge_fn``.
 #
 def build_judger(config: JudgerConfigLike) -> Judger:
     if isinstance(config, ComposedJudgerConfig):

--- a/xtuner/v1/rl/judger/native.py
+++ b/xtuner/v1/rl/judger/native.py
@@ -29,7 +29,7 @@ Judger 体系关系图
      ┌──────────────────────────────────────┐
      │         ComposedJudger               │
      │                                      │
-     │  select_fn → 选 branch → judge       │
+     │  data_source → 选 branch → judge     │
      │  merge_fn  → 合并多个 branch 的结果  │
      │                                      │
      │  branches: dict[str, Judger]         │
@@ -85,6 +85,9 @@ JudgerOutputBatch: TypeAlias = JudgerOutput | list[JudgerOutput]
 
 
 class Judger(ABC):
+    def __init__(self, judger_name: str | None = None):
+        self._judger_name = judger_name or self.__class__.__name__
+
     def preprocess(self, rollout_state: RolloutState) -> JudgerPayload:
         return {
             "response": rollout_state.response,
@@ -105,6 +108,7 @@ class Judger(ABC):
     async def judge(self, rollout_state: list[RolloutState]) -> list[RolloutState]: ...
 
     async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:
+        # batch samples judge
         if isinstance(rollout_state, list):
             payloads = [self.preprocess(state) for state in rollout_state]
             outputs = await self.judge_payload(payloads)
@@ -113,7 +117,7 @@ class Judger(ABC):
             if len(outputs) != len(rollout_state):
                 raise ValueError(f"Judger returned {len(outputs)} outputs for {len(rollout_state)} rollout states.")
             return [self.postprocess(state, output) for state, output in zip(rollout_state, outputs)]
-
+        # single sample judge
         payload = self.preprocess(rollout_state)
         output = await self.judge_payload(payload)
         if isinstance(output, list):
@@ -122,6 +126,9 @@ class Judger(ABC):
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         raise NotImplementedError(f"{self.__class__.__name__}.judge_payload() is not implemented.")
+
+    def get_judger_name(self) -> str:
+        return self._judger_name
 
 
 class NativeJudger(Judger):
@@ -135,7 +142,7 @@ class NativeJudger(Judger):
         extra_info: dict | None = None,
         request_timeout: float = 30.0,
     ):
-        self._judger_name = judger_name
+        super().__init__(judger_name=judger_name)
         self.extra_info = extra_info or {}
         self.reward_handler = reward_handler
         self.request_timeout = request_timeout
@@ -158,6 +165,8 @@ class NativeJudger(Judger):
 
         judger_response = None
         if isinstance(self.reward_handler, str):
+            # TODO: 如果超时或者返回状态错误，会如何？
+            # TODO: 这里不好 try 的原因是在异常情况下，我们应该给 -1 还是 0 分呢？
             async with httpx.AsyncClient(timeout=self.request_timeout) as client:
                 response = await client.post(self.reward_handler, json=input_kwargs)
                 response.raise_for_status()
@@ -174,30 +183,34 @@ class NativeJudger(Judger):
         )
         return cast(JudgerOutput, judger_response)
 
-    def get_judger_name(self) -> str:
-        return self._judger_name
-
 
 class RemoteJudger(Judger):
+    """Driver-side proxy for a Ray-hosted judger.
+
+    ``RemoteJudger`` keeps the same ``Judger`` interface as local judgers, so
+    callers still pass ``RolloutState`` to ``judge``. The base ``Judger`` logic
+    converts that state to a lightweight payload on the driver, then this proxy
+    sends only the payload to ``JudgerActor``. ``JudgerActor`` lives in the Ray
+    worker process and owns the real local judger instance that executes
+    ``judge_payload``.
+    """
+
     def __init__(self, actor: RayJudgerProxy, judger_name: str):
+        super().__init__(judger_name=judger_name)
         self.actor = actor
-        self._judger_name = judger_name
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         return await self.actor.judge_payload.remote(payload)
-
-    def get_judger_name(self) -> str:
-        return self._judger_name
 
 
 class JudgerPool(Judger):
     """Round-robin dispatch across replicas of the same judger type."""
 
     def __init__(self, replicas: list[Judger], judger_name: str):
+        super().__init__(judger_name=judger_name)
         if not replicas:
             raise ValueError("JudgerPool requires at least one replica.")
         self.replicas = replicas
-        self._judger_name = judger_name
         self._rr_index = 0
         self._lock = asyncio.Lock()
         self._worker_loads = dict.fromkeys(range(len(replicas)), 0)
@@ -222,9 +235,6 @@ class JudgerPool(Judger):
 
     def get_worker_status(self) -> dict[str, int]:
         return {f"{self._judger_name}[{idx}]": load for idx, load in self._worker_loads.items()}
-
-    def get_judger_name(self) -> str:
-        return self._judger_name
 
 
 class JudgerConfig(BaseModel):
@@ -271,31 +281,6 @@ class JudgerConfig(BaseModel):
             request_timeout=self.request_timeout,
             extra_info=self.extra_info,
         )
-
-    def _build_remote_actor(self, cpu_resources: CPUResourcesConfig) -> RayJudgerProxy:
-        return CPUActorLauncher.build_actor(
-            JudgerActor,
-            self,
-            actor_num_cpus=cpu_resources.num_cpus_per_worker,
-            actor_memory=cpu_resources.cpu_memory_per_worker,
-        )
-
-    def _build_remote_actors(
-        self,
-        cpu_resources: CPUResourcesConfig,
-    ) -> list[RayJudgerProxy]:
-        return [self._build_remote_actor(cpu_resources) for _ in range(cpu_resources.num_workers)]
-
-    def _build_remote_judger(self, cpu_resources: CPUResourcesConfig) -> Judger:
-        return RemoteJudger(self._build_remote_actor(cpu_resources), judger_name=self.judger_name)
-
-    def _build_remote_judgers(
-        self,
-        cpu_resources: CPUResourcesConfig,
-    ) -> list[Judger]:
-        return [
-            RemoteJudger(actor, judger_name=self.judger_name) for actor in self._build_remote_actors(cpu_resources)
-        ]
 
     def build(self) -> Judger:
         from .factory import build_judger

--- a/xtuner/v1/rl/judger/native.py
+++ b/xtuner/v1/rl/judger/native.py
@@ -63,7 +63,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from abc import ABC
 from typing import Any, Callable, TypeAlias, cast, overload
 
 import httpx
@@ -84,7 +83,7 @@ JudgerOutput: TypeAlias = dict[str, Any]
 JudgerOutputBatch: TypeAlias = JudgerOutput | list[JudgerOutput]
 
 
-class Judger(ABC):
+class Judger:
     def __init__(self, judger_name: str | None = None):
         self._judger_name = judger_name or self.__class__.__name__
 
@@ -147,9 +146,13 @@ class NativeJudger(Judger):
         self.reward_handler = reward_handler
         self.request_timeout = request_timeout
 
+    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState:
+        if isinstance(rollout_state, list):
+            raise NotImplementedError("NativeJudger does not support batch RolloutState input.")
+        return await super().judge(rollout_state)
+
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
-        if isinstance(payload, list):
-            raise NotImplementedError("NativeJudger does not support batch payloads.")
+        assert not isinstance(payload, list), "NativeJudger does not support batch payloads."
         assert payload["response"] is not None, (
             "RolloutState must have a response for judging. You should detokenize the response_ids in AgentLoop"
         )

--- a/xtuner/v1/rl/judger/native.py
+++ b/xtuner/v1/rl/judger/native.py
@@ -5,6 +5,7 @@ Judger 体系关系图
                         ┌─────────────────┐
                         │     Judger      │  ← 所有 judger 的统一接口
                         │   judge(state)  │
+                        │ batch_judge(list)│
                         └────────┬────────┘
                                  │ 继承
               ┌──────────────────┼───────────────────┐
@@ -60,16 +61,16 @@ AgentLoop
 
 批量打分语义
 ------------
-Judger.judge 支持单条 RolloutState 或 list[RolloutState] 两种输入形态。
-但不是所有具体 judger 都支持 batch。比如 NativeJudger 和 CompassVerifierV2
-只支持单条输入，会在 judge(list[RolloutState]) 入口直接报错。
+Judger.judge 只处理单条 RolloutState。需要批量打分时调用
+Judger.batch_judge(list[RolloutState])。不是所有具体 judger 都支持 batch；
+比如 NativeJudger 和 CompassVerifierV2 会在 batch_judge 入口直接报错。
 """
 
 from __future__ import annotations
 
 import asyncio
 import inspect
-from typing import Any, Callable, TypeAlias, cast, overload
+from typing import Any, Callable, TypeAlias, cast
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
@@ -107,27 +108,21 @@ class Judger:
         rollout_state.reward = output
         return rollout_state
 
-    @overload
-    async def judge(self, rollout_state: RolloutState) -> RolloutState: ...
-    @overload
-    async def judge(self, rollout_state: list[RolloutState]) -> list[RolloutState]: ...
-
-    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:
-        # batch samples judge
-        if isinstance(rollout_state, list):
-            payloads = [self.preprocess(state) for state in rollout_state]
-            outputs = await self.judge_payload(payloads)
-            if not isinstance(outputs, list):
-                raise TypeError(f"Judger returned a single output for {len(rollout_state)} rollout states.")
-            if len(outputs) != len(rollout_state):
-                raise ValueError(f"Judger returned {len(outputs)} outputs for {len(rollout_state)} rollout states.")
-            return [self.postprocess(state, output) for state, output in zip(rollout_state, outputs)]
-        # single sample judge
+    async def judge(self, rollout_state: RolloutState) -> RolloutState:
         payload = self.preprocess(rollout_state)
         output = await self.judge_payload(payload)
         if isinstance(output, list):
             raise TypeError("Judger returned a list output for a single rollout state.")
         return self.postprocess(rollout_state, output)
+
+    async def batch_judge(self, rollout_states: list[RolloutState]) -> list[RolloutState]:
+        payloads = [self.preprocess(state) for state in rollout_states]
+        outputs = await self.judge_payload(payloads)
+        if not isinstance(outputs, list):
+            raise TypeError(f"Judger returned a single output for {len(rollout_states)} rollout states.")
+        if len(outputs) != len(rollout_states):
+            raise ValueError(f"Judger returned {len(outputs)} outputs for {len(rollout_states)} rollout states.")
+        return [self.postprocess(state, output) for state, output in zip(rollout_states, outputs)]
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         raise NotImplementedError(f"{self.__class__.__name__}.judge_payload() is not implemented.")
@@ -141,7 +136,7 @@ class NativeJudger(Judger):
     endpoint.
 
     ``NativeJudger`` calls one reward handler for one rollout sample. It does
-    not support ``judge(list[RolloutState])``; callers that need grouped
+    not support ``batch_judge(list[RolloutState])``; callers that need grouped
     routing should use ``ComposedJudger`` or a judger implementation that
     explicitly supports batch payloads.
     """
@@ -158,10 +153,8 @@ class NativeJudger(Judger):
         self.reward_handler = reward_handler
         self.request_timeout = request_timeout
 
-    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState:
-        if isinstance(rollout_state, list):
-            raise NotImplementedError("NativeJudger does not support batch RolloutState input.")
-        return await super().judge(rollout_state)
+    async def batch_judge(self, rollout_states: list[RolloutState]) -> list[RolloutState]:
+        raise NotImplementedError("NativeJudger does not support batch_judge.")
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         assert not isinstance(payload, list), "NativeJudger does not support batch payloads."

--- a/xtuner/v1/rl/judger/native.py
+++ b/xtuner/v1/rl/judger/native.py
@@ -196,16 +196,26 @@ class RemoteJudger(Judger):
     """Driver-side proxy for a Ray-hosted judger.
 
     ``RemoteJudger`` keeps the same ``Judger`` interface as local judgers, so
-    callers still pass ``RolloutState`` to ``judge``. The base ``Judger`` logic
-    converts that state to a lightweight payload on the driver, then this proxy
-    sends only the payload to ``JudgerActor``. ``JudgerActor`` lives in the Ray
-    worker process and owns the real local judger instance that executes
-    ``judge_payload``. Batch support is determined by that actor-side judger.
+    callers still pass ``RolloutState`` to ``judge``. This proxy runs the same
+    ``preprocess`` implementation as the actor-side judger on the driver, then
+    sends only the lightweight payload to ``JudgerActor``. ``JudgerActor`` lives
+    in the Ray worker process and owns the real local judger instance that
+    executes ``judge_payload``. Batch support is determined by that actor-side
+    judger.
     """
 
-    def __init__(self, actor: RayJudgerProxy, judger_name: str):
+    def __init__(self, actor: RayJudgerProxy, judger_name: str, preprocess_judger: Judger | None = None):
         super().__init__(judger_name=judger_name)
         self.actor = actor
+        self.preprocess_judger = preprocess_judger
+
+    # Preprocess must run on the driver before the Ray call. Otherwise the full
+    # RolloutState would be serialized to the actor, and remote branches with
+    # custom preprocess logic would lose the payload fields they require.
+    def preprocess(self, rollout_state: RolloutState) -> JudgerPayload:
+        if self.preprocess_judger is None:
+            return super().preprocess(rollout_state)
+        return self.preprocess_judger.preprocess(rollout_state)
 
     async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         return await self.actor.judge_payload.remote(payload)

--- a/xtuner/v1/rl/judger/native.py
+++ b/xtuner/v1/rl/judger/native.py
@@ -53,8 +53,9 @@ Judger 体系关系图
 ------------------------------------
 AgentLoop
   └─► RemoteJudger.judge(state)
-        └─► JudgerActor.judge.remote(state)   ← Ray 跨进程/机器调用
-              └─► NativeJudger.judge(state)
+        ├─► preprocess(state)                 ← driver 侧提取轻量 payload
+        └─► JudgerActor.judge_payload.remote(payload)
+              └─► NativeJudger.judge_payload(payload)
                     └─► reward_handler(response, label)
 """
 
@@ -62,8 +63,8 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from abc import ABC, abstractmethod
-from typing import Callable, TypeAlias, cast, overload
+from abc import ABC
+from typing import Any, Callable, TypeAlias, cast, overload
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
@@ -77,14 +78,50 @@ from xtuner.v1.utils.type_helper import ray_method
 
 logger = get_logger()
 
+JudgerPayload: TypeAlias = dict[str, Any]
+JudgerPayloadBatch: TypeAlias = JudgerPayload | list[JudgerPayload]
+JudgerOutput: TypeAlias = dict[str, Any]
+JudgerOutputBatch: TypeAlias = JudgerOutput | list[JudgerOutput]
+
 
 class Judger(ABC):
+    def preprocess(self, rollout_state: RolloutState) -> JudgerPayload:
+        return {
+            "response": rollout_state.response,
+            "label": rollout_state.reward_model.get("ground_truth") if rollout_state.reward_model else None,
+            "message": rollout_state.message,
+            "status": rollout_state.status,
+            "data_source": rollout_state.data_source,
+            "task_name": rollout_state.task_name,
+        }
+
+    def postprocess(self, rollout_state: RolloutState, output: JudgerOutput) -> RolloutState:
+        rollout_state.reward = output
+        return rollout_state
+
     @overload
     async def judge(self, rollout_state: RolloutState) -> RolloutState: ...
     @overload
     async def judge(self, rollout_state: list[RolloutState]) -> list[RolloutState]: ...
-    @abstractmethod
-    async def judge(self, rollout_state): ...
+
+    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:
+        if isinstance(rollout_state, list):
+            payloads = [self.preprocess(state) for state in rollout_state]
+            outputs = await self.judge_payload(payloads)
+            if not isinstance(outputs, list):
+                raise TypeError(f"Judger returned a single output for {len(rollout_state)} rollout states.")
+            if len(outputs) != len(rollout_state):
+                raise ValueError(f"Judger returned {len(outputs)} outputs for {len(rollout_state)} rollout states.")
+            return [self.postprocess(state, output) for state, output in zip(rollout_state, outputs)]
+
+        payload = self.preprocess(rollout_state)
+        output = await self.judge_payload(payload)
+        if isinstance(output, list):
+            raise TypeError("Judger returned a list output for a single rollout state.")
+        return self.postprocess(rollout_state, output)
+
+    async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
+        raise NotImplementedError(f"{self.__class__.__name__}.judge_payload() is not implemented.")
 
 
 class NativeJudger(Judger):
@@ -103,18 +140,19 @@ class NativeJudger(Judger):
         self.reward_handler = reward_handler
         self.request_timeout = request_timeout
 
-    @ray_method
-    async def judge(self, rollout_state: RolloutState) -> RolloutState:  # type: ignore[override]
-        assert rollout_state.response is not None, (
+    async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
+        if isinstance(payload, list):
+            raise NotImplementedError("NativeJudger does not support batch payloads.")
+        assert payload["response"] is not None, (
             "RolloutState must have a response for judging. You should detokenize the response_ids in AgentLoop"
         )
-        assert rollout_state.reward_model is not None and "ground_truth" in rollout_state.reward_model, (
-            "RolloutState must have reward_model with 'ground_truth' for judging. You should set reward_model in AgentLoop"
+        assert payload["label"] is not None, (
+            "RolloutState must have reward_model with 'ground_truth' for judging. You should set reward_model in "
+            "AgentLoop"
         )
-
         input_kwargs = {
-            "response": rollout_state.response,
-            "label": rollout_state.reward_model["ground_truth"],
+            "response": payload["response"],
+            "label": payload["label"],
             "extra_info": {**self.extra_info},
         }
 
@@ -134,8 +172,7 @@ class NativeJudger(Judger):
         assert isinstance(judger_response, dict), (
             f"Reward handler must return a dict, but got {type(judger_response)}."
         )
-        rollout_state.reward = judger_response
-        return rollout_state
+        return cast(JudgerOutput, judger_response)
 
     def get_judger_name(self) -> str:
         return self._judger_name
@@ -146,9 +183,8 @@ class RemoteJudger(Judger):
         self.actor = actor
         self._judger_name = judger_name
 
-    @ray_method
-    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:  # type: ignore[override]
-        return await self.actor.judge.remote(rollout_state)
+    async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
+        return await self.actor.judge_payload.remote(payload)
 
     def get_judger_name(self) -> str:
         return self._judger_name
@@ -177,11 +213,10 @@ class JudgerPool(Judger):
         async with self._lock:
             self._worker_loads[replica_idx] -= 1
 
-    @ray_method
-    async def judge(self, rollout_state: RolloutState | list[RolloutState]) -> RolloutState | list[RolloutState]:  # type: ignore[override]
+    async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
         replica_idx, replica = await self._pick_replica()
         try:
-            return await replica.judge(rollout_state)
+            return await replica.judge_payload(payload)
         finally:
             await self._release_replica(replica_idx)
 
@@ -273,8 +308,8 @@ class JudgerActor:
         self.judger = judger_config.build_local()
 
     @ray_method
-    async def judge(self, rollout_state: RolloutState) -> RolloutState:
-        return await self.judger.judge(rollout_state)
+    async def judge_payload(self, payload: JudgerPayloadBatch) -> JudgerOutputBatch:
+        return await self.judger.judge_payload(payload)
 
 
 RayJudger = cast(ActorClass[JudgerActor], CPUActorLauncher.to_actor_class(JudgerActor))

--- a/xtuner/v1/rl/judger/native.py
+++ b/xtuner/v1/rl/judger/native.py
@@ -3,7 +3,7 @@ Judger 体系关系图
 =================
 
                         ┌─────────────────┐
-                        │   Judger (ABC)  │  ← 所有 judger 的统一接口
+                        │     Judger      │  ← 所有 judger 的统一接口
                         │   judge(state)  │
                         └────────┬────────┘
                                  │ 继承
@@ -57,6 +57,12 @@ AgentLoop
         └─► JudgerActor.judge_payload.remote(payload)
               └─► NativeJudger.judge_payload(payload)
                     └─► reward_handler(response, label)
+
+批量打分语义
+------------
+Judger.judge 支持单条 RolloutState 或 list[RolloutState] 两种输入形态。
+但不是所有具体 judger 都支持 batch。比如 NativeJudger 和 CompassVerifierV2
+只支持单条输入，会在 judge(list[RolloutState]) 入口直接报错。
 """
 
 from __future__ import annotations
@@ -132,7 +138,13 @@ class Judger:
 
 class NativeJudger(Judger):
     """Local judger implementation backed by a Python callable or HTTP
-    endpoint."""
+    endpoint.
+
+    ``NativeJudger`` calls one reward handler for one rollout sample. It does
+    not support ``judge(list[RolloutState])``; callers that need grouped
+    routing should use ``ComposedJudger`` or a judger implementation that
+    explicitly supports batch payloads.
+    """
 
     def __init__(
         self,
@@ -195,7 +207,7 @@ class RemoteJudger(Judger):
     converts that state to a lightweight payload on the driver, then this proxy
     sends only the payload to ``JudgerActor``. ``JudgerActor`` lives in the Ray
     worker process and owns the real local judger instance that executes
-    ``judge_payload``.
+    ``judge_payload``. Batch support is determined by that actor-side judger.
     """
 
     def __init__(self, actor: RayJudgerProxy, judger_name: str):


### PR DESCRIPTION
之前 Judger 存在如下问题：
- rolloutstate 直传给 judger，会出现多次没有必要的 ray 序列化开销
- 为了避免同一个 rolloutstate  相互干扰，之前逻辑需要强制 deepcopy(rolloutstate) 不仅带来额外开销，还会引入不可控的卡死风险
- ComposedJudger 逻辑过于复杂

新方案解决了如上问题：
- judger 只传入必要的字段即可，无需 rolloutstate  序列化开销
- 无需额外的 deepcopy(rolloutstate) 保证正确性
- 如果某一条轨迹要经过多个 judge，目前从串行改成了并行
- 简化逻辑
