### PR TITLE
[Fix] DCP async checkpoint daemon TCPStore fails with EADDRINUSE during spawn window

### DIFF
--- a/tests/utils/test_dcp_async_port.py
+++ b/tests/utils/test_dcp_async_port.py
@@ -1,0 +1,139 @@
+"""Regression tests for the DCP async-checkpoint daemon port patch.
+
+The original bug: PyTorch's process-based async checkpoint picks the daemon TCPStore
+port via ``get_free_port`` (``bind(("localhost", 0))`` -> ephemeral port -> close),
+so a transient outbound connection can grab the same port during the spawn window and
+the daemon ``listen`` fails with ``EADDRINUSE`` (more likely at large scale).
+
+``patch_dcp_async_daemon_port`` relocates the daemon port to a fixed range *outside*
+the kernel ephemeral range, which the kernel never auto-assigns. These tests verify the
+patch is wired to the symbol torch actually calls and that the chosen port is kept out
+of the ephemeral range.
+"""
+
+import socket
+from unittest.mock import MagicMock
+
+import pytest
+import torch.distributed.checkpoint._async_process_executor as _async_process_executor
+
+import xtuner.v1.patch.dcp_async_port as dcp_async_port
+from xtuner.v1.patch import patch_dcp_async_daemon_port
+
+
+def _free_port_for_test() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+@pytest.fixture
+def reset_patch_state():
+    original = _async_process_executor.get_free_port
+    was_patched = dcp_async_port._PATCHED
+    dcp_async_port._PATCHED = False
+    yield
+    _async_process_executor.get_free_port = original
+    dcp_async_port._PATCHED = was_patched
+
+
+class TestDcpAsyncPort:
+    def test_patch_replaces_get_free_port(self, reset_patch_state):
+        assert _async_process_executor.get_free_port is not dcp_async_port._xtuner_dcp_get_free_port
+        patch_dcp_async_daemon_port()
+        # torch calls the name bound in the executor module namespace, so that is what
+        # must be replaced for the fix to take effect.
+        assert _async_process_executor.get_free_port is dcp_async_port._xtuner_dcp_get_free_port
+
+    def test_patch_is_idempotent(self, reset_patch_state):
+        patch_dcp_async_daemon_port()
+        sentinel = lambda: 0  # noqa: E731 - stand-in for a later reassignment
+        _async_process_executor.get_free_port = sentinel
+        patch_dcp_async_daemon_port()  # second call must be a no-op
+        assert _async_process_executor.get_free_port is sentinel
+
+    def test_chosen_port_is_outside_ephemeral(self, monkeypatch):
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "29600")
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "400")
+        monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: (32768, 60999))
+        port = dcp_async_port._xtuner_dcp_get_free_port()
+        assert 29600 <= port < 30000
+        assert port < 32768
+
+    def test_env_overrides_range(self, monkeypatch):
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "31234")
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "7")
+        assert dcp_async_port._port_base() == 31234
+        assert dcp_async_port._port_span() == 7
+
+    def test_port_span_clamped_to_minimum_one(self, monkeypatch):
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "0")
+        assert dcp_async_port._port_span() == 1
+
+    def test_probe_skips_occupied_port(self, monkeypatch):
+        occupied = _free_port_for_test()
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("", occupied))
+        listener.listen(1)
+        try:
+            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", str(occupied))
+            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "5")
+            monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: None)
+            port = dcp_async_port._xtuner_dcp_get_free_port()
+            # SO_REUSEADDR still cannot bind over an actively listening socket, so the
+            # probe must move past the occupied base port.
+            assert occupied < port < occupied + 5
+        finally:
+            listener.close()
+
+    def test_no_free_port_raises(self, monkeypatch):
+        occupied = _free_port_for_test()
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("", occupied))
+        listener.listen(1)
+        try:
+            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", str(occupied))
+            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "1")
+            monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: None)
+            with pytest.raises(RuntimeError, match="no free daemon port"):
+                dcp_async_port._xtuner_dcp_get_free_port()
+        finally:
+            listener.close()
+
+    @pytest.mark.parametrize(
+        "base,hi_excl,eph,expected",
+        [
+            (29600, 30000, (32768, 60999), True),  # fully below ephemeral range
+            (61000, 61400, (32768, 60999), True),  # fully above ephemeral range
+            (40000, 40400, (32768, 60999), False),  # inside ephemeral range
+            (29600, 30000, None, False),  # unknown range -> conservative False
+            (32768, 33000, (32768, 60999), False),  # overlaps the lower bound
+        ],
+    )
+    def test_is_outside_ephemeral(self, base, hi_excl, eph, expected):
+        assert dcp_async_port._is_outside_ephemeral(base, hi_excl, eph) is expected
+
+    def test_patch_warns_when_range_overlaps_ephemeral(self, reset_patch_state, monkeypatch):
+        mock_logger = MagicMock()
+        monkeypatch.setattr(dcp_async_port, "logger", mock_logger)
+        monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: (29000, 60999))
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "29600")
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "400")
+        patch_dcp_async_daemon_port()
+        assert mock_logger.warning.called
+        assert not mock_logger.info.called
+
+    def test_patch_logs_info_when_range_outside_ephemeral(self, reset_patch_state, monkeypatch):
+        mock_logger = MagicMock()
+        monkeypatch.setattr(dcp_async_port, "logger", mock_logger)
+        monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: (32768, 60999))
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "29600")
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "400")
+        patch_dcp_async_daemon_port()
+        assert mock_logger.info.called
+        assert not mock_logger.warning.called

