### PR TITLE
[CI] Add RL-specific Claude review guidance

### DIFF
--- a/.github/workflows/claude-general.yml
+++ b/.github/workflows/claude-general.yml
@@ -59,7 +59,22 @@ jobs:
             - Security implications
             - `.claude/CLAUDE.md` compliance
 
-            ### Review Process
+            ### Required Analysis Before Commenting
+            1. Read `.claude/CLAUDE.md` before reviewing. If it references `.claude/rules`, read the relevant files too.
+
+            2. Read the PR title, body, comments, and patch:
+              - `gh pr view <PR NUMBER> --comments`
+              - `gh pr diff <PR NUMBER> --patch`
+
+            3. For each changed contract, search the repository for constructors, readers, writers, fake implementations, and tests.
+
+            4. If the PR changes any code under `xtuner/v1/rl`, the review summary must include:
+              `ProduceBatchResult impact: <impact or "not affected">`
+
+            5. If the PR changes any code related to routed_experts, the review summary must include:
+              `RoutedExperts impact: <impact or "not affected">`
+
+            ### GitHub Commenting Process
 
             1. For every issue, rate how significant it is. Make sure you are confident in your diagnosis.
 
@@ -223,4 +238,3 @@ jobs:
             }
           allowed_non_write_users: "*"
           track_progress: false
-


### PR DESCRIPTION
## Summary

Move RL-specific Claude review requirements out of the generic workflow prompt and into repository review documentation.

## Changes

- Keep `.github/workflows/claude-general.yml` focused on generic review execution: read repo instructions, read PR content, and post GitHub comments.
- Add `.claude/rules/rl_review.md` for PRs that change `xtuner/v1/rl` code.
- Reference the RL review rules from `.claude/CLAUDE.md`.
- Require RL reviews to summarize `ProduceBatchResult impact`, and routed-experts impact when relevant.

## Validation

- `git diff --check origin/main..HEAD`
