### PR TITLE
Fix RL rollout port allocation collisions in CI

### DIFF
--- a/.dev_scripts/debug_gateway.py
+++ b/.dev_scripts/debug_gateway.py
@@ -57,8 +57,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cpu-memory-per-worker-gb", type=int, default=8)
     parser.add_argument("--context-length", type=int, default=32768)
     parser.add_argument("--dist-port-base", type=int, default=42000)
-    parser.add_argument("--api-host", default="127.0.0.1")
-    parser.add_argument("--api-port", type=int, default=30080)
     parser.add_argument("--worker-log-dir", default=str(DEFAULT_WORK_DIR / "worker_logs"))
     parser.add_argument("--placement-group-name", default="xtuner_debug_gateway_pg")
     parser.add_argument(
@@ -127,8 +125,6 @@ def build_rollout_config(args: argparse.Namespace):
         context_length=args.context_length,
         worker_log_dir=args.worker_log_dir,
         dist_port_base=args.dist_port_base,
-        api_host=args.api_host,
-        api_port=args.api_port,
         tool_call_parser=args.tool_call_parser,
         reasoning_parser=args.reasoning_parser,
     )

--- a/recipe/claude_code/test_claude_code_with_calculator.py
+++ b/recipe/claude_code/test_claude_code_with_calculator.py
@@ -183,8 +183,6 @@ def _start_rollout_controller_and_gateway(
         ),
         tool_call_parser=os.environ.get("XTUNER_CLAUDECODE_TOOL_CALL_PARSER", "qwen3p5"),
         reasoning_parser=os.environ.get("XTUNER_CLAUDECODE_REASONING_PARSER", "qwen3"),
-        api_host="127.0.0.1",
-        api_port=find_free_ports()[0],
     )
     controller = rollout_config.build(placement_group)
     gateway_host = ray.util.get_node_ip_address()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ import xtuner.v1  # noqa: E402,F401
 
 from huggingface_hub import constants  # noqa: E402
 
+from xtuner._testing.patch_rollout_config import patch_rollout_config_dist_port_base
+
 
 _HF_DYNAMIC_MODULE_PREFIX = "transformers_modules"
 _HF_PATCH_MODULES_CACHE_PREFIX = "modules_cache"
@@ -52,4 +54,10 @@ def _cleanup_hf_dynamic_modules() -> None:
 
 
 def pytest_runtest_setup(item):
+    item_path_obj = getattr(item, "path", None)
+    if item_path_obj is None:
+        item_path_obj = item.fspath
+    item_path = Path(str(item_path_obj))
+    if item_path.parent.name == "rl":
+        patch_rollout_config_dist_port_base()
     _cleanup_hf_dynamic_modules()

--- a/tests/rl/test_rollout_config_dist_port_base_patch.py
+++ b/tests/rl/test_rollout_config_dist_port_base_patch.py
@@ -1,0 +1,27 @@
+from xtuner._testing.patch_rollout_config import get_rollout_config_dist_port_base_default
+from xtuner.v1.rl.rollout.worker import RolloutConfig
+
+
+def _build_rollout_config(**kwargs) -> RolloutConfig:
+    return RolloutConfig(
+        model_path="/tmp/nonexistent-model",
+        context_length=1,
+        **kwargs,
+    )
+
+
+def test_rollout_config_default_dist_port_base_is_staggered(monkeypatch):
+    monkeypatch.delenv("XTUNER_USE_SGLANG", raising=False)
+    monkeypatch.delenv("XTUNER_USE_VLLM", raising=False)
+    monkeypatch.setenv("XTUNER_USE_LMDEPLOY", "1")
+
+    base = get_rollout_config_dist_port_base_default()
+    first = _build_rollout_config()
+    second = _build_rollout_config()
+    explicit = _build_rollout_config(dist_port_base=45678)
+    third = _build_rollout_config()
+
+    assert first.dist_port_base == base
+    assert second.dist_port_base == base + 24
+    assert explicit.dist_port_base == 45678
+    assert third.dist_port_base == base + 48

