### PR TITLE
[Fix] fix rollout worker recovery before colocated training when ep_size = 1

### DIFF
--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -19,6 +19,7 @@ Bad Tests:
 """
 
 import asyncio
+import threading
 import tempfile
 import unittest
 from pathlib import Path
@@ -32,6 +33,7 @@ from xtuner.v1.data_proto.rl_data import RolloutState, Status
 from xtuner.v1.rl.agent_loop_manager import AsyncProduceStrategyConfig, ProduceBatchResult
 from xtuner.v1.rl.agent_loop_manager.agent_loop_manager import AgentLoopManager, _TaskRunner
 from xtuner.v1.rl.replay_buffer import AsyncReplayBufferConfig, SerializedRayObjectRef
+from xtuner.v1.rl.rollout.controller import RolloutController, WorkerInfo
 from xtuner.v1.train.rl_trainer import RLColocateTrainer, RLThroughputBenchmark
 
 
@@ -131,6 +133,7 @@ class TestRLColocateTrainer(unittest.TestCase):
         trainer._benchmark_start_time_s = 100.0
         trainer._benchmark_training_samples = 0
         trainer._benchmark_training_tokens = 0
+        trainer._rollout_config = SimpleNamespace(rollout_timeout=37.0)
         trainer._save_trajectories = MagicMock()
         trainer._sync_weights_and_save = MagicMock(
             side_effect=lambda train_step, step_timer_dict: train_step % trainer._sync_weights_interval == 0
@@ -142,6 +145,9 @@ class TestRLColocateTrainer(unittest.TestCase):
 
         trainer.rollout_controller = SimpleNamespace(
             offload=SimpleNamespace(remote=MagicMock(return_value="rollout_offloaded")),
+            ensure_workers_healthy_before_training=SimpleNamespace(
+                remote=MagicMock(return_value="rollout_ready_for_training")
+            ),
         )
         trainer.train_controller = SimpleNamespace(
             onload=MagicMock(return_value="train_onloaded"),
@@ -180,10 +186,11 @@ class TestRLColocateTrainer(unittest.TestCase):
 
         with (
             patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
-            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
         ):
             trainer.fit()
 
+        trainer.rollout_controller.ensure_workers_healthy_before_training.remote.assert_called_once_with()
         trainer.rollout_controller.offload.remote.assert_called_once_with()
         trainer.train_controller.onload.assert_called_once_with(target="all")
         trainer.train_controller.fit.assert_called_once()
@@ -199,7 +206,7 @@ class TestRLColocateTrainer(unittest.TestCase):
 
         with (
             patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
-            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
         ):
             with self.assertRaisesRegex(AssertionError, "return non-empty rollout_states"):
                 trainer.fit()
@@ -208,6 +215,179 @@ class TestRLColocateTrainer(unittest.TestCase):
         trainer.train_controller.onload.assert_not_called()
         trainer.train_controller.fit.assert_not_called()
         self.assertEqual(trainer._cur_step, 0)
+
+    def test_fit_does_not_onload_train_when_rollout_training_barrier_fails(self):
+        # 验证共卡训练进入训练前必须先通过 rollout phase-switch barrier；
+        # 失败时不能 onload 训练。
+        async def _produce_batch(batch_size, train_step, *, model_step):
+            return ProduceBatchResult(
+                rollout_states=[[SimpleNamespace(message_uid=train_step, uid=train_step)]]
+            )
+
+        trainer = self._make_trainer(SimpleNamespace(produce_batch=_produce_batch))
+        trainer.rollout_controller.ensure_workers_healthy_before_training.remote.side_effect = RuntimeError(
+            "inactive rollout workers before training"
+        )
+
+        with (
+            patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "inactive rollout workers"):
+                trainer.fit()
+
+        trainer.rollout_controller.ensure_workers_healthy_before_training.remote.assert_called_once_with()
+        trainer.rollout_controller.offload.remote.assert_not_called()
+        trainer.train_controller.onload.assert_not_called()
+        trainer.train_controller.fit.assert_not_called()
+        self.assertEqual(trainer._cur_step, 0)
+
+    def test_fit_uses_real_rollout_controller_barrier_to_recover_before_next_rollout(self):
+        # Trainer 只负责调用真实 rollout controller barrier；
+        # recovery 细节由 RolloutController.ensure_workers_healthy_before_training 覆盖。
+        events = []
+        worker_url = "http://worker-0"
+        worker_state = {"healthy": True}
+        workers_info = {}
+
+        class _RemoteAction:
+            def __init__(self, action):
+                self.remote = MagicMock(side_effect=action)
+
+        def check_health():
+            is_healthy = worker_state["healthy"]
+            events.append(("check_health", workers_info[0].is_active, is_healthy))
+            return is_healthy
+
+        def shutdown():
+            events.append(("shutdown", workers_info[0].is_active))
+            self.assertFalse(workers_info[0].is_active)
+
+        def init(*args, **kwargs):
+            events.append(("init", args, kwargs, worker_url))
+            self.assertFalse(workers_info[0].is_active)
+            worker_state["healthy"] = True
+            return 0, worker_url
+
+        def init_dist_port():
+            events.append(("init_dist_port",))
+            return "127.0.0.1:12345"
+
+        def assert_worker_available(event_name):
+            self.assertEqual(workers_info[0].url, worker_url)
+            self.assertTrue(worker_state["healthy"])
+            self.assertTrue(workers_info[0].is_active)
+            events.append((event_name, worker_state["healthy"], workers_info[0].is_active, worker_url))
+
+        worker = SimpleNamespace(
+            check_health=_RemoteAction(check_health),
+            shutdown=_RemoteAction(shutdown),
+            init=_RemoteAction(init),
+            init_dist_port=_RemoteAction(init_dist_port),
+            offload=_RemoteAction(lambda: assert_worker_available("rollout_offload")),
+            onload_weights=_RemoteAction(lambda: assert_worker_available("rollout_onload_weights")),
+            onload_kvcache=_RemoteAction(lambda: assert_worker_available("rollout_onload_kvcache")),
+        )
+        workers_info[0] = WorkerInfo(actor=worker, url=worker_url, is_active=True)
+
+        controller = RolloutController.__new__(RolloutController)
+        controller.rank2info = workers_info
+        controller.worker_info_lock = threading.RLock()
+        controller.health_checker = SimpleNamespace(
+            pause=lambda: events.append(("health_pause",)),
+            resume=lambda: events.append(("health_resume",)),
+            stop=lambda: events.append(("health_stop",)),
+        )
+        controller.logger = MagicMock()
+
+        class _LocalRolloutControllerProxy:
+            def __init__(self, real_controller):
+                self.ensure_workers_healthy_before_training = _RemoteAction(
+                    real_controller.ensure_workers_healthy_before_training
+                )
+                self.offload = _RemoteAction(real_controller.offload)
+                self.onload_weights = _RemoteAction(real_controller.onload_weights)
+                self.onload_kvcache = _RemoteAction(real_controller.onload_kvcache)
+
+        rollout_controller = _LocalRolloutControllerProxy(controller)
+        produce_calls = []
+
+        async def _produce_batch(batch_size, train_step, *, model_step):
+            produce_calls.append((batch_size, train_step, model_step))
+            events.append(("rollout", train_step, worker_state["healthy"], workers_info[0].is_active, worker_url))
+            if train_step == 1:
+                worker_state["healthy"] = False
+                events.append(("worker_failed", train_step, worker_url))
+            else:
+                self.assertTrue(worker_state["healthy"])
+                self.assertTrue(workers_info[0].is_active)
+                self.assertEqual(workers_info[0].url, worker_url)
+            return ProduceBatchResult(
+                rollout_states=[[SimpleNamespace(message_uid=train_step, uid=train_step)]]
+            )
+
+        trainer = self._make_trainer(
+            SimpleNamespace(produce_batch=_produce_batch),
+            total_train_steps=2,
+            sync_weights_interval=10,
+        )
+        trainer.rollout_controller = rollout_controller
+        trainer.train_controller.onload = MagicMock(side_effect=lambda target: events.append(("train_onload", target)))
+        trainer.train_controller.fit = MagicMock(
+            side_effect=lambda *args, rollout_idx, **kwargs: events.append(("train_fit", rollout_idx)) or []
+        )
+
+        def sync_rollout_after_train(train_step, step_timer_dict):
+            events.append(("sync_after_train", train_step))
+            rollout_controller.onload_weights.remote()
+            rollout_controller.onload_kvcache.remote()
+            return False
+
+        trainer._sync_weights_and_save = MagicMock(side_effect=sync_rollout_after_train)
+
+        with (
+            patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
+        ):
+            trainer.fit()
+
+        self.assertEqual(produce_calls, [(1, 1, 0), (1, 2, 0)])
+        self.assertEqual(workers_info[0].url, worker_url)
+        self.assertTrue(worker_state["healthy"])
+        self.assertTrue(workers_info[0].is_active)
+        self.assertEqual([event[0] for event in events].count("init"), 1)
+        self.assertNotIn(("init_dist_port",), events)
+        self.assertEqual(trainer.train_controller.fit.call_count, 2)
+        self.assertEqual(trainer._cur_step, 2)
+        self.assertLess(
+            events.index(("worker_failed", 1, worker_url)),
+            events.index(("check_health", True, False)),
+        )
+        self.assertLess(events.index(("check_health", True, False)), events.index(("shutdown", False)))
+        self.assertLess(events.index(("shutdown", False)), events.index(("init", (), {}, worker_url)))
+        self.assertLess(
+            events.index(("init", (), {}, worker_url)),
+            events.index(("check_health", False, True)),
+        )
+        self.assertLess(
+            events.index(("check_health", False, True)),
+            events.index(("rollout_offload", True, True, worker_url)),
+        )
+        self.assertLess(
+            events.index(("rollout_offload", True, True, worker_url)),
+            events.index(("train_onload", "all")),
+        )
+        self.assertLess(events.index(("train_onload", "all")), events.index(("train_fit", 1)))
+        self.assertLess(events.index(("train_fit", 1)), events.index(("sync_after_train", 1)))
+        self.assertLess(
+            events.index(("rollout_onload_weights", True, True, worker_url)),
+            events.index(("rollout", 2, True, True, worker_url)),
+        )
+        self.assertLess(
+            events.index(("rollout_onload_kvcache", True, True, worker_url)),
+            events.index(("rollout", 2, True, True, worker_url)),
+        )
+        self.assertIn(("rollout", 2, True, True, worker_url), events)
 
     def test_fit_uses_sync_interval_and_passes_rollout_model_step(self):
         # 验证 rollout 看到的是按 sync interval 推进后的 model_step。
@@ -226,7 +406,7 @@ class TestRLColocateTrainer(unittest.TestCase):
         )
         with (
             patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
-            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
         ):
             trainer.fit()
 
@@ -252,7 +432,7 @@ class TestRLColocateTrainer(unittest.TestCase):
 
         with (
             patch("xtuner.v1.train.rl_trainer.asyncio_run", side_effect=asyncio.run),
-            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj: obj),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
         ):
             trainer.fit()
 

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -293,9 +293,24 @@ class TestRLColocateTrainer(unittest.TestCase):
         controller = RolloutController.__new__(RolloutController)
         controller.rank2info = workers_info
         controller.worker_info_lock = threading.RLock()
+        health_checker_state = {"paused": False}
+
+        def is_health_checker_paused():
+            events.append(("health_is_paused", health_checker_state["paused"]))
+            return health_checker_state["paused"]
+
+        def pause_health_checker():
+            events.append(("health_pause",))
+            health_checker_state["paused"] = True
+
+        def resume_health_checker():
+            events.append(("health_resume",))
+            health_checker_state["paused"] = False
+
         controller.health_checker = SimpleNamespace(
-            pause=lambda: events.append(("health_pause",)),
-            resume=lambda: events.append(("health_resume",)),
+            is_paused=is_health_checker_paused,
+            pause=pause_health_checker,
+            resume=resume_health_checker,
             stop=lambda: events.append(("health_stop",)),
         )
         controller.logger = MagicMock()
@@ -363,14 +378,21 @@ class TestRLColocateTrainer(unittest.TestCase):
             events.index(("worker_failed", 1, worker_url)),
             events.index(("check_health", True, False)),
         )
+        self.assertLess(events.index(("health_is_paused", False)), events.index(("health_pause",)))
+        self.assertLess(events.index(("health_pause",)), events.index(("check_health", True, False)))
         self.assertLess(events.index(("check_health", True, False)), events.index(("shutdown", False)))
-        self.assertLess(events.index(("shutdown", False)), events.index(("init", (), {}, worker_url)))
+        restart_event = ("init", (), {}, worker_url)
+        self.assertLess(events.index(("shutdown", False)), events.index(restart_event))
         self.assertLess(
-            events.index(("init", (), {}, worker_url)),
+            events.index(restart_event),
             events.index(("check_health", False, True)),
         )
         self.assertLess(
             events.index(("check_health", False, True)),
+            events.index(("health_resume",)),
+        )
+        self.assertLess(
+            events.index(("health_resume",)),
             events.index(("rollout_offload", True, True, worker_url)),
         )
         self.assertLess(

--- a/tests/rl/test_rl_trainer_checkpoint.py
+++ b/tests/rl/test_rl_trainer_checkpoint.py
@@ -85,6 +85,7 @@ class _FakeRolloutController:
         self.pause_generation = _RemoteMethod(async_result=True)
         self.continue_generation = _RemoteMethod(async_result=True)
         self.offload = _RemoteMethod(return_value="rollout_offloaded")
+        self.ensure_workers_healthy_before_training = _RemoteMethod(return_value="rollout_ready_for_training")
         self.recover_failed_workers = _RemoteMethod(return_value="rollout_recovered")
         self.onload_weights = _RemoteMethod(return_value="weights_loaded")
         self.onload_kvcache = _RemoteMethod(return_value="kvcache_loaded")

--- a/tests/rl/test_rollout_utils.py
+++ b/tests/rl/test_rollout_utils.py
@@ -23,6 +23,41 @@ RESOURCE_MAP = {"npu": "NPU", "cuda": "GPU"}
 TEST_TEXT_MESSAGES=[{"role": "user", "content": "Hello!"}]
 
 
+class _FakeControllerRemoteMethod:
+    def __init__(self, name, call_log, return_value=None):
+        self.name = name
+        self.call_log = call_log
+        self.return_value = return_value if return_value is not None else name
+
+    def remote(self, *args, **kwargs):
+        self.call_log.append((self.name, args, kwargs))
+        if isinstance(self.return_value, list):
+            if len(self.return_value) > 1:
+                value = self.return_value.pop(0)
+            else:
+                value = self.return_value[0]
+            if isinstance(value, Exception):
+                raise value
+            return value
+        if isinstance(self.return_value, Exception):
+            raise self.return_value
+        return self.return_value
+
+
+class _FakeControllerHealthChecker:
+    def __init__(self):
+        self.call_log = []
+
+    def pause(self):
+        self.call_log.append("pause")
+
+    def run_once(self):
+        self.call_log.append("run_once")
+
+    def resume(self):
+        self.call_log.append("resume")
+
+
 class _FakeRemoteMethod:
     def __init__(self, name, call_log):
         self.name = name
@@ -90,6 +125,160 @@ class TestRolloutHealthChecker(unittest.TestCase):
         check_worker_health_mock.assert_not_called()
         ray_get_mock.assert_not_called()
         self.assertEqual(worker.call_log, [])
+
+
+class TestRolloutControllerTrainingBarrier(unittest.TestCase):
+    def _build_controller(self, workers_info):
+        controller = RolloutController.__new__(RolloutController)
+        controller.rank2info = workers_info
+        controller.worker_info_lock = threading.RLock()
+        controller.health_checker = _FakeControllerHealthChecker()
+        controller.logger = SimpleNamespace(
+            info=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+            error=lambda *args, **kwargs: None,
+            exception=lambda *args, **kwargs: None,
+        )
+        return controller
+
+    def _ray_get(self, ref, timeout=None):
+        if isinstance(ref, list):
+            return ref
+        return ref
+
+    def _remote(self, func):
+        return SimpleNamespace(remote=func)
+
+    def test_ensure_workers_healthy_before_training_recovers_with_original_url(self):
+        # recovery 必须在原 URL 上重启成功，才能允许共卡训练继续。
+        call_log = []
+        health_results = [False, True]
+
+        def check_health():
+            result = health_results.pop(0)
+            call_log.append(("check_health", workers_info[0].is_active, result))
+            return result
+
+        def shutdown():
+            call_log.append(("shutdown", workers_info[0].is_active))
+
+        def init(*args, **kwargs):
+            call_log.append(("init", args, kwargs))
+            return 0, "http://worker-0"
+
+        def init_dist_port():
+            call_log.append(("init_dist_port",))
+            return "127.0.0.1:12345"
+
+        worker = SimpleNamespace(
+            offload=_FakeControllerRemoteMethod("offload", call_log),
+            shutdown=self._remote(shutdown),
+            init_dist_port=self._remote(init_dist_port),
+            init=self._remote(init),
+            check_health=self._remote(check_health),
+        )
+        workers_info = {0: WorkerInfo(actor=worker, url="http://worker-0", is_active=True)}
+        controller = self._build_controller(workers_info)
+
+        with patch("xtuner.v1.rl.rollout.controller.ray.get", side_effect=self._ray_get):
+            controller.ensure_workers_healthy_before_training()
+
+        self.assertTrue(workers_info[0].is_active)
+        self.assertEqual(workers_info[0].url, "http://worker-0")
+        self.assertEqual(
+            call_log,
+            [
+                ("check_health", True, False),
+                ("shutdown", False),
+                ("init", (), {}),
+                ("check_health", False, True),
+            ],
+        )
+
+    def test_ensure_workers_healthy_before_training_fails_if_restarted_url_changes(self):
+        # recovery 后 URL 改变时，不能允许共卡训练继续。
+        call_log = []
+
+        def check_health():
+            call_log.append(("check_health", workers_info[0].is_active, False))
+            return False
+
+        def shutdown():
+            call_log.append(("shutdown", workers_info[0].is_active))
+
+        def init(*args, **kwargs):
+            call_log.append(("init", args, kwargs))
+            return 0, "http://worker-0-new"
+
+        def init_dist_port():
+            call_log.append(("init_dist_port",))
+            return "127.0.0.1:12345"
+
+        worker = SimpleNamespace(
+            offload=_FakeControllerRemoteMethod("offload", call_log),
+            shutdown=self._remote(shutdown),
+            init_dist_port=self._remote(init_dist_port),
+            init=self._remote(init),
+            check_health=self._remote(check_health),
+        )
+        workers_info = {0: WorkerInfo(actor=worker, url="http://worker-0", is_active=True)}
+        controller = self._build_controller(workers_info)
+
+        with patch("xtuner.v1.rl.rollout.controller.ray.get", side_effect=self._ray_get):
+            with self.assertRaisesRegex(RuntimeError, "inactive rollout workers before training"):
+                controller.ensure_workers_healthy_before_training()
+
+        self.assertFalse(workers_info[0].is_active)
+        self.assertEqual(workers_info[0].url, "http://worker-0")
+        self.assertEqual(
+            call_log,
+            [
+                ("check_health", True, False),
+                ("shutdown", False),
+                ("init", (), {}),
+            ],
+        )
+
+    def test_ensure_workers_healthy_before_training_fails_if_worker_cannot_recover(self):
+        # recover 失败时不能进入训练，也不能执行最终 offload 伪装成安全。
+        call_log = []
+        worker = SimpleNamespace(
+            offload=_FakeControllerRemoteMethod("offload", call_log),
+            shutdown=_FakeControllerRemoteMethod("shutdown", call_log),
+            init_dist_port=_FakeControllerRemoteMethod("init_dist_port", call_log, "127.0.0.1:12345"),
+            init=_FakeControllerRemoteMethod("init", call_log, (0, "http://worker-0")),
+            check_health=_FakeControllerRemoteMethod("check_health", call_log, False),
+        )
+        workers_info = {0: WorkerInfo(actor=worker, url="http://worker-0", is_active=False)}
+        controller = self._build_controller(workers_info)
+
+        with patch("xtuner.v1.rl.rollout.controller.ray.get", side_effect=self._ray_get):
+            with self.assertRaisesRegex(RuntimeError, "inactive rollout workers before training"):
+                controller.ensure_workers_healthy_before_training()
+
+        self.assertFalse(workers_info[0].is_active)
+        self.assertNotEqual(call_log[-1], ("offload", (), {}))
+
+    def test_ensure_workers_healthy_before_training_fails_if_shutdown_fails(self):
+        # 旧 rollout server 不能确认释放时，不能继续进入共卡训练。
+        call_log = []
+        worker = SimpleNamespace(
+            offload=_FakeControllerRemoteMethod("offload", call_log),
+            shutdown=_FakeControllerRemoteMethod("shutdown", call_log, RuntimeError("shutdown failed")),
+            init_dist_port=_FakeControllerRemoteMethod("init_dist_port", call_log, "127.0.0.1:12345"),
+            init=_FakeControllerRemoteMethod("init", call_log, (0, "http://worker-0")),
+            check_health=_FakeControllerRemoteMethod("check_health", call_log, False),
+        )
+        workers_info = {0: WorkerInfo(actor=worker, url="http://worker-0", is_active=True)}
+        controller = self._build_controller(workers_info)
+
+        with patch("xtuner.v1.rl.rollout.controller.ray.get", side_effect=self._ray_get):
+            with self.assertRaisesRegex(RuntimeError, "inactive rollout workers before training"):
+                controller.ensure_workers_healthy_before_training()
+
+        self.assertFalse(workers_info[0].is_active)
+        self.assertIn(("shutdown", (), {}), call_log)
+        self.assertNotIn(("init", (), {}), call_log)
 
 
 class TestPartialRolloutHandler(unittest.IsolatedAsyncioTestCase):
@@ -206,7 +395,7 @@ class TestRolloutControllerRecover(unittest.TestCase):
         out = asyncio_run(controller.generate(rollout_state))
         self.assertEqual(out.status, Status.FAILED)
 
-        controller.recover_failed_workers()
+        controller.ensure_workers_healthy_before_training()
 
         self.assertTrue(controller.rank2info[rank0].is_active)
         self.assertEqual(url, controller.rank2info[rank0].url)

--- a/tests/rl/test_rollout_utils.py
+++ b/tests/rl/test_rollout_utils.py
@@ -45,17 +45,24 @@ class _FakeControllerRemoteMethod:
 
 
 class _FakeControllerHealthChecker:
-    def __init__(self):
-        self.call_log = []
+    def __init__(self, paused=True, call_log=None):
+        self.call_log = call_log if call_log is not None else []
+        self._paused = paused
+
+    def is_paused(self):
+        self.call_log.append("health_is_paused")
+        return self._paused
 
     def pause(self):
-        self.call_log.append("pause")
+        self.call_log.append("health_pause")
+        self._paused = True
 
     def run_once(self):
         self.call_log.append("run_once")
 
     def resume(self):
-        self.call_log.append("resume")
+        self.call_log.append("health_resume")
+        self._paused = False
 
 
 class _FakeRemoteMethod:
@@ -79,6 +86,15 @@ class TestRolloutHealthChecker(unittest.TestCase):
     def _build_checker(self, workers_info):
         config = SimpleNamespace(health_check_interval_seconds=10, health_check_failure_threshold=1)
         return RolloutHealthChecker(config, workers_info)
+
+    def test_stopped_checker_is_treated_as_paused(self):
+        checker = self._build_checker({})
+        checker.start()
+        checker.resume()
+
+        checker.stop()
+
+        self.assertTrue(checker.is_paused())
 
     def test_shutdown_runs_when_offload_fails(self):
         worker = _FakeWorker()
@@ -128,11 +144,11 @@ class TestRolloutHealthChecker(unittest.TestCase):
 
 
 class TestRolloutControllerTrainingBarrier(unittest.TestCase):
-    def _build_controller(self, workers_info):
+    def _build_controller(self, workers_info, health_checker=None):
         controller = RolloutController.__new__(RolloutController)
         controller.rank2info = workers_info
         controller.worker_info_lock = threading.RLock()
-        controller.health_checker = _FakeControllerHealthChecker()
+        controller.health_checker = health_checker or _FakeControllerHealthChecker()
         controller.logger = SimpleNamespace(
             info=lambda *args, **kwargs: None,
             warning=lambda *args, **kwargs: None,
@@ -195,8 +211,8 @@ class TestRolloutControllerTrainingBarrier(unittest.TestCase):
             ],
         )
 
-    def test_ensure_workers_healthy_before_training_fails_if_restarted_url_changes(self):
-        # recovery 后 URL 改变时，不能允许共卡训练继续。
+    def test_ensure_workers_healthy_before_training_asserts_if_restarted_url_changes(self):
+        # recovery 重启后的 URL 必须保持不变，否则权重同步会连到错误服务。
         call_log = []
 
         def check_health():
@@ -209,6 +225,45 @@ class TestRolloutControllerTrainingBarrier(unittest.TestCase):
         def init(*args, **kwargs):
             call_log.append(("init", args, kwargs))
             return 0, "http://worker-0-new"
+
+        worker = SimpleNamespace(
+            offload=_FakeControllerRemoteMethod("offload", call_log),
+            shutdown=self._remote(shutdown),
+            init=self._remote(init),
+            check_health=self._remote(check_health),
+        )
+        workers_info = {0: WorkerInfo(actor=worker, url="http://worker-0", is_active=True)}
+        controller = self._build_controller(workers_info)
+
+        with patch("xtuner.v1.rl.rollout.controller.ray.get", side_effect=self._ray_get):
+            with self.assertRaisesRegex(AssertionError, "unexpected URL"):
+                controller.ensure_workers_healthy_before_training()
+
+        self.assertFalse(workers_info[0].is_active)
+        self.assertEqual(workers_info[0].url, "http://worker-0")
+        self.assertEqual(
+            call_log,
+            [
+                ("check_health", True, False),
+                ("shutdown", False),
+                ("init", (), {}),
+            ],
+        )
+
+    def test_ensure_workers_healthy_before_training_fails_if_restart_health_check_fails(self):
+        # recovery 必须用原 URL 重启；重启后仍不健康时不能允许共卡训练继续。
+        call_log = []
+
+        def check_health():
+            call_log.append(("check_health", workers_info[0].is_active, False))
+            return False
+
+        def shutdown():
+            call_log.append(("shutdown", workers_info[0].is_active))
+
+        def init(*args, **kwargs):
+            call_log.append(("init", args, kwargs))
+            return 0, "http://worker-0"
 
         def init_dist_port():
             call_log.append(("init_dist_port",))
@@ -236,6 +291,7 @@ class TestRolloutControllerTrainingBarrier(unittest.TestCase):
                 ("check_health", True, False),
                 ("shutdown", False),
                 ("init", (), {}),
+                ("check_health", False, False),
             ],
         )
 
@@ -278,7 +334,7 @@ class TestRolloutControllerTrainingBarrier(unittest.TestCase):
 
         self.assertFalse(workers_info[0].is_active)
         self.assertIn(("shutdown", (), {}), call_log)
-        self.assertNotIn(("init", (), {}), call_log)
+        self.assertFalse(any(call[0] == "init" for call in call_log))
 
 
 class TestPartialRolloutHandler(unittest.IsolatedAsyncioTestCase):

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -273,6 +273,46 @@ class RolloutController:
         if failed_worker_urls:
             self.logger.warning(f"Abort request failed: worker_urls={failed_worker_urls}")
 
+    def ensure_workers_healthy_before_training(self):
+        """Ensure rollout workers are healthy before colocated training
+        onloads."""
+        self.health_checker.pause()
+        with self.worker_info_lock:
+            workers = {rank: (info.actor, info.url, info.is_active) for rank, info in self.rank2info.items()}
+
+        for rank, (actor, url, was_active) in workers.items():
+            try:
+                is_healthy = ray.get(actor.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            except Exception as e:
+                is_healthy = False
+                self.logger.warning(f"Final health check raised for rollout worker {rank} at {url}: {e}.")
+
+            if not is_healthy:
+                self.logger.warning(f"Final health check failed for rollout worker {rank} at {url}.")
+
+            with self.worker_info_lock:
+                info = self.rank2info[rank]
+                info.is_active = bool(is_healthy)
+
+            if is_healthy and not was_active:
+                self.logger.info(f"Mark rollout worker {rank} active after final health check: url={url}")
+            elif not is_healthy and was_active:
+                self.logger.warning(
+                    f"Mark rollout worker {rank} inactive because final health check failed before training: url={url}"
+                )
+
+        self._recover_failed_workers()
+        with self.worker_info_lock:
+            inactive_workers = [
+                f"rank={rank}, url={info.url}" for rank, info in self.rank2info.items() if not info.is_active
+            ]
+        if inactive_workers:
+            raise RuntimeError(
+                "inactive rollout workers before training: "
+                + ", ".join(inactive_workers)
+                + ". Refusing to onload training workers because rollout GPU memory may still be held."
+            )
+
     def continue_generation(self):
         self.health_checker.resume()
         self._broadcast_to_active_workers("continue_generation")
@@ -299,29 +339,36 @@ class RolloutController:
         self.health_checker.stop()
         self._broadcast_to_active_workers("shutdown")
 
-    def recover_failed_workers(self):
-        """Recovers from worker failures by restarting failed workers and
-        reinitializing the rollout setup."""
+    def _recover_failed_workers(self) -> None:
+        """Recover inactive workers before training while keeping health checks
+        paused."""
         self.health_checker.pause()
         with self.worker_info_lock:
             failed_workers = [info for info in self.rank2info.values() if not info.is_active]
+
         if not failed_workers:
             self.logger.info("No failed workers detected during recovery.")
             return
 
         self.logger.warning(f"Detected {len(failed_workers)} failed workers. Initiating recovery process.")
         for worker in failed_workers:
-            if self._restart_failed_workers(worker.actor):
+            if self._restart_failed_workers(worker.actor, expected_url=worker.url):
                 with self.worker_info_lock:
                     rank = self._get_rank_by_actor(worker.actor)
                     if rank is not None:
                         self.rank2info[rank].is_active = True
-        self.health_checker.resume()
 
-    def _restart_failed_workers(self, worker: RolloutWorker) -> bool:
+    def _restart_failed_workers(self, worker: RolloutWorker, expected_url: str) -> bool:
         try:
-            dist_init_addr = ray.get(worker.init_dist_port.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            _, url = ray.get(worker.init.remote(dist_init_addr), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            # 先保证把老的worker关掉
+            ray.get(worker.shutdown.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            # 保证新的worker启动在之前的端口上，否则权重更新会出错
+            _, url = ray.get(worker.init.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            if url != expected_url:
+                self.logger.error(
+                    f"Worker {worker} restarted with unexpected URL {url}; expected original URL {expected_url}."
+                )
+                return False
             is_healthy = ray.get(worker.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
             if is_healthy:
                 self.logger.info(f"Successfully restarted worker {worker} with URL {url}.")

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -342,7 +342,6 @@ class RolloutController:
     def _recover_failed_workers(self) -> None:
         """Recover inactive workers before training while keeping health checks
         paused."""
-        self.health_checker.pause()
         with self.worker_info_lock:
             failed_workers = [info for info in self.rank2info.values() if not info.is_active]
 
@@ -363,12 +362,7 @@ class RolloutController:
             # 先保证把老的worker关掉
             ray.get(worker.shutdown.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
             # 保证新的worker启动在之前的端口上，否则权重更新会出错
-            _, url = ray.get(worker.init.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            if url != expected_url:
-                self.logger.error(
-                    f"Worker {worker} restarted with unexpected URL {url}; expected original URL {expected_url}."
-                )
-                return False
+            _, url = ray.get(worker.init.remote(dist_init_addr=expected_url), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
             is_healthy = ray.get(worker.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
             if is_healthy:
                 self.logger.info(f"Successfully restarted worker {worker} with URL {url}.")

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -276,42 +276,48 @@ class RolloutController:
     def ensure_workers_healthy_before_training(self):
         """Ensure rollout workers are healthy before colocated training
         onloads."""
-        self.health_checker.pause()
-        with self.worker_info_lock:
-            workers = {rank: (info.actor, info.url, info.is_active) for rank, info in self.rank2info.items()}
-
-        for rank, (actor, url, was_active) in workers.items():
-            try:
-                is_healthy = ray.get(actor.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            except Exception as e:
-                is_healthy = False
-                self.logger.warning(f"Final health check raised for rollout worker {rank} at {url}: {e}.")
-
-            if not is_healthy:
-                self.logger.warning(f"Final health check failed for rollout worker {rank} at {url}.")
-
+        health_checker_was_paused = self.health_checker.is_paused()
+        if not health_checker_was_paused:
+            self.health_checker.pause()
+        try:
             with self.worker_info_lock:
-                info = self.rank2info[rank]
-                info.is_active = bool(is_healthy)
+                workers = {rank: (info.actor, info.url, info.is_active) for rank, info in self.rank2info.items()}
 
-            if is_healthy and not was_active:
-                self.logger.info(f"Mark rollout worker {rank} active after final health check: url={url}")
-            elif not is_healthy and was_active:
-                self.logger.warning(
-                    f"Mark rollout worker {rank} inactive because final health check failed before training: url={url}"
+            for rank, (actor, url, was_active) in workers.items():
+                try:
+                    is_healthy = ray.get(actor.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+                except Exception as e:
+                    is_healthy = False
+                    self.logger.warning(f"Final health check raised for rollout worker {rank} at {url}: {e}.")
+
+                if not is_healthy:
+                    self.logger.warning(f"Final health check failed for rollout worker {rank} at {url}.")
+
+                with self.worker_info_lock:
+                    info = self.rank2info[rank]
+                    info.is_active = bool(is_healthy)
+
+                if is_healthy and not was_active:
+                    self.logger.info(f"Mark rollout worker {rank} active after final health check: url={url}")
+                elif not is_healthy and was_active:
+                    self.logger.warning(
+                        f"Mark rollout worker {rank} inactive because final health check failed before training: url={url}"
+                    )
+
+            self._recover_failed_workers()
+            with self.worker_info_lock:
+                inactive_workers = [
+                    f"rank={rank}, url={info.url}" for rank, info in self.rank2info.items() if not info.is_active
+                ]
+            if inactive_workers:
+                raise RuntimeError(
+                    "inactive rollout workers before training: "
+                    + ", ".join(inactive_workers)
+                    + ". Refusing to onload training workers because rollout GPU memory may still be held."
                 )
-
-        self._recover_failed_workers()
-        with self.worker_info_lock:
-            inactive_workers = [
-                f"rank={rank}, url={info.url}" for rank, info in self.rank2info.items() if not info.is_active
-            ]
-        if inactive_workers:
-            raise RuntimeError(
-                "inactive rollout workers before training: "
-                + ", ".join(inactive_workers)
-                + ". Refusing to onload training workers because rollout GPU memory may still be held."
-            )
+        finally:
+            if not health_checker_was_paused:
+                self.health_checker.resume()
 
     def continue_generation(self):
         self.health_checker.resume()
@@ -362,7 +368,8 @@ class RolloutController:
             # 先保证把老的worker关掉
             ray.get(worker.shutdown.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
             # 保证新的worker启动在之前的端口上，否则权重更新会出错
-            _, url = ray.get(worker.init.remote(dist_init_addr=expected_url), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            _, url = ray.get(worker.init.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            assert url == expected_url, f"Worker restarted with unexpected URL: expected {expected_url}, got {url}."
             is_healthy = ray.get(worker.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
             if is_healthy:
                 self.logger.info(f"Successfully restarted worker {worker} with URL {url}.")
@@ -370,6 +377,8 @@ class RolloutController:
             else:
                 self.logger.error(f"Worker {worker} is still unhealthy after restart.")
                 return False
+        except AssertionError:
+            raise
         except Exception as e:
             self.logger.error(f"Failed to restart worker: {e}")
             return False

--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -163,7 +163,7 @@ class LMDeployWorker(RolloutWorker):
         url = f"{self.server_url}/{self.endpoints['sleep']}"
         headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.api_keys}"}
         data = {"level": level}
-        response = requests.post(url, headers=headers, params=data)
+        response = requests.post(url, headers=headers, params=data, timeout=60)
         assert response.status_code == 200, response.status_code
         return response.text
 
@@ -180,7 +180,7 @@ class LMDeployWorker(RolloutWorker):
         url = f"{self.server_url}/{self.endpoints['wake_up']}"
         headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.api_keys}"}
         data = {"tags": tags}
-        response = requests.post(url, headers=headers, params=data)
+        response = requests.post(url, headers=headers, params=data, timeout=60)
         assert response.status_code == 200, response.status_code
         return response.text
 

--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -223,6 +223,7 @@ class LMDeployWorker(RolloutWorker):
         # Therefore, each server only needs to handle 1 / dp_size of the total requests
         max_batch_size = self.config.rollout_max_batch_size_per_instance // dp_size
         distributed_executor_backend = lmdeploy_config_kwargs.get("distributed_executor_backend", "ray")
+        lmdeploy_config_kwargs["allow_terminate_by_client"] = True
         lmdeploy_config_kwargs["log_level"] = lmdeploy_config_kwargs.pop("log_level", "ERROR")
         lmdeploy_config_kwargs["uvicorn_log_level"] = lmdeploy_config_kwargs.pop("uvicorn_log_level", "ERROR")
         lmdeploy_config_kwargs["tm_log_level"] = lmdeploy_config_kwargs.pop("tm_log_level", "ERROR")

--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -184,6 +184,24 @@ class LMDeployWorker(RolloutWorker):
         assert response.status_code == 200, response.status_code
         return response.text
 
+    def _request_server_terminate(self) -> bool:
+        """Ask the inference server to terminate itself if it supports it."""
+        terminate_url = f"{self.server_url}/terminate"
+        try:
+            response = requests.get(terminate_url, timeout=5.0)
+        except requests.RequestException as e:
+            self.logger.debug(f"Worker {self.rank} terminate request failed for {terminate_url}: {e}")
+            return False
+
+        if response.status_code == 200:
+            self.logger.debug(f"Worker {self.rank} terminate request accepted by {terminate_url}.")
+            return True
+
+        self.logger.debug(
+            f"Worker {self.rank} terminate request to {terminate_url} returned status {response.status_code}."
+        )
+        return False
+
     async def _decode_routed_experts(self, routed_experts: Any) -> Any:
         if isinstance(routed_experts, str):
             if self.lmdeploy_actor is None:

--- a/xtuner/v1/rl/rollout/sglang.py
+++ b/xtuner/v1/rl/rollout/sglang.py
@@ -293,6 +293,10 @@ class SGLangWorker(RolloutWorker):
 
         return sglang_server_args
 
+    def _request_server_terminate(self) -> bool:
+        self.logger.warning("SGLang server does not support terminate request, will directly kill the process.")
+        return True
+
     def _transform_sample_params(self, sample_params: Dict):
         if sample_params["top_p"] > 0:
             sample_params["top_k"] = -1  # top_p优先级更高

--- a/xtuner/v1/rl/rollout/utils.py
+++ b/xtuner/v1/rl/rollout/utils.py
@@ -139,6 +139,7 @@ class RolloutHealthChecker:
         self._thread.join(timeout=5)
         self._thread = None
         self._stop_event = None
+        self._pause_event = None
         logger.info("RolloutHealthChecker stopped.")
 
     def pause(self) -> None:
@@ -146,6 +147,9 @@ class RolloutHealthChecker:
             return
         self._pause_event.set()
         logger.info("RolloutHealthChecker paused.")
+
+    def is_paused(self) -> bool:
+        return self._pause_event is None or self._pause_event.is_set()
 
     def resume(self) -> None:
         if self._pause_event is None:

--- a/xtuner/v1/rl/rollout/vllm.py
+++ b/xtuner/v1/rl/rollout/vllm.py
@@ -440,5 +440,5 @@ class vLLMWorker(RolloutWorker):
         return rollout_state
 
     def _request_server_terminate(self) -> bool:
-        self.logger.warning("SGLang server does not support terminate request, will directly kill the process.")
+        self.logger.warning("VLLM server does not support terminate request, will directly kill the process.")
         return True

--- a/xtuner/v1/rl/rollout/vllm.py
+++ b/xtuner/v1/rl/rollout/vllm.py
@@ -438,3 +438,7 @@ class vLLMWorker(RolloutWorker):
         rollout_state.status = rollout_status
 
         return rollout_state
+
+    def _request_server_terminate(self) -> bool:
+        self.logger.warning("SGLang server does not support terminate request, will directly kill the process.")
+        return True

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -586,7 +586,9 @@ class RolloutWorker(SingleAcceleratorWorker):
     def shutdown(self):
         """Shut down the worker, its server task, and any child processes."""
         if self.server_task is not None:
-            ray.cancel(self.server_task, force=True)
+            server_task = self.server_task
+            self._request_server_terminate()
+            ray.cancel(server_task, force=True, recursive=True)
             self.server_task = None
             return
 
@@ -609,6 +611,24 @@ class RolloutWorker(SingleAcceleratorWorker):
             self.server_process = None
             self.logger.debug(f"Worker {self.rank} server process and its children terminated.")
             return
+
+    def _request_server_terminate(self) -> bool:
+        """Ask the inference server to terminate itself if it supports it."""
+        terminate_url = f"{self.server_url}/terminate"
+        try:
+            response = requests.get(terminate_url, timeout=5.0)
+        except requests.RequestException as e:
+            self.logger.debug(f"Worker {self.rank} terminate request failed for {terminate_url}: {e}")
+            return False
+
+        if response.status_code == 200:
+            self.logger.debug(f"Worker {self.rank} terminate request accepted by {terminate_url}.")
+            return True
+
+        self.logger.debug(
+            f"Worker {self.rank} terminate request to {terminate_url} returned status {response.status_code}."
+        )
+        return False
 
     async def pause_generation(self):
         """Pause the worker's generation process."""

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -612,24 +612,6 @@ class RolloutWorker(SingleAcceleratorWorker):
             self.logger.debug(f"Worker {self.rank} server process and its children terminated.")
             return
 