--- a/tests/utils/test_dcp_async_port.py
+++ b/tests/utils/test_dcp_async_port.py
@@ -6,13 +6,13 @@ so a transient outbound connection can grab the same port during the spawn windo
 the daemon ``listen`` fails with ``EADDRINUSE`` (more likely at large scale).
 
 ``patch_dcp_async_daemon_port`` relocates the daemon port to a fixed range *outside*
-the kernel ephemeral range, which the kernel never auto-assigns. These tests verify the
-patch is wired to the symbol torch actually calls and that the chosen port is kept out
-of the ephemeral range.
+the kernel ephemeral range, which the kernel never auto-assigns. These tests drive the
+public patch through the symbol torch actually calls and assert observable behavior:
+the chosen port lands in the configured range and is bindable, a single-port range is
+pinned, occupied ports are skipped, and an exhausted range fails fast.
 """
 
 import socket
-from unittest.mock import MagicMock
 
 import pytest
 import torch.distributed.checkpoint._async_process_executor as _async_process_executor
@@ -40,13 +40,26 @@ def reset_patch_state():
     dcp_async_port._PATCHED = was_patched
 
 
+def _get_daemon_port() -> int:
+    """Call the port selector exactly as torch's async-checkpoint executor does."""
+    return _async_process_executor.get_free_port()
+
+
 class TestDcpAsyncPort:
-    def test_patch_replaces_get_free_port(self, reset_patch_state):
-        assert _async_process_executor.get_free_port is not dcp_async_port._xtuner_dcp_get_free_port
+    def test_patch_routes_daemon_port_into_configured_range(self, reset_patch_state, monkeypatch):
+        # Pick a free range so the assertion is deterministic on any host.
+        base = _free_port_for_test()
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_RANGE", f"{base}:{base + 50}")
+
         patch_dcp_async_daemon_port()
-        # torch calls the name bound in the executor module namespace, so that is what
-        # must be replaced for the fix to take effect.
-        assert _async_process_executor.get_free_port is dcp_async_port._xtuner_dcp_get_free_port
+        port = _get_daemon_port()
+
+        # The patch must take effect on the symbol torch actually calls, so the returned
+        # port falls in our configured range and is genuinely bindable.
+        assert base <= port < base + 50
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            probe.bind(("", port))
 
     def test_patch_is_idempotent(self, reset_patch_state):
         patch_dcp_async_daemon_port()
@@ -55,85 +68,50 @@ class TestDcpAsyncPort:
         patch_dcp_async_daemon_port()  # second call must be a no-op
         assert _async_process_executor.get_free_port is sentinel
 