--- a/xtuner/_testing/patch_rollout_config.py
+++ b/xtuner/_testing/patch_rollout_config.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import threading
+
+
+_PATCHED_ATTR = "_xtuner_testing_dist_port_base_patched"
+_NEXT_BASE_ATTR = "_xtuner_testing_next_dist_port_base"
+_STEP_ATTR = "_xtuner_testing_dist_port_base_step"
+_LOCK_ATTR = "_xtuner_testing_dist_port_base_lock"
+_ORIGINAL_DEFAULT_ATTR = "_xtuner_testing_dist_port_base_original_default"
+
+
+def reset_rollout_config_dist_port_base_sequence(initial_base: int | None = None) -> int:
+    """Reset the next automatic RolloutConfig dist_port_base for this process."""
+    from xtuner.v1.rl.rollout.worker import RolloutConfig
+
+    if initial_base is None:
+        initial_base = int(
+            getattr(RolloutConfig, _ORIGINAL_DEFAULT_ATTR, RolloutConfig.model_fields["dist_port_base"].default)
+        )
+    setattr(RolloutConfig, _NEXT_BASE_ATTR, initial_base)
+    return initial_base
+
+
+def get_rollout_config_dist_port_base_default() -> int:
+    """Return the dist_port_base that the next implicit RolloutConfig will use."""
+    from xtuner.v1.rl.rollout.worker import RolloutConfig
+
+    return int(getattr(RolloutConfig, _NEXT_BASE_ATTR, RolloutConfig.model_fields["dist_port_base"].default))
+
+
+def patch_rollout_config_dist_port_base(step: int = 24, initial_base: int | None = None) -> None:
+    """Assign a per-process dist_port_base sequence to implicit RolloutConfig defaults.
+
+    When ``dist_port_base`` is not passed to ``RolloutConfig(...)``, each new
+    object receives the next base port in a process-local sequence. Explicit
+    ``dist_port_base`` values are left untouched and do not consume the sequence.
+    """
+    from xtuner.v1.rl.rollout.worker import RolloutConfig
+
+    field = RolloutConfig.model_fields["dist_port_base"]
+    dist_port_base_default = int(getattr(RolloutConfig, _ORIGINAL_DEFAULT_ATTR, field.default))
+    if not hasattr(RolloutConfig, _ORIGINAL_DEFAULT_ATTR):
+        setattr(RolloutConfig, _ORIGINAL_DEFAULT_ATTR, dist_port_base_default)
+
+    setattr(RolloutConfig, _STEP_ATTR, step)
+    if not hasattr(RolloutConfig, _LOCK_ATTR):
+        setattr(RolloutConfig, _LOCK_ATTR, threading.Lock())
+    if initial_base is not None or not hasattr(RolloutConfig, _NEXT_BASE_ATTR):
+        reset_rollout_config_dist_port_base_sequence(initial_base)
+
+    if getattr(RolloutConfig, _PATCHED_ATTR, False):
+        return
+
+    def dist_port_base_factory() -> int:
+        with getattr(RolloutConfig, _LOCK_ATTR):
+            next_base = int(getattr(RolloutConfig, _NEXT_BASE_ATTR))
+            updated_base = next_base + int(getattr(RolloutConfig, _STEP_ATTR))
+            updated_base = (updated_base - dist_port_base_default) % (65536 - dist_port_base_default) + dist_port_base_default
+            setattr(RolloutConfig, _NEXT_BASE_ATTR, updated_base)
+            return next_base
+
+    field.default_factory = dist_port_base_factory
+    RolloutConfig.model_rebuild(force=True)
+    setattr(RolloutConfig, _PATCHED_ATTR, True)
+
+
+__all__ = [
+    "get_rollout_config_dist_port_base_default",
+    "patch_rollout_config_dist_port_base",
+    "reset_rollout_config_dist_port_base_sequence",
+]

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -4,7 +4,6 @@ import json
 import math
 import multiprocessing
 import os
-import socket
 import threading
 import time
 import traceback
@@ -33,7 +32,6 @@ from xtuner.v1.rl.utils import (
     AutoAcceleratorWorkers,
     CPUResourcesConfig,
     SingleAcceleratorWorker,
-    find_master_addr_and_port,
     get_eos_token,
     register_cpu_resources,
 )
