### PR TITLE
[Enhance] avoid peak memory in internal metrics dummy fwd

### DIFF
--- a/xtuner/v1/utils/internal_metrics.py
+++ b/xtuner/v1/utils/internal_metrics.py
@@ -252,7 +252,9 @@ class InternalMetricsRecorder:
             for i in range(0, len(data_batches)):
                 data_batch = data_batches[i]
                 seq_ctx = data_batch["seq_ctx"]
-                output = self.model(seq_ctx=seq_ctx, loss_ctx=None, **additional_kwargs)
+                loss_ctx = data_batch["loss_ctx"]
+
+                output = self.model(seq_ctx=seq_ctx, loss_ctx=loss_ctx, **additional_kwargs)  # type:ignore[arg-type]
 
                 if (
                     self.internal_metrics_cfg.monitor_moe_load_balance_stats


### PR DESCRIPTION
Pass `loss_ctx` through the internal metrics dummy forward path.

For long-sequence training, passing `loss_ctx=None` into model forward would materialize a large fp32 `logits` tensor.
https://github.com/InternLM/xtuner/blob/0e40b0d7ba11b7357d3fcff05c24f171ad8bf972/xtuner/v1/module/lm_head/lm_head.py#L46-L47

This will lead a large peak memory spike and even OOM. Passing in a dummy `loss_ctx` keeps memory footprint within the range of a regular forward pass (typically chunked loss calculation).