-    def test_chosen_port_is_outside_ephemeral(self, monkeypatch):
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "29600")
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "400")
-        monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: (32768, 60999))
-        port = dcp_async_port._xtuner_dcp_get_free_port()
-        assert 29600 <= port < 30000
-        assert port < 32768
+    def test_single_port_range_is_pinned(self, reset_patch_state, monkeypatch):
+        base = _free_port_for_test()
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_RANGE", f"{base}:{base + 1}")
 
-    def test_env_overrides_range(self, monkeypatch):
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "31234")
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "7")
-        assert dcp_async_port._port_base() == 31234
-        assert dcp_async_port._port_span() == 7
+        patch_dcp_async_daemon_port()
 
-    def test_port_span_clamped_to_minimum_one(self, monkeypatch):
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "0")
-        assert dcp_async_port._port_span() == 1
+        assert _get_daemon_port() == base
 
-    def test_probe_skips_occupied_port(self, monkeypatch):
+    def test_degenerate_range_falls_back_to_single_port(self, reset_patch_state, monkeypatch):
+        # "X:X" is empty; the patch must clamp it to a single usable port (X) rather
+        # than failing to find any port.
+        base = _free_port_for_test()
+        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_RANGE", f"{base}:{base}")
+
+        patch_dcp_async_daemon_port()
+
+        assert _get_daemon_port() == base
+
+    def test_patch_skips_occupied_port(self, reset_patch_state, monkeypatch):
         occupied = _free_port_for_test()
         listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         listener.bind(("", occupied))
         listener.listen(1)
         try:
-            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", str(occupied))
-            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "5")
-            monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: None)
-            port = dcp_async_port._xtuner_dcp_get_free_port()
+            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_RANGE", f"{occupied}:{occupied + 5}")
+            patch_dcp_async_daemon_port()
+            port = _get_daemon_port()
             # SO_REUSEADDR still cannot bind over an actively listening socket, so the
-            # probe must move past the occupied base port.
+            # base port is occupied and selection must move past it.
             assert occupied < port < occupied + 5
         finally:
             listener.close()
 
-    def test_no_free_port_raises(self, monkeypatch):
+    def test_patch_raises_when_no_free_port(self, reset_patch_state, monkeypatch):
         occupied = _free_port_for_test()
         listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         listener.bind(("", occupied))
         listener.listen(1)
         try:
-            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", str(occupied))
-            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "1")
-            monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: None)
+            monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_RANGE", f"{occupied}:{occupied + 1}")
+            patch_dcp_async_daemon_port()
             with pytest.raises(RuntimeError, match="no free daemon port"):
-                dcp_async_port._xtuner_dcp_get_free_port()
+                _get_daemon_port()
         finally:
             listener.close()
-
-    @pytest.mark.parametrize(
-        "base,hi_excl,eph,expected",
-        [
-            (29600, 30000, (32768, 60999), True),  # fully below ephemeral range
-            (61000, 61400, (32768, 60999), True),  # fully above ephemeral range
-            (40000, 40400, (32768, 60999), False),  # inside ephemeral range
-            (29600, 30000, None, False),  # unknown range -> conservative False
-            (32768, 33000, (32768, 60999), False),  # overlaps the lower bound
-        ],
-    )
-    def test_is_outside_ephemeral(self, base, hi_excl, eph, expected):
-        assert dcp_async_port._is_outside_ephemeral(base, hi_excl, eph) is expected
-
-    def test_patch_warns_when_range_overlaps_ephemeral(self, reset_patch_state, monkeypatch):
-        mock_logger = MagicMock()
-        monkeypatch.setattr(dcp_async_port, "logger", mock_logger)
-        monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: (29000, 60999))
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "29600")
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "400")
-        patch_dcp_async_daemon_port()
-        assert mock_logger.warning.called
-        assert not mock_logger.info.called
-
-    def test_patch_logs_info_when_range_outside_ephemeral(self, reset_patch_state, monkeypatch):
-        mock_logger = MagicMock()
-        monkeypatch.setattr(dcp_async_port, "logger", mock_logger)
-        monkeypatch.setattr(dcp_async_port, "_ephemeral_range", lambda: (32768, 60999))
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_BASE", "29600")
-        monkeypatch.setenv("XTUNER_DCP_DAEMON_PORT_SPAN", "400")
-        patch_dcp_async_daemon_port()
-        assert mock_logger.info.called
-        assert not mock_logger.warning.called

