### PR TITLE
Support EP rollout worker group recovery

### DIFF
--- a/tests/rl/fast/pr_fast/test_rl_colocate_trainer.py
+++ b/tests/rl/fast/pr_fast/test_rl_colocate_trainer.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import ray
+import requests
 import torch
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status

--- a/tests/rl/fast/pr_fast/test_rl_disaggregated_trainer.py
+++ b/tests/rl/fast/pr_fast/test_rl_disaggregated_trainer.py
@@ -122,6 +122,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
             return_value=([{"seq_ctx": "fake"}], {"batch_size": 1, "rewards/mean": 1.0})
         )
         trainer._save_trajectories = MagicMock()
+        trainer._save_eval_trajectories = MagicMock()
         trainer._log_step = MagicMock()
         trainer._maybe_save_checkpoint = AsyncMock()
         trainer._maybe_save_hf = MagicMock()

--- a/tests/rl/fast/pr_fast/test_rollout_logic.py
+++ b/tests/rl/fast/pr_fast/test_rollout_logic.py
@@ -3,7 +3,7 @@
 本文件合并旧的 test_rollout_worker.py 和 test_rollout_utils.py 中不依赖真实模型/后端的测试：
 - SGLangWorker pause/continue 对 abort flag 和 server request 的控制。
 - RolloutWorker abort、abort request timeout 和 in-flight request 取消语义。
-- RolloutHealthChecker 对 inactive/unhealthy worker 的清理逻辑。
+- RolloutHealthChecker 对 inactive/unhealthy worker 的状态标记逻辑。
 - PartialRolloutHandler 拼接 routed_experts 后释放旧 Ray ObjectRef 的逻辑。
 
 旧 test_rollout_utils.py 中的 TestRolloutControllerRecover 需要真实 Ray controller / lmdeploy backend，
@@ -227,8 +227,8 @@ class TestRolloutHealthChecker(unittest.TestCase):
         config = SimpleNamespace(health_check_interval_seconds=10, health_check_failure_threshold=1)
         return RolloutHealthChecker(config, workers_info)
 
-    def test_shutdown_runs_when_offload_fails(self):
-        # worker 健康检查失败且 offload 也失败时，health checker 应 shutdown 并标记 inactive。
+    def test_unhealthy_worker_is_marked_inactive(self):
+        # worker 健康检查失败时，health checker 只标记 inactive；清理/恢复由 controller 统一处理。
         worker = _FakeWorker()
         workers_info = {0: SimpleNamespace(actor=worker, url="http://worker-0", is_active=True)}
         checker = self._build_checker(workers_info)
@@ -236,28 +236,12 @@ class TestRolloutHealthChecker(unittest.TestCase):
         async def unhealthy_worker(*args, **kwargs):
             return False
 
-        def ray_get(ref, timeout=None):
-            worker.call_log.append((ref, "get"))
-            if ref == "offload":
-                raise RuntimeError("offload failed")
-            return None
-
-        with (
-            patch("xtuner.v1.rl.rollout.utils.check_worker_health", side_effect=unhealthy_worker),
-            patch("xtuner.v1.rl.rollout.utils.ray.get", side_effect=ray_get),
-        ):
+        with patch("xtuner.v1.rl.rollout.utils.check_worker_health", side_effect=unhealthy_worker) as health_check:
             checker.run_once()
 
         self.assertFalse(workers_info[0].is_active)
-        self.assertEqual(
-            worker.call_log,
-            [
-                ("offload", "remote"),
-                ("offload", "get"),
-                ("shutdown", "remote"),
-                ("shutdown", "get"),
-            ],
-        )
+        health_check.assert_called_once_with(worker, 0, "http://worker-0", True, 1)
+        self.assertEqual(worker.call_log, [])
 
     def test_inactive_worker_is_not_cleaned_up_again(self):
         # 已 inactive 的 worker 不再重复健康检查、offload 或 shutdown。

--- a/tests/rl/test_rl_trainer_checkpoint.py
+++ b/tests/rl/test_rl_trainer_checkpoint.py
@@ -183,6 +183,9 @@ class TestRLTrainerCheckpoint(unittest.TestCase):
     def _patched_runtime(self):
         runtime = SimpleNamespace(train_controllers=[], rollout_controllers=[])
 