@@ -65,8 +63,6 @@ class RolloutConfig(BaseModel):
         tokenizer_path (str): Path to the model tokenizer. Defaults to "".
         api_key (Optional[Union[List[str], str]]): API keys for rollout service. Supports single key or
             list of keys. Defaults to None.
-        api_port (Optional[int]): Port number for the rollout API server. If not set, it will find an
-            available port starting from 8000. Defaults to 8000.
         gpus_per_node (int): Number of GPUs per node. Defaults to 8.
         dtype (str): Model data type ('bfloat16', 'float16', 'int8'). Defaults to "bfloat16".
         gpu_memory_utilization (float): GPU memory utilization ratio. Defaults to 0.85.
@@ -125,14 +121,6 @@ class RolloutConfig(BaseModel):
             help="API keys for the rollout service. Can be a single key or a list of keys.",
         ),
     ] = None
-    api_port: Annotated[
-        int,
-        Parameter(group=infer_group, help="Port number for the rollout API server. If not set, 8000 will be used."),
-    ] = 8000
-    api_host: Annotated[
-        str,
-        Parameter(group=infer_group, help="Host for the rollout API server."),
-    ] = "0.0.0.0"
     gpus_per_node: Annotated[int, Parameter(group=infer_group, help="Number of GPUs allocated per node.")] = 8
     dtype: Annotated[
         str,
@@ -399,16 +387,6 @@ class RolloutConfig(BaseModel):
         if self.tokenizer_path is None:
             self.tokenizer_path = str(self.model_path)
 
-        port = self.api_port
-        while True:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                try:
-                    s.bind((self.api_host if self.api_host != "0.0.0.0" else "localhost", port))
-                    break
-                except OSError:
-                    port += 1
-        self.api_port = port
-
         if self.device == "NPU":
             self.gpus_per_node = 16
 
@@ -551,34 +529,19 @@ class RolloutWorker(SingleAcceleratorWorker):
     def init_dist_port(self) -> str:
         """Initialize distributed communication ports.
 
-        This method acquires three free ports for the distributed setup:
-        one for the inference server, one for NCCL, and one for Ray's
-        distributed communication.
+        This method initializes three fixed ports for the distributed setup:
+        one for the inference server, one for NCCL, and one for distributed
+        communication.
 
         Returns:
             str: The distributed initialization address (host:port).
         """
-        scheduling_strategy = PlacementGroupSchedulingStrategy(
-            placement_group=ray.util.get_current_placement_group(),
-            placement_group_capture_child_tasks=True,
-            placement_group_bundle_index=self.engine_bundle_idxs[0],
-        )
-
         local_rank = int(ray.get_runtime_context().get_accelerator_ids()[self.accelerator][0])
-        interval = 1024
-        start_port = self.config.dist_port_base + local_rank * interval
-        end_port = start_port + interval
-        self.host, self.ports = ray.get(
-            find_master_addr_and_port.options(scheduling_strategy=scheduling_strategy).remote(
-                nums=3,
-                start_port=start_port,
-                end_port=end_port,
-            )
-        )
-
-        self.dist_port = self.ports[0]
-        self.server_port = self.ports[1]
-        self.nccl_port = self.ports[2]
+        base_port = self.config.dist_port_base + local_rank * 3
+        self.host = ray.util.get_node_ip_address()
+        self.dist_port = base_port
+        self.server_port = base_port + 1
+        self.nccl_port = base_port + 2
         self.dist_init_addr = f"{self.host}:{self.dist_port}"
         self.server_url = f"http://{self.host}:{self.server_port}"
         return self.dist_init_addr


### PR DESCRIPTION
## Summary
- Use fixed per-local-rank port offsets for RL rollout dist/server/NCCL ports instead of probing free ports.
- Remove unused rollout API host/port config and corresponding debug/demo arguments.
- Add a test-only RolloutConfig default dist_port_base patch so RL tests stagger implicit port bases within one process.
- Add a regression test covering staggered defaults and explicit dist_port_base overrides.