--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -373,15 +373,6 @@ class TrainEngine:
             self._async_checkpoint_pg = dist.new_group(backend="gloo")
         return self._async_checkpoint_pg
 
-    @staticmethod
-    def _is_async_checkpoint_daemon_init_error(exc: BaseException) -> bool:
-        message = str(exc)
-        return (
-            "EADDRINUSE" in message
-            or "address already in use" in message
-            or "Checkpoint background process is dead" in message
-        )
-
     def async_save_dcp(
         self,
         weights_dir: Path,
@@ -432,34 +423,13 @@ class TrainEngine:
         dcp_future = start_async_save()
 
         def commit_async_save() -> None:
-            nonlocal dcp_future
-            # Retry only PyTorch DCP daemon init port races, such as
-            # EADDRINUSE from TCPStore. Other checkpoint failures still raise.
-            max_daemon_init_attempts = 3
-            for attempt in range(1, max_daemon_init_attempts + 1):
-                try:
-                    dcp_future.result()
-                    break
-                except BaseException as exc:
-                    if attempt == max_daemon_init_attempts or not self._is_async_checkpoint_daemon_init_error(exc):
-                        elapsed = time.time() - t0
-                        logger.error(f"[DCP async_save for {weights_dir}] failed after {elapsed:.2f}s: {exc}")
-                        logger.error(traceback.format_exc())
-                        raise
-
-                    if dist.get_rank() == 0:
-                        logger.warning(
-                            "[DCP async_save for %s] checkpoint daemon init failed on attempt %s/%s, retrying: %s",
-                            weights_dir,
-                            attempt,
-                            max_daemon_init_attempts,
-                            exc,
-                        )
-                        if incomplete_dir.exists():
-                            shutil.rmtree(incomplete_dir)
-                        incomplete_dir.mkdir(parents=True, exist_ok=True)
-                    dist.barrier(group=async_checkpoint_pg)
-                    dcp_future = start_async_save()
+            try:
+                dcp_future.result()
+            except BaseException as exc:
+                elapsed = time.time() - t0
+                logger.error(f"[DCP async_save for {weights_dir}] failed after {elapsed:.2f}s: {exc}")
+                logger.error(traceback.format_exc())
+                raise
 
             dist.barrier(group=async_checkpoint_pg)
             if dist.get_rank() == 0:

--- a/xtuner/v1/patch/__init__.py
+++ b/xtuner/v1/patch/__init__.py
@@ -1,4 +1,5 @@
 from . import torch_shape_env_simplify_pt28
+from .dcp_async_port import patch_dcp_async_daemon_port
 from .torch_dcp_planner import patch_dcp_save_state_dict, patch_dcp_save_with_cache_storage, patch_default_save_plan
 
 
@@ -7,4 +8,5 @@ __all__ = [
     "torch_shape_env_simplify_pt28",
     "patch_dcp_save_state_dict",
     "patch_dcp_save_with_cache_storage",
+    "patch_dcp_async_daemon_port",
 ]

--- a/xtuner/v1/patch/dcp_async_port.py
+++ b/xtuner/v1/patch/dcp_async_port.py
@@ -1,0 +1,149 @@
+"""Patch DCP async-checkpoint daemon port selection.
+
+PyTorch's process-based async checkpoint (``dcp.async_save`` +
+``AsyncCheckpointerType.PROCESS``) spawns a background daemon. The coordinator rank
+calls ``torch.distributed.elastic.utils.distributed.get_free_port`` to pick a port,
+broadcasts it to all ranks, and each rank's daemon initializes a GLOO ``TCPStore``
+with it.
+
+``get_free_port`` binds ``("localhost", 0)`` so the kernel assigns a port from the
+ephemeral range (``net.ipv4.ip_local_port_range``, typically 32768-60999) and then
+immediately ``close()``s it. Between that ``close()`` and the daemon subprocess
+actually calling ``bind()/listen()`` there is a spawn window (hundreds of ms) during
+which the kernel may hand the same port to a transient NCCL/gloo outbound connection,
+making the daemon TCPStore ``listen`` fail with ``EADDRINUSE``. The larger the job
+(more connections, slower spawn/broadcast), the more likely it triggers.
+
+This patch picks the daemon port from a fixed range *outside* the ephemeral range.
+The kernel only auto-assigns outbound ports from ``ip_local_port_range``, so a port
+outside it is *never* taken by the kernel's automatic source-port assignment -- this
+categorically removes the dominant production vector (the EADDRINUSE we actually hit),
+regardless of training scale.
+
+Scope of the guarantee:
+- Kernel auto-assignment (``bind(port=0)`` / unbound ``connect``): eliminated entirely.
+- An explicit ``bind(("", <our_port>))`` by some co-located process (monitoring agent,
+  another framework's rendezvous, etc.) is NOT governed by ``ip_local_port_range`` and
+  is still allowed by the kernel. This residual is rare, scale-independent, and the
+  probe below skips ports already taken; only an explicit bind landing in the spawn
+  window could still collide. Note ``ip_local_reserved_ports`` also does not stop an
+  explicit bind -- fully closing this window requires holding the port continuously
+  (have the daemon bind first and report back), which needs an upstream change.
+"""
+
+import os
+import socket
+
+import torch.distributed.checkpoint._async_process_executor as _async_process_executor
+
+from xtuner.v1.utils.logger import get_logger
+
+
+logger = get_logger()
+
+# Default daemon port range, outside the ephemeral range (>=32768) and clear of the
+# common training MASTER_PORT (29500).
+_DEFAULT_PORT_BASE = 29600
+_DEFAULT_PORT_SPAN = 400
+
+_PATCHED = False
+
+
+def _port_base() -> int:
+    return int(os.environ.get("XTUNER_DCP_DAEMON_PORT_BASE", str(_DEFAULT_PORT_BASE)))
+
+
+def _port_span() -> int:
+    return max(1, int(os.environ.get("XTUNER_DCP_DAEMON_PORT_SPAN", str(_DEFAULT_PORT_SPAN))))
+
+
+def _ephemeral_range() -> tuple[int, int] | None:
+    """Return the kernel ephemeral port range
+    (net.ipv4.ip_local_port_range)."""
+    try:
+        with open("/proc/sys/net/ipv4/ip_local_port_range") as f:
+            lo, hi = f.read().split()[:2]
+            return int(lo), int(hi)
+    except Exception:
+        return None
+
+
+def _is_outside_ephemeral(base: int, hi_excl: int, eph: tuple[int, int] | None) -> bool:
+    """Whether [base, hi_excl) does not intersect the kernel ephemeral range.
+
+    The kernel only auto-assigns outbound ports from the ephemeral range, so a daemon port outside it cannot be grabbed
+    by a transient connection during the spawn window.
+    """
+    if eph is None:
+        return False
+    eph_lo, eph_hi = eph
+    return hi_excl <= eph_lo or base > eph_hi
+
+
+def _xtuner_dcp_get_free_port() -> int:
+    """Scan for a free port from a fixed range (kept outside the ephemeral
+    range by default).
+
+    Only the coordinator rank (global rank 0) calls this; the chosen port is then
+    broadcast to all nodes (which all connect to master_addr=node0), so it only needs
+    to be free on node0.
+
+    ``SO_REUSEADDR`` is set to mirror the daemon's actual TCPStore listener (c10d's
+    ``socket.cpp`` calls ``enableAddressReuse()`` before bind on non-Windows). Matching
+    it makes this probe a faithful predictor of the daemon bind: we no longer reject a
+    port the daemon could reuse (e.g. lingering TIME_WAIT from a previous run). It does
+    NOT weaken in-use detection -- ``SO_REUSEADDR`` still cannot bind over an actively
+    listening socket (that would require ``SO_REUSEPORT``).
+    """
+    base = _port_base()
+    span = _port_span()
+    eph = _ephemeral_range()
+    last_err: OSError | None = None
+    for port in range(base, base + span):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("", port))
+            sock.listen(1)
+            # Per-checkpoint evidence for verification: every line must say "outside"; any
+            # "in-ephemeral" means the race can still trigger. Greppable at scale.
+            status = "outside" if _is_outside_ephemeral(port, port + 1, eph) else "in-ephemeral"
+            logger.info(f"[DCP async_save] DCP daemon port chosen: {port} ({status} ephemeral range {eph})")
+            return port
+        except OSError as exc:
+            last_err = exc
+        finally:
+            sock.close()
+    raise RuntimeError(
+        f"[DCP async_save] no free daemon port in [{base}, {base + span}); "
+        f"set XTUNER_DCP_DAEMON_PORT_BASE / XTUNER_DCP_DAEMON_PORT_SPAN to relocate. last error: {last_err}"
+    )
+
+
+def patch_dcp_async_daemon_port() -> None:
+    """Route the DCP async checkpoint daemon port to a fixed range (outside the
+    ephemeral range by default)."""
+    global _PATCHED
+    if _PATCHED:
+        return
+    _async_process_executor.get_free_port = _xtuner_dcp_get_free_port
+    _PATCHED = True
+
+    base = _port_base()
+    hi_excl = base + _port_span()
+    eph = _ephemeral_range()
+    if _is_outside_ephemeral(base, hi_excl, eph):
+        logger.info(
+            f"[DCP async_save] patched daemon port selection to range "
+            f"[{base}, {hi_excl}), outside kernel ephemeral range {eph}"
+        )
+    else:
+        # NOTE: keep the real error signatures ("EADDRINUSE" / "address already in use")
+        # out of this benign log line, so a naive grep for those tokens only matches
+        # actual daemon failures, not this warning.
+        logger.warning(
+            f"[DCP async_save] daemon port range [{base}, {hi_excl}) overlaps the kernel "
+            f"ephemeral range {eph}; the TCPStore daemon-port bind race may persist (the "
+            f"port can be grabbed during the spawn window). Set XTUNER_DCP_DAEMON_PORT_BASE "
+            f"below {eph[0] if eph else 32768} to avoid it."
+        )