+        async def inline_to_thread(func, /, *args, **kwargs):
+            return func(*args, **kwargs)
+
         def build_pg(resources_config, name="train"):
             idx = len(getattr(build_pg, "built", []))
             build_pg.built = getattr(build_pg, "built", []) + [name]
@@ -199,15 +202,11 @@ class TestRLTrainerCheckpoint(unittest.TestCase):
             return controller
 
         with (
-            patch("xtuner.v1.rl.utils.ray_accelerator_worker.ray.is_initialized", return_value=True),
-            patch(
-                "xtuner.v1.rl.utils.ray_accelerator_worker.ray.available_resources",
-                return_value={"CPU": 64, "memory": 128 * 1024**3, "GPU": 8},
-            ),
             patch("xtuner.v1.train.rl_trainer.AutoAcceleratorWorkers.build_placement_group", side_effect=build_pg),
             patch("xtuner.v1.train.rl_trainer.CPUResourceManager", _FakeCPUResourceManager),
             patch("xtuner.v1.train.rl_trainer.set_cpu_resource_manager", lambda manager: None),
             patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
+            patch("asyncio.to_thread", side_effect=inline_to_thread),
             patch.object(WorkerConfig, "build", autospec=True, side_effect=build_train_controller),
             patch.object(RolloutConfig, "build", autospec=True, side_effect=build_rollout_controller),
         ):

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -408,9 +408,22 @@ class RolloutController:
                 )
                 self._cleanup_inactive_worker_group(workers)
                 return False
-            else:
-                self.logger.info(f"Successfully restarted rollout worker group ranks={group_ranks}.")
-                return True
+
+            session_url_map = self._collect_worker_session_url_map([actor for _, actor, _, _ in workers])
+            missing_session_url_ranks = sorted(rank for rank, _, _, _ in workers if rank not in session_url_map)
+            if missing_session_url_ranks:
+                self.logger.error(
+                    f"Restarted rollout worker group ranks={group_ranks} has no SessionServer URL for "
+                    f"ranks={missing_session_url_ranks}."
+                )
+                self._cleanup_inactive_worker_group(workers)
+                return False
+
+            with self.worker_info_lock:
+                for rank, session_url in session_url_map.items():
+                    self.rank2info[rank].session_url = session_url
+            self.logger.info(f"Successfully restarted rollout worker group ranks={group_ranks}.")
+            return True
         except Exception as e:
             self.logger.error(f"Failed to restart worker: {e}")
             if workers:
@@ -475,6 +488,19 @@ class RolloutController:
             if attempt < max_attempts:
                 time.sleep(retry_interval_seconds)
         return sorted(pending)
+
+    def _collect_worker_session_url_map(self, active_rollout_workers: list[RolloutWorker]) -> dict[int, str]:
+        session_server_infos = ray.get(
+            [worker.get_session_server_info.remote() for worker in active_rollout_workers],  # type: ignore[attr-defined]
+            timeout=ROLLOUT_RAY_GET_TIMEOUT,
+        )
+        session_url_map: dict[int, str] = {}
+        for rank, session_url in session_server_infos:
+            if session_url is None:
+                self.logger.warning(f"Rollout worker rank={rank} has no SessionServer URL.")
+                continue
+            session_url_map[int(rank)] = session_url
+        return session_url_map
 
     def _check_chat_completion_ready_once(
         self,
@@ -696,16 +722,21 @@ class RolloutController:
         )
         active_ranks = list(worker_server_urls_map.keys())
         rank_to_ep_group = self._build_rank_to_ep_group(active_ranks, server_urls_per_engine)
+        worker_session_url_map = self._collect_worker_session_url_map(active_rollout_workers)
         workers_info = {}
         for i, rank in enumerate(active_ranks):
             url = worker_server_urls_map[rank]
             workers_info[rank] = WorkerInfo(
                 actor=active_rollout_workers[i],
                 url=url,
+                session_url=worker_session_url_map.get(rank),
                 dist_init_addr=worker_dist_init_addr_map[rank],
                 ep_group_ranks=rank_to_ep_group[rank],
             )
         self.logger.info(f"Rollout worker server URLs: {[info.url for info in workers_info.values()]}")