-    def _request_server_terminate(self) -> bool:
-        """Ask the inference server to terminate itself if it supports it."""
-        terminate_url = f"{self.server_url}/terminate"
-        try:
-            response = requests.get(terminate_url, timeout=5.0)
-        except requests.RequestException as e:
-            self.logger.debug(f"Worker {self.rank} terminate request failed for {terminate_url}: {e}")
-            return False
-
-        if response.status_code == 200:
-            self.logger.debug(f"Worker {self.rank} terminate request accepted by {terminate_url}.")
-            return True
-
-        self.logger.debug(
-            f"Worker {self.rank} terminate request to {terminate_url} returned status {response.status_code}."
-        )
-        return False
-
     async def pause_generation(self):
         """Pause the worker's generation process."""
         self.receive_abort_request.set()

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -532,7 +532,7 @@ class RolloutWorker(SingleAcceleratorWorker):
     def set_enable_partial_rollout(self, enable: bool) -> None:
         self.enable_partial_rollout = enable
 
-    def init(self, dist_init_addr: str = "") -> tuple[int, str]:
+    def init(self, dist_init_addr: str) -> tuple[int, str]:
         """Initialize the worker and launch the server.
 
         Args:
@@ -543,7 +543,6 @@ class RolloutWorker(SingleAcceleratorWorker):
             Tuple[int, str]: A tuple containing the worker's rank and its
                 server URL.
         """