--- a/xtuner/v1/patch/dcp_async_port.py
+++ b/xtuner/v1/patch/dcp_async_port.py
@@ -41,43 +41,52 @@ from xtuner.v1.utils.logger import get_logger
 
 logger = get_logger()
 
-# Default daemon port range, outside the ephemeral range (>=32768) and clear of the
-# common training MASTER_PORT (29500).
-_DEFAULT_PORT_BASE = 29600
-_DEFAULT_PORT_SPAN = 400
+# Default daemon port range "low:high" (high exclusive), outside the ephemeral range
+# (>=32768) and clear of the common training MASTER_PORT (29500).
+_DEFAULT_PORT_RANGE = "29600:30000"
 
 _PATCHED = False
 
 
-def _port_base() -> int:
-    return int(os.environ.get("XTUNER_DCP_DAEMON_PORT_BASE", str(_DEFAULT_PORT_BASE)))
+def _port_range() -> tuple[int, int]:
+    """Parse ``XTUNER_DCP_DAEMON_PORT_RANGE`` as ``"low:high"`` (high
+    exclusive).
+
+    Returns ``(low, high)`` with ``high > low`` guaranteed (a degenerate or inverted
+    range is clamped to a single port).
+    """
+    raw = os.environ.get("XTUNER_DCP_DAEMON_PORT_RANGE", _DEFAULT_PORT_RANGE)
+    low_str, high_str = raw.split(":")
+    low, high = int(low_str), int(high_str)
+    if high <= low:
+        high = low + 1
+    return low, high
 
 
-def _port_span() -> int:
-    return max(1, int(os.environ.get("XTUNER_DCP_DAEMON_PORT_SPAN", str(_DEFAULT_PORT_SPAN))))
-
-
-def _ephemeral_range() -> tuple[int, int] | None:
+def _read_kernel_ephemeral_range() -> tuple[int, int] | None:
     """Return the kernel ephemeral port range
     (net.ipv4.ip_local_port_range)."""
     try:
         with open("/proc/sys/net/ipv4/ip_local_port_range") as f:
-            lo, hi = f.read().split()[:2]
-            return int(lo), int(hi)
+            low, high = f.read().split()[:2]
+            return int(low), int(high)
     except Exception:
         return None
 
 
-def _is_outside_ephemeral(base: int, hi_excl: int, eph: tuple[int, int] | None) -> bool:
-    """Whether [base, hi_excl) does not intersect the kernel ephemeral range.
+def _is_outside_ephemeral_range(
+    range_low: int, range_high_exclusive: int, ephemeral_range: tuple[int, int] | None
+) -> bool:
+    """Whether [range_low, range_high_exclusive) does not intersect the kernel
+    ephemeral range.
 
     The kernel only auto-assigns outbound ports from the ephemeral range, so a daemon port outside it cannot be grabbed
     by a transient connection during the spawn window.
     """
-    if eph is None:
+    if ephemeral_range is None:
         return False
-    eph_lo, eph_hi = eph
-    return hi_excl <= eph_lo or base > eph_hi
+    ephemeral_low, ephemeral_high = ephemeral_range
+    return range_high_exclusive <= ephemeral_low or range_low > ephemeral_high
 
 
 def _xtuner_dcp_get_free_port() -> int:
@@ -95,28 +104,37 @@ def _xtuner_dcp_get_free_port() -> int:
     NOT weaken in-use detection -- ``SO_REUSEADDR`` still cannot bind over an actively
     listening socket (that would require ``SO_REUSEPORT``).
     """
