### PR TITLE
Align async HF non-weight file export

### DIFF
--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -1896,6 +1896,10 @@ class BaseModel(nn.Module):
             f.write(json.dumps(local_status, indent=2))
 
     def _write_hf_non_weight_files(self, hf_dir: Path) -> None:
+        if self.config.hf_config is not None:
+            self.config.save_hf(hf_dir)
+            return
+
         if self._hf_path is not None:
             for file in cast(Path, self._hf_path).iterdir():
                 if file.suffix != ".safetensors":
@@ -1904,10 +1908,6 @@ class BaseModel(nn.Module):
                         copy(file, target_path)
                     else:
                         copytree(file, target_path, ignore_dangling_symlinks=True, dirs_exist_ok=True)
-            return
-
-        if self.config.hf_config is not None:
-            self.config.save_hf(hf_dir)
             return
 
         raise RuntimeError("Internal Error, both self.config.hf_config and self._hf_path are None")

--- a/xtuner/v1/model/compose/base.py
+++ b/xtuner/v1/model/compose/base.py
@@ -2,7 +2,7 @@ import json
 import multiprocessing as py_mp
 from pathlib import Path
 from shutil import rmtree
-from typing import Callable, Self, Sequence
+from typing import Callable, Mapping, Self, Sequence
 
 import torch
 import torch.distributed as dist
@@ -170,6 +170,15 @@ class BaseComposeModel(BaseModel):
             with open(hf_dir / "model.safetensors.index.json", "w") as f:
                 json.dump({"weight_map": weight_map_dict, "metadata": {}}, f, indent=4)
         dist.barrier()
+
+    def _write_hf_index_and_config(self, hf_dir: Path | str, weight_map: Mapping[str, str]) -> None:
+        if isinstance(hf_dir, str):
+            hf_dir = Path(hf_dir)
+
+        self._write_hf_non_weight_files(hf_dir)
+
+        with open(hf_dir / "model.safetensors.index.json", "w") as f:
+            json.dump({"weight_map": dict(weight_map), "metadata": {}}, f, indent=4)
 
     def async_save_hf(
         self,


### PR DESCRIPTION
## Summary
- Align async HF non-weight file export with sync HF by preferring generated HF config when available.
- Keep fallback copying from the original HF path when no hf_config is available.

## Verification
- python3 -m py_compile xtuner/v1/model/base.py
- Compared async/sync HF non-safetensors outputs; config.json and model.safetensors.index.json now match by sha256.