-        self.dist_init_addr = dist_init_addr if dist_init_addr else self.dist_init_addr
         self.receive_abort_request.clear()
         self._launch_server()
         return (self.rank, self.server_url)

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -532,7 +532,7 @@ class RolloutWorker(SingleAcceleratorWorker):
     def set_enable_partial_rollout(self, enable: bool) -> None:
         self.enable_partial_rollout = enable
 
-    def init(self, dist_init_addr: str) -> tuple[int, str]:
+    def init(self, dist_init_addr: str | None = None) -> tuple[int, str]:
         """Initialize the worker and launch the server.
 
         Args:
@@ -543,6 +543,8 @@ class RolloutWorker(SingleAcceleratorWorker):
             Tuple[int, str]: A tuple containing the worker's rank and its
                 server URL.
         """
+        if dist_init_addr is not None:
+            self.dist_init_addr = dist_init_addr
         self.receive_abort_request.clear()
         self._launch_server()
         return (self.rank, self.server_url)

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -532,7 +532,7 @@ class RolloutWorker(SingleAcceleratorWorker):
     def set_enable_partial_rollout(self, enable: bool) -> None:
         self.enable_partial_rollout = enable
 
-    def init(self, dist_init_addr: str) -> tuple[int, str]:
+    def init(self, dist_init_addr: str = "") -> tuple[int, str]:
         """Initialize the worker and launch the server.
 
         Args:
@@ -587,12 +587,17 @@ class RolloutWorker(SingleAcceleratorWorker):
         """Shut down the worker, its server task, and any child processes."""
         if self.server_task is not None:
             ray.cancel(self.server_task, force=True)
+            self.server_task = None
             return
 
         if self.server_process is not None:
             import psutil
 
-            parent = psutil.Process(self.server_process.pid)
+            try:
+                parent = psutil.Process(self.server_process.pid)
+            except psutil.NoSuchProcess:
+                self.server_process = None
+                return
             children = parent.children(recursive=True)
             for child in children:
                 child.terminate()
@@ -601,6 +606,7 @@ class RolloutWorker(SingleAcceleratorWorker):
                 child.kill()
             parent.terminate()
             parent.wait(timeout=5)
+            self.server_process = None
             self.logger.debug(f"Worker {self.rank} server process and its children terminated.")
             return
 

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -59,6 +59,7 @@ from xtuner.v1.utils.env_check import get_rollout_engine_version
 
 # TODO: Move DEVICE to `xtuner.utils.device`
 PG_READY_TIMEOUT = 30
+RL_TRAINER_RAY_GET_TIMEOUT = 600
 DEVICE = get_device()
 DEVICE_MODULE = get_torch_device_module()
 
@@ -87,7 +88,10 @@ def bind_train_rollout(
     rollout_controller: RolloutControllerProxy,
 ) -> None:
     """Bind the training and rollout workers for update weights."""
-    info_dict = ray.get(rollout_controller.get_rollout_metadata.remote())  # type: ignore[attr-defined]
+    info_dict = ray.get(
+        rollout_controller.get_rollout_metadata.remote(),  # type: ignore[attr-defined]
+        timeout=RL_TRAINER_RAY_GET_TIMEOUT,
+    )
     train_controller.update_rollout_info(info_dict)
     return
 
@@ -665,7 +669,10 @@ class BaseRLTrainer:
         if cfg.gateway_config is None or not cfg.gateway_config.auto_start:
             return
         # gateway 依赖 rollout controller，因此在 rollout controller 构建完成后统一启动。
-        ray.get(self.rollout_controller.start_gateway.remote(cfg.gateway_config))
+        ray.get(
+            self.rollout_controller.start_gateway.remote(cfg.gateway_config),
+            timeout=RL_TRAINER_RAY_GET_TIMEOUT,
+        )
 
     def _build_agent_loop_components(self, cfg: BaseRLTrainerConfig, replay_buffer) -> None:
         self.tokenizer = AutoTokenizer.from_pretrained(cfg.tokenizer_path, trust_remote_code=True)
@@ -855,9 +862,13 @@ class BaseRLTrainer:
         self._save_trajectories(train_batch, train_trajectory_path)
         self.logger.info(f"Train step {train_step} train trajectories saved to {train_trajectory_path}")
 
-        # 共卡需要先释放 rollout，再把训练 worker onload；非共卡不走这两个动作。
+        # 共卡需要先确认 rollout worker 可恢复，再释放 rollout，最后把训练 worker onload；非共卡不走这些动作。
         if offload_rollout_before_train:
-            ray.get(self.rollout_controller.offload.remote())
+            ray.get(
+                self.rollout_controller.ensure_workers_healthy_before_training.remote(),
+                timeout=RL_TRAINER_RAY_GET_TIMEOUT,
+            )
+            ray.get(self.rollout_controller.offload.remote(), timeout=RL_TRAINER_RAY_GET_TIMEOUT)
         if onload_train_before_train:
             with timer("onload", step_timer_dict):
                 self.train_controller.onload(target="all")
@@ -1373,12 +1384,12 @@ class RLColocateTrainer(BaseRLTrainer):
 
     def _sync_weights_from_train_workers(self) -> None:
         self.logger.info("Rollout workers skip load weights, update weights from train workers.")
-        ray.get(self.rollout_controller.offload.remote())
+        ray.get(self.rollout_controller.offload.remote(), timeout=RL_TRAINER_RAY_GET_TIMEOUT)
         self.train_controller.onload(target="model")
-        ray.get(self.rollout_controller.onload_weights.remote())
+        ray.get(self.rollout_controller.onload_weights.remote(), timeout=RL_TRAINER_RAY_GET_TIMEOUT)
         self.train_controller.update_weights()
         self.train_controller.offload(target="model")
-        ray.get(self.rollout_controller.onload_kvcache.remote())
+        ray.get(self.rollout_controller.onload_kvcache.remote(), timeout=RL_TRAINER_RAY_GET_TIMEOUT)
         self.logger.info("Rollout workers updated weights from train workers.")
 
     def fit(self):
@@ -1490,19 +1501,18 @@ class RLColocateTrainer(BaseRLTrainer):
             asyncio_run(self._maybe_save_checkpoint(train_step))
             self._maybe_save_hf(train_step)
 
-        ray.get(self.rollout_controller.recover_failed_workers.remote())
         timer_name = "sync_weight" if should_sync_weights else "switch_to_rollout"
         with timer(timer_name, step_timer_dict):
             if should_sync_weights:
                 bind_train_rollout(train_controller=self.train_controller, rollout_controller=self.rollout_controller)
-                ray.get(self.rollout_controller.onload_weights.remote())
+                ray.get(self.rollout_controller.onload_weights.remote(), timeout=RL_TRAINER_RAY_GET_TIMEOUT)
                 self.train_controller.update_weights()
                 self.logger.info("Rollout workers update weights successfully in colocate mode")
                 self.train_controller.offload(target="model")
             else:
                 self.train_controller.offload(target="model")
-                ray.get(self.rollout_controller.onload_weights.remote())
-            ray.get(self.rollout_controller.onload_kvcache.remote())
+                ray.get(self.rollout_controller.onload_weights.remote(), timeout=RL_TRAINER_RAY_GET_TIMEOUT)
+            ray.get(self.rollout_controller.onload_kvcache.remote(), timeout=RL_TRAINER_RAY_GET_TIMEOUT)
         return should_sync_weights
 
 
@@ -1688,7 +1698,7 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
             await self._maybe_save_checkpoint(model_step)
             self._maybe_save_hf(model_step)
 
-        ray.get(self.rollout_controller.recover_failed_workers.remote())
+        # 非共卡需要额外加健康检查恢复worker的逻辑
         with timer("sync_weight", step_timer_dict):
             bind_train_rollout(train_controller=self.train_controller, rollout_controller=self.rollout_controller)
             self.update_weights()

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -59,7 +59,7 @@ from xtuner.v1.utils.env_check import get_rollout_engine_version
 
 # TODO: Move DEVICE to `xtuner.utils.device`
 PG_READY_TIMEOUT = 30
-RL_TRAINER_RAY_GET_TIMEOUT = 600
+RL_TRAINER_RAY_GET_TIMEOUT = 3600
 DEVICE = get_device()
 DEVICE_MODULE = get_torch_device_module()
 

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1698,7 +1698,7 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
             await self._maybe_save_checkpoint(model_step)
             self._maybe_save_hf(model_step)
 
-        # 非共卡需要额外加健康检查恢复worker的逻辑
+        # TODO: 非共卡需要额外加健康检查恢复worker的逻辑，共卡是在训练之前恢复，但是非共卡不需要在训练之前恢复,挂掉就恢复或者更新权重前恢复，需要评估一下哪种方式更合理。
         with timer("sync_weight", step_timer_dict):
             bind_train_rollout(train_controller=self.train_controller, rollout_controller=self.rollout_controller)
             self.update_weights()


### PR DESCRIPTION
### 问题
 **权重更新前对失败的推理引擎进行重启的逻辑** 存在漏洞，具体表现为：在重启失败推理引擎之前，训练的模型权重和推理的模型权重都期望在cpu上，经过重启，lmdeploy的权重会在gpu上，此时调用onload接口，lmdeploy期望模型在cpu/meta上，所以会报错

### 修复方法

- 在produce_batch完成后，rollout offload之前，对失败的worker进行一次最终的健康检查，如果健康检查为失败，那就将server_task kill掉并进行重启，并保证启动在同样的server url上；
- 如果重启失败，trainer就会直接报错

说明：produce-batch后的健康检查，lmdeploy的引擎应该都会处于空闲状态，那么健康检查不返回的概率将会很低，但这里仍然可能会有风险

### 不能处理的情况
1. LmdeployWorker 挂掉
2. lmdeploy的api server挂掉后engine残留的显存无法释放，那就会报错
3. ep>1的情况下需要把ep group内的worker都重启才行