-    base = _port_base()
-    span = _port_span()
-    eph = _ephemeral_range()
-    last_err: OSError | None = None
-    for port in range(base, base + span):
+    range_low, range_high = _port_range()
+    ephemeral_range = _read_kernel_ephemeral_range()
+    last_error: OSError | None = None
+    for port in range(range_low, range_high):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            # Bind the wildcard address ("") rather than localhost: the real daemon
+            # TCPStore server (GLOO PG init with MASTER_ADDR=node0's FQDN) binds all
+            # interfaces so other nodes can reach it, so probing the wildcard is the
+            # faithful predictor of the daemon bind. (torch's etcd_server binds localhost
+            # only because it is a single-host rendezvous; this daemon is cross-node.)
             sock.bind(("", port))
-            sock.listen(1)
-            # Per-checkpoint evidence for verification: every line must say "outside"; any
-            # "in-ephemeral" means the race can still trigger. Greppable at scale.
-            status = "outside" if _is_outside_ephemeral(port, port + 1, eph) else "in-ephemeral"
-            logger.info(f"[DCP async_save] DCP daemon port chosen: {port} ({status} ephemeral range {eph})")
+            # backlog is irrelevant for a probe we close immediately; we only confirm the
+            # port can enter LISTEN, mirroring the daemon's listener.
+            sock.listen(0)
+            # Per-checkpoint evidence emitted at debug level: "outside" means the port is
+            # safe; "in-ephemeral" means the race can still trigger. Enable debug logging
+            # to grep this at scale.
+            status = "outside" if _is_outside_ephemeral_range(port, port + 1, ephemeral_range) else "in-ephemeral"
+            logger.debug(
+                f"[DCP async_save] DCP daemon port chosen: {port} ({status} ephemeral range {ephemeral_range})"
+            )
             return port
-        except OSError as exc:
-            last_err = exc
+        except OSError as error:
+            last_error = error
         finally:
             sock.close()
     raise RuntimeError(
-        f"[DCP async_save] no free daemon port in [{base}, {base + span}); "
-        f"set XTUNER_DCP_DAEMON_PORT_BASE / XTUNER_DCP_DAEMON_PORT_SPAN to relocate. last error: {last_err}"
+        f"[DCP async_save] no free daemon port in [{range_low}, {range_high}); "
+        f'set XTUNER_DCP_DAEMON_PORT_RANGE (e.g. "29600:30000") to relocate. last error: {last_error}'
     )
 
 
@@ -129,21 +147,20 @@ def patch_dcp_async_daemon_port() -> None:
     _async_process_executor.get_free_port = _xtuner_dcp_get_free_port
     _PATCHED = True
 