+        self.logger.info(
+            f"Rollout worker session URLs: {[info.session_url for info in workers_info.values() if info.session_url]}"
+        )
         self.logger.info(f"Rollout worker EP groups: {sorted(set(rank_to_ep_group.values()))}")
         return engine_rank_mesh_array, worker_server_urls_map, workers_info
 

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -2,11 +2,13 @@ import asyncio
 import math
 import os
 import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, TypeAlias, TypedDict
 from uuid import uuid4
 
 import ray
+import requests
 from ray.actor import ActorProxy
 from ray.util.placement_group import PlacementGroup
 
@@ -34,6 +36,8 @@ class WorkerInfo:
     url: str
     session_url: str | None = None
     is_active: bool = True
+    dist_init_addr: str = ""
+    ep_group_ranks: tuple[int, ...] = ()
 
 
 class RolloutWorkerMetadata(TypedDict):
@@ -258,6 +262,9 @@ class RolloutController:
                 workers = {rank: (info.actor, info.url, info.is_active) for rank, info in self.rank2info.items()}
 
             for rank, (actor, url, was_active) in workers.items():
+                if not was_active:
+                    continue
+
                 try:
                     is_healthy = ray.get(actor.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
                 except Exception as e:
@@ -271,9 +278,7 @@ class RolloutController:
                     info = self.rank2info[rank]
                     info.is_active = bool(is_healthy)
 
-                if is_healthy and not was_active:
-                    self.logger.info(f"Mark rollout worker {rank} active after final health check: url={url}")
-                elif not is_healthy and was_active:
+                if not is_healthy:
                     self.logger.warning(
                         f"Mark rollout worker {rank} inactive because final health check failed before training: url={url}"
                     )
@@ -323,47 +328,194 @@ class RolloutController:
         """Recover inactive workers before training while keeping health checks
         paused."""
         with self.worker_info_lock:
-            failed_workers = [info for info in self.rank2info.values() if not info.is_active]
+            failed_group_to_ranks: dict[tuple[int, ...], list[int]] = {}
+            for rank, info in self.rank2info.items():
+                if info.is_active:
+                    continue
+                group_ranks = info.ep_group_ranks or (rank,)
+                failed_group_to_ranks.setdefault(group_ranks, []).append(rank)
 
-        if not failed_workers:
+        if not failed_group_to_ranks:
             self.logger.info("No failed workers detected during recovery.")
             return
 
-        self.logger.warning(f"Detected {len(failed_workers)} failed workers. Initiating recovery process.")
-        for worker in failed_workers:
-            if self._restart_failed_workers(worker.actor, expected_url=worker.url):
+        failed_groups = set(failed_group_to_ranks)
+        for group_ranks in sorted(failed_groups):
+            failed_ranks = sorted(failed_group_to_ranks[group_ranks])
+            if len(group_ranks) > 1:
+                related_restart_ranks = [rank for rank in group_ranks if rank not in failed_ranks]
+                self.logger.warning(
+                    f"Detected failed rollout worker ranks={failed_ranks}; "
+                    f"restart_group_ranks={group_ranks}, related_restart_ranks={related_restart_ranks}."
+                )
+            else:
+                self.logger.warning(f"Detected failed rollout worker rank={failed_ranks[0]}. Initiating recovery.")
+
+        with self.worker_info_lock:
+            for group_ranks in failed_groups:
+                for rank in group_ranks:
+                    if rank in self.rank2info:
+                        self.rank2info[rank].is_active = False
+
+        for group_ranks in sorted(failed_groups):
+            if self._restart_worker_group(group_ranks):
                 with self.worker_info_lock:
-                    rank = self._get_rank_by_actor(worker.actor)
-                    if rank is not None:
+                    for rank in group_ranks:
                         self.rank2info[rank].is_active = True
 
-    def _restart_failed_workers(self, worker: RolloutWorker, expected_url: str) -> bool:
+    def _restart_worker_group(self, group_ranks: tuple[int, ...]) -> bool:
+        workers: list[tuple[int, RolloutWorker, str, str]] = []
         try:
-            # 先保证把老的worker关掉
-            ray.get(worker.shutdown.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            # 保证新的worker启动在之前的端口上，否则权重更新会出错
-            _, url = ray.get(worker.init.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            assert url == expected_url, f"Worker restarted with unexpected URL: expected {expected_url}, got {url}."
-            _, session_url = ray.get(worker.get_session_server_info.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            is_healthy = ray.get(worker.check_health.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
+            with self.worker_info_lock:
+                workers = [
+                    (
+                        rank,
+                        self.rank2info[rank].actor,
+                        self.rank2info[rank].url,
+                        self.rank2info[rank].dist_init_addr,
+                    )
+                    for rank in group_ranks
+                ]
 
-            if is_healthy:
-                self.logger.info(f"Successfully restarted worker {worker} with URL {url}.")
-                with self.worker_info_lock:
-                    rank = self._get_rank_by_actor(worker)
-                    if rank is not None:
-                        self.rank2info[rank].url = url
-                        self.rank2info[rank].session_url = session_url
-                        self.worker_server_urls_map[rank] = url
-                return True
-            else:
-                self.logger.error(f"Worker {worker} is still unhealthy after restart.")
+            if not self._cleanup_inactive_worker_group(workers):
                 return False
-        except AssertionError:
-            raise
+            init_refs = [
+                actor.init.remote(dist_init_addr=dist_init_addr)  # type: ignore[attr-defined]
+                for _, actor, _, dist_init_addr in workers
+            ]
+            init_results = ray.get(init_refs, timeout=ROLLOUT_RAY_GET_TIMEOUT)
+            if len(init_results) != len(workers):
+                self.logger.error(
+                    f"Restarted rollout worker group ranks={group_ranks} returned "
+                    f"{len(init_results)} init results, expected {len(workers)}."
+                )
+                self._cleanup_inactive_worker_group(workers)
+                return False
+            for (rank, _, expected_url, _), (actual_rank, actual_url) in zip(workers, init_results):
+                if actual_rank != rank or actual_url != expected_url:
+                    self.logger.error(
+                        f"Restarted rollout worker {rank} returned rank={actual_rank}, url={actual_url}; "
+                        f"expected rank={rank}, url={expected_url}."
+                    )
+                    self._cleanup_inactive_worker_group(workers)
+                    return False
+
+            infer_not_ready_ranks = self._check_worker_group_infer_ready_after_restart(workers)
+            if infer_not_ready_ranks:
+                self.logger.error(
+                    f"Restarted rollout worker group ranks={group_ranks} has ranks not ready for inference: "
+                    f"{infer_not_ready_ranks}."
+                )
+                self._cleanup_inactive_worker_group(workers)
+                return False
+            else:
+                self.logger.info(f"Successfully restarted rollout worker group ranks={group_ranks}.")
+                return True
         except Exception as e:
             self.logger.error(f"Failed to restart worker: {e}")
+            if workers:
+                self._cleanup_inactive_worker_group(workers)
             return False
+
+    def _cleanup_inactive_worker_group(self, workers: list[tuple[int, RolloutWorker, str, str]]) -> bool:
+        shutdown_succeeded = True
+        for rank, actor, url, _ in workers:
+            try:
+                ray.get(actor.shutdown.remote(), timeout=60)  # type: ignore[attr-defined]
+            except Exception as e:
+                shutdown_succeeded = False
+                self.logger.warning(f"Cleanup shutdown failed for rollout worker {rank} at {url}: {e}")
+                continue
+            if not self._wait_worker_server_down_after_shutdown(rank, url):
+                shutdown_succeeded = False
+        return shutdown_succeeded
+
+    def _wait_worker_server_down_after_shutdown(
+        self,
+        rank: int,
+        url: str,
+        *,
+        max_attempts: int = 60,
+        retry_interval_seconds: float = 5.0,
+    ) -> bool:
+        endpoint_url = f"{url}/health"
+        headers = {
+            "Content-Type": "application/json; charset=utf-8",
+            "Authorization": f"Bearer {self.config.api_key}",
+        }
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = requests.get(endpoint_url, headers=headers, timeout=1.0)
+            except requests.RequestException:
+                return True
+            if attempt < max_attempts:
+                self.logger.warning(
+                    f"Rollout worker rank={rank} server still responds after shutdown "
+                    f"attempt={attempt}/{max_attempts}, url={url}, status={response.status_code}."
+                )
+                time.sleep(retry_interval_seconds)
+        self.logger.error(f"Rollout worker rank={rank} server did not stop after shutdown: url={url}.")
+        return False
+
+    def _check_worker_group_infer_ready_after_restart(
+        self,
+        workers: list[tuple[int, RolloutWorker, str, str]],
+        *,
+        max_attempts: int = 60,
+        retry_interval_seconds: float = 5.0,
+    ) -> list[int]:
+        # NOTE: 推理引擎现在仅依靠 /health 接口来判断是否 ready, 有可能会出现server已经ready了，但是推理引擎还未ready的情况，所以重启后需要判断推理引擎是否能够推理成功才认为启动成功
+        pending = {rank: url for rank, _, url, _ in workers}
+        for attempt in range(1, max_attempts + 1):
+            for rank, url in list(pending.items()):
+                if self._check_chat_completion_ready_once(rank, url, attempt, max_attempts):
+                    del pending[rank]
+            if not pending:
+                return []
+            if attempt < max_attempts:
+                time.sleep(retry_interval_seconds)
+        return sorted(pending)
+
+    def _check_chat_completion_ready_once(
+        self,
+        rank: int,
+        url: str,
+        attempt: int,
+        max_attempts: int,
+    ) -> bool:
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.config.api_key}",
+        }
+        payload = {
+            "model": self.config.model_name,
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "n": 1,
+            "stream": False,
+            "max_tokens": 1,
+            "repetition_penalty": 1.0,
+            "top_k": 1,
+            "skip_special_tokens": True,
+        }
+        endpoint_url = f"{url}/v1/chat/completions"
+        try:
+            response = requests.post(endpoint_url, headers=headers, json=payload, timeout=60)
+        except requests.RequestException as e:
+            self.logger.warning(
+                f"Restarted rollout worker rank={rank} inference readiness request failed "
+                f"attempt={attempt}/{max_attempts}: {e}"
+            )
+            return False
+
+        if response.status_code != 200:
+            self.logger.warning(
+                f"Restarted rollout worker rank={rank} inference readiness request returned "
+                f"status={response.status_code}, attempt={attempt}/{max_attempts}, response={response.text}"
+            )
+            return False
+        return True
 
     def _update_dist_init_addr(self, nodes_per_engine, server_urls_per_engine, dist_init_addrs, tp_size):
         """Update the distributed initialization addresses for workers.
@@ -455,6 +607,22 @@ class RolloutController:
                 return rank
         return None
 
+    @staticmethod
+    def _build_rank_to_ep_group(active_ranks: list[int], server_urls_per_engine: int) -> dict[int, tuple[int, ...]]:
+        if server_urls_per_engine <= 1:
+            return {rank: (rank,) for rank in active_ranks}
+
+        assert len(active_ranks) % server_urls_per_engine == 0, (
+            f"active rollout worker count {len(active_ranks)} must be divisible by "
+            f"server_urls_per_engine={server_urls_per_engine}"
+        )
+        rank_to_ep_group: dict[int, tuple[int, ...]] = {}
+        for start in range(0, len(active_ranks), server_urls_per_engine):
+            ep_group = tuple(active_ranks[start : start + server_urls_per_engine])
+            for rank in ep_group:
+                rank_to_ep_group[rank] = ep_group
+        return rank_to_ep_group
+
     def _update_active_workers_and_urls_map(self, active_rollout_workers, worker_server_urls_map):
         """Update the list of active rollout workers and their server URLs.
 
@@ -518,29 +686,27 @@ class RolloutController:
             nodes_per_engine, server_urls_per_engine, init_dist_init_addrs, self.num_gpus_per_engine
         )
         # launch rollout servers
-        init_results = ray.get(
+        worker_server_urls = ray.get(
             [worker.init.remote(dist_init_addrs[i]) for i, worker in enumerate(active_rollout_workers)]
         )
-        worker_server_urls_map = dict(init_results)  # rank -> url
-        worker_session_url_dict = dict(
-            ray.get([worker.get_session_server_info.remote() for worker in active_rollout_workers])
-        )
+        worker_server_urls_map = dict(worker_server_urls)  # rank -> url
+        worker_dist_init_addr_map = {rank: dist_init_addrs[i] for i, (rank, _) in enumerate(worker_server_urls)}
         active_rollout_workers, worker_server_urls_map = self._update_active_workers_and_urls_map(
             active_rollout_workers, worker_server_urls_map
         )
         active_ranks = list(worker_server_urls_map.keys())
-        worker_session_url_dict = {rank: worker_session_url_dict[rank] for rank in active_ranks}
+        rank_to_ep_group = self._build_rank_to_ep_group(active_ranks, server_urls_per_engine)
         workers_info = {}
-        for i in range(len(active_rollout_workers)):
-            rank = list(worker_server_urls_map.keys())[i]
+        for i, rank in enumerate(active_ranks):
             url = worker_server_urls_map[rank]
             workers_info[rank] = WorkerInfo(
                 actor=active_rollout_workers[i],
                 url=url,
-                session_url=worker_session_url_dict[rank],
+                dist_init_addr=worker_dist_init_addr_map[rank],
+                ep_group_ranks=rank_to_ep_group[rank],
             )
         self.logger.info(f"Rollout worker server URLs: {[info.url for info in workers_info.values()]}")
-        self.logger.info(f"Rollout worker session server URLs: {[info.session_url for info in workers_info.values()]}")
+        self.logger.info(f"Rollout worker EP groups: {sorted(set(rank_to_ep_group.values()))}")
         return engine_rank_mesh_array, worker_server_urls_map, workers_info
 
 

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -385,47 +385,32 @@ class RolloutController:
             ]
             init_results = ray.get(init_refs, timeout=ROLLOUT_RAY_GET_TIMEOUT)
             if len(init_results) != len(workers):
-                self.logger.error(
+                raise RuntimeError(
                     f"Restarted rollout worker group ranks={group_ranks} returned "
                     f"{len(init_results)} init results, expected {len(workers)}."
                 )
-                self._cleanup_inactive_worker_group(workers)
-                return False
-            for (rank, _, expected_url, _), (actual_rank, actual_url) in zip(workers, init_results):
+
+            for worker_info, init_result in zip(workers, init_results):
+                rank, _, expected_url, _ = worker_info
+                actual_rank, actual_url = init_result
                 if actual_rank != rank or actual_url != expected_url:
-                    self.logger.error(
+                    raise RuntimeError(
                         f"Restarted rollout worker {rank} returned rank={actual_rank}, url={actual_url}; "
                         f"expected rank={rank}, url={expected_url}."
                     )
-                    self._cleanup_inactive_worker_group(workers)
-                    return False
 
             infer_not_ready_ranks = self._check_worker_group_infer_ready_after_restart(workers)
             if infer_not_ready_ranks:
-                self.logger.error(
+                raise RuntimeError(
                     f"Restarted rollout worker group ranks={group_ranks} has ranks not ready for inference: "
                     f"{infer_not_ready_ranks}."
                 )
-                self._cleanup_inactive_worker_group(workers)
-                return False
 
-            session_url_map = self._collect_worker_session_url_map([actor for _, actor, _, _ in workers])
-            missing_session_url_ranks = sorted(rank for rank, _, _, _ in workers if rank not in session_url_map)
-            if missing_session_url_ranks:
-                self.logger.error(
-                    f"Restarted rollout worker group ranks={group_ranks} has no SessionServer URL for "
-                    f"ranks={missing_session_url_ranks}."
-                )
-                self._cleanup_inactive_worker_group(workers)
-                return False
-
-            with self.worker_info_lock:
-                for rank, session_url in session_url_map.items():
-                    self.rank2info[rank].session_url = session_url
+            # SessionServer is not stopped during worker restart, so its URL in rank2info remains valid.
             self.logger.info(f"Successfully restarted rollout worker group ranks={group_ranks}.")
             return True
         except Exception as e:
-            self.logger.error(f"Failed to restart worker: {e}")
+            self.logger.error(f"Failed to restart worker group ranks={group_ranks}: {e}")
             if workers:
                 self._cleanup_inactive_worker_group(workers)
             return False
@@ -488,19 +473,6 @@ class RolloutController:
             if attempt < max_attempts:
                 time.sleep(retry_interval_seconds)
         return sorted(pending)
-
-    def _collect_worker_session_url_map(self, active_rollout_workers: list[RolloutWorker]) -> dict[int, str]:
-        session_server_infos = ray.get(
-            [worker.get_session_server_info.remote() for worker in active_rollout_workers],  # type: ignore[attr-defined]
-            timeout=ROLLOUT_RAY_GET_TIMEOUT,
-        )
-        session_url_map: dict[int, str] = {}
-        for rank, session_url in session_server_infos:
-            if session_url is None:
-                self.logger.warning(f"Rollout worker rank={rank} has no SessionServer URL.")
-                continue
-            session_url_map[int(rank)] = session_url
-        return session_url_map
 
     def _check_chat_completion_ready_once(
         self,
@@ -712,24 +684,29 @@ class RolloutController:
             nodes_per_engine, server_urls_per_engine, init_dist_init_addrs, self.num_gpus_per_engine
         )
         # launch rollout servers
-        worker_server_urls = ray.get(
+        init_results = ray.get(
             [worker.init.remote(dist_init_addrs[i]) for i, worker in enumerate(active_rollout_workers)]
         )
-        worker_server_urls_map = dict(worker_server_urls)  # rank -> url
-        worker_dist_init_addr_map = {rank: dist_init_addrs[i] for i, (rank, _) in enumerate(worker_server_urls)}
+        worker_server_urls_map = dict(init_results)  # rank -> url
+        worker_dist_init_addr_map = {rank: dist_init_addrs[i] for i, (rank, _) in enumerate(init_results)}
         active_rollout_workers, worker_server_urls_map = self._update_active_workers_and_urls_map(
             active_rollout_workers, worker_server_urls_map
         )
         active_ranks = list(worker_server_urls_map.keys())
         rank_to_ep_group = self._build_rank_to_ep_group(active_ranks, server_urls_per_engine)
-        worker_session_url_map = self._collect_worker_session_url_map(active_rollout_workers)
+        worker_session_url_dict = dict(
+            ray.get(
+                [worker.get_session_server_info.remote() for worker in active_rollout_workers],  # type: ignore[attr-defined]
+                timeout=ROLLOUT_RAY_GET_TIMEOUT,
+            )
+        )
         workers_info = {}
         for i, rank in enumerate(active_ranks):
             url = worker_server_urls_map[rank]
             workers_info[rank] = WorkerInfo(
                 actor=active_rollout_workers[i],
                 url=url,
-                session_url=worker_session_url_map.get(rank),
+                session_url=worker_session_url_dict.get(rank),
                 dist_init_addr=worker_dist_init_addr_map[rank],
                 ep_group_ranks=rank_to_ep_group[rank],
             )

--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -163,7 +163,7 @@ class LMDeployWorker(RolloutWorker):
         url = f"{self.server_url}/{self.endpoints['sleep']}"
         headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.api_keys}"}
         data = {"level": level}
-        response = requests.post(url, headers=headers, params=data, timeout=180)
+        response = requests.post(url, headers=headers, params=data, timeout=10 * 60)
         assert response.status_code == 200, response.status_code
         return response.text
 

--- a/xtuner/v1/rl/rollout/trace_store.py
+++ b/xtuner/v1/rl/rollout/trace_store.py
@@ -386,6 +386,9 @@ def get_existing_store():
     if _handle_cache is not None:
         return _handle_cache
 
+    if not ray.is_initialized():
+        return None
+
     try:
         _handle_cache = ray.get_actor(_STORE_NAME, namespace=_STORE_NAMESPACE)
     except ValueError:

--- a/xtuner/v1/rl/rollout/utils.py
+++ b/xtuner/v1/rl/rollout/utils.py
@@ -184,34 +184,16 @@ class RolloutHealthChecker:
             return await asyncio.gather(*tasks)
 
         check_results = asyncio.run(_run_checks())
-        inactive_workers = []
         for (rank, _, _, _), is_healthy in zip(workers_to_check, check_results):
             if not is_healthy:
                 logger.warning(f"Worker {rank} failed health check. Marking as inactive.")
                 if self._worker_infos_lock is None:
                     self._workers_info[rank].is_active = False
-                    inactive_worker = self._workers_info[rank].actor
                 else:
                     with self._worker_infos_lock:
                         self._workers_info[rank].is_active = False
-                        inactive_worker = self._workers_info[rank].actor
-                if inactive_worker is None:
-                    logger.error(f"[RolloutHealthChecker] Worker {rank} has no actor reference. Skipping shutdown.")
-                    continue
-                inactive_workers.append((rank, inactive_worker))
             else:
                 logger.debug(f"[RolloutHealthChecker] Worker {rank} passed health check.")
-
-        for rank, inactive_worker in inactive_workers:
-            try:
-                ray.get(inactive_worker.offload.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            except Exception as e:
-                logger.error(f"Exception while offloading worker {rank}: {e}")
-
-            try:
-                ray.get(inactive_worker.shutdown.remote(), timeout=ROLLOUT_RAY_GET_TIMEOUT)  # type: ignore[attr-defined]
-            except Exception as e:
-                logger.error(f"Exception while shutting down worker {rank}: {e}")
 
     def _run_loop(self) -> None:
         assert self._stop_event is not None and self._pause_event is not None

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -571,6 +571,13 @@ class RolloutWorker(SingleAcceleratorWorker):
             server_task = self.server_task
             self._request_server_terminate()
             ray.cancel(server_task, force=True, recursive=True)
+            try:
+                ray.get(server_task, timeout=60)
+            except ray.exceptions.GetTimeoutError:
+                self.logger.warning(f"Worker {self.rank} server task did not stop within shutdown timeout.")
+                raise
+            except Exception as e:
+                self.logger.debug(f"Worker {self.rank} server task stopped after shutdown: {e}")
             self.server_task = None
             return
 

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1494,23 +1494,15 @@ def add_apiproxy(self):
                 time.sleep(interval)
         return False
 
-    worker_session_url_dict = info_dict["worker_session_url_dict"]
-    worker_session_urls_status = info_dict["worker_session_urls_status"]
-    if not worker_session_url_dict:
-        raise RuntimeError("Routed API proxy requested, but rollout metadata contains no SessionServer URLs.")
-    active_worker_session_urls = [
-        worker_session_url
-        for _, worker_session_url in sorted(worker_session_url_dict.items())
-        if worker_session_urls_status.get(worker_session_url, False)
-    ]
-    if not active_worker_session_urls:
-        raise RuntimeError("Routed API proxy requested, but no active SessionServer URLs are available.")
-
     delete_from_routedapiproxy(model_name)
     self.logger.info(f"deleted {model_name} from routedapiproxy")
     self.logger.info("registering to routedapiproxy")
 
-    for worker_session_url in active_worker_session_urls:
+    worker_session_url_dict = info_dict["worker_session_url_dict"]
+    worker_session_urls_status = info_dict["worker_session_urls_status"]
+    for _, worker_session_url in sorted(worker_session_url_dict.items()):
+        if not worker_session_urls_status.get(worker_session_url, False):
+            continue
         register_to_routedapiproxy(model_name, worker_session_url)
 
         # test server url

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1494,15 +1494,23 @@ def add_apiproxy(self):
                 time.sleep(interval)
         return False
 
+    worker_session_url_dict = info_dict["worker_session_url_dict"]
+    worker_session_urls_status = info_dict["worker_session_urls_status"]
+    if not worker_session_url_dict:
+        raise RuntimeError("Routed API proxy requested, but rollout metadata contains no SessionServer URLs.")
+    active_worker_session_urls = [
+        worker_session_url
+        for _, worker_session_url in sorted(worker_session_url_dict.items())
+        if worker_session_urls_status.get(worker_session_url, False)
+    ]
+    if not active_worker_session_urls:
+        raise RuntimeError("Routed API proxy requested, but no active SessionServer URLs are available.")
+
     delete_from_routedapiproxy(model_name)
     self.logger.info(f"deleted {model_name} from routedapiproxy")
     self.logger.info("registering to routedapiproxy")
 
-    worker_session_url_dict = info_dict["worker_session_url_dict"]
-    worker_session_urls_status = info_dict["worker_session_urls_status"]
-    for _, worker_session_url in sorted(worker_session_url_dict.items()):
-        if not worker_session_urls_status.get(worker_session_url, False):
-            continue
+    for worker_session_url in active_worker_session_urls:
         register_to_routedapiproxy(model_name, worker_session_url)
 
         # test server url


### PR DESCRIPTION
1. 支持当ep_size>1时，当一个ep_group中某个worker挂了，会把这个worker所在的ep_group全部重启；
2. 增强了 shutdown 功能，当一个worker的serverl_url不能访问时，才认为这个worker已经被关闭了，并且进行重启
3. 增强了重启功能，目前的`/health`接口并不能很好的判断推理引擎真的ready并且可以接受请求了，所以在重启时，临时增加向推理引擎发送一个`/v1/chat/completions`请求，该接口返回正常，才认为推理引擎重启成功

说明：目前rollout controller和 rollout health checker的功能耦合比较严重，边界非常不清晰，会在下一个pr (https://github.com/InternLM/xtuner/pull/1877) 进行重构，把关闭/重启等功能从controller移到health checker去