### PR TITLE
build(docker): install nvidia-nvshmem-cu12 conditionally before DEEP_EP wheel build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 
 WORKDIR ${CODESPACE}/DeepEP
 
-RUN pip show nvidia-nvshmem-cu12 >/dev/null 2>&1 || pip install nvidia-nvshmem-cu12==3.4.5 && \
+RUN (pip show nvidia-nvshmem-cu12 >/dev/null 2>&1 || pip install nvidia-nvshmem-cu12==3.4.5) && \
     pip wheel -w ${DEEP_EP_DIR} -v --no-deps .
 
 # compile deep_gemm

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,8 @@ RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 
 WORKDIR ${CODESPACE}/DeepEP
 
-RUN pip wheel -w ${DEEP_EP_DIR} -v --no-deps .
+RUN pip show nvidia-nvshmem-cu12 >/dev/null 2>&1 || pip install nvidia-nvshmem-cu12==3.4.5 && \
+    pip wheel -w ${DEEP_EP_DIR} -v --no-deps .
 
 # compile deep_gemm
 FROM setup_env AS deep_gemm


### PR DESCRIPTION
Add a check before DEEP_EP wheel build: if `nvidia-nvshmem-cu12` is not installed, run `pip install nvidia-nvshmem-cu12==3.4.5` first, then proceed with the build.