-    base = _port_base()
-    hi_excl = base + _port_span()
-    eph = _ephemeral_range()
-    if _is_outside_ephemeral(base, hi_excl, eph):
-        logger.info(
+    range_low, range_high = _port_range()
+    ephemeral_range = _read_kernel_ephemeral_range()
+    if _is_outside_ephemeral_range(range_low, range_high, ephemeral_range):
+        logger.debug(
             f"[DCP async_save] patched daemon port selection to range "
-            f"[{base}, {hi_excl}), outside kernel ephemeral range {eph}"
+            f"[{range_low}, {range_high}), outside kernel ephemeral range {ephemeral_range}"
         )
     else:
         # NOTE: keep the real error signatures ("EADDRINUSE" / "address already in use")
         # out of this benign log line, so a naive grep for those tokens only matches
         # actual daemon failures, not this warning.
         logger.warning(
-            f"[DCP async_save] daemon port range [{base}, {hi_excl}) overlaps the kernel "
-            f"ephemeral range {eph}; the TCPStore daemon-port bind race may persist (the "
-            f"port can be grabbed during the spawn window). Set XTUNER_DCP_DAEMON_PORT_BASE "
-            f"below {eph[0] if eph else 32768} to avoid it."
+            f"[DCP async_save] daemon port range [{range_low}, {range_high}) overlaps the kernel "
+            f"ephemeral range {ephemeral_range}; the TCPStore daemon-port bind race may persist (the "
+            f"port can be grabbed during the spawn window). Set XTUNER_DCP_DAEMON_PORT_RANGE "
+            f"to a range below {ephemeral_range[0] if ephemeral_range else 32768} to avoid it."
         )

--- a/xtuner/v1/train/trainer.py
+++ b/xtuner/v1/train/trainer.py
@@ -46,7 +46,12 @@ from xtuner.v1.engine.train_engine import TrainStepInfo
 from xtuner.v1.loss import CELossConfig
 from xtuner.v1.model.base import AsyncHFSaveHandle, ModelItem, XTunerBaseModelConfig
 from xtuner.v1.model.moe.moe import MoEConfig
-from xtuner.v1.patch import patch_dcp_save_state_dict, patch_dcp_save_with_cache_storage, patch_default_save_plan
+from xtuner.v1.patch import (
+    patch_dcp_async_daemon_port,
+    patch_dcp_save_state_dict,
+    patch_dcp_save_with_cache_storage,
+    patch_default_save_plan,
+)
 from xtuner.v1.profiler import profiling_memory, profiling_time
 from xtuner.v1.profiler.prober import ProberList
 from xtuner.v1.profiler.prober_utils import setup_prober_list
@@ -572,6 +577,13 @@ class Trainer:
         self._micro_batch_size: int | None = None
         if skip_checkpoint_validation:
             patch_default_save_plan()
+
+        # Keep the DCP async checkpoint daemon port out of the kernel ephemeral range to
+        # avoid the TCPStore EADDRINUSE race where get_free_port's port is grabbed by a
+        # transient connection during the spawn window (more likely at large scale).
+        # Only relevant to async (process) checkpointing, so gate it on async_checkpoint.
+        if async_checkpoint:
+            patch_dcp_async_daemon_port()
 
         if patch_for_dcp_finish:
             if torch.__version__.startswith("2.7."):
@@ -1226,7 +1238,7 @@ class Trainer:
 
         # Save model and optimizer
         future: Future | None = None
-        if self._async_checkpoint and not is_snapshot:
+        if self._async_checkpoint:
             future = self._engine.async_save_dcp(weights_dir=weights_path)
         else:
             self._engine.save_dcp(weights_dir=weights_path)


### PR DESCRIPTION
[Fix] Pin DCP async checkpoint daemon port outside the ephemeral range

  The process-based async checkpoint picks the daemon TCPStore port on rank0
  via get_free_port (bind(0) -> ephemeral port -> close), then binds it later
  in a spawned subprocess. In that spawn window a transient connection's
  ephemeral source port can grab the freed port, so the daemon listen fails
  with EADDRINUSE -- more likely at scale, where the daemon group's own
  bring-up bursts ephemeral connects on node0.
  
  Route the daemon port to a fixed range outside the kernel ephemeral range
  (default [29600, 30000)); the kernel never auto-assigns source ports there,
  so it can't be grabbed regardless of scale. Drop the now-unnecessary,
  cross-rank deadlock-prone EADDRINUSE retry in favor of fail-fast.