### PR TITLE
[Fix] add missing HTTPS_PROXY secret mount for DEEP_EP nvshmem pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,8 @@ RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
 
 WORKDIR ${CODESPACE}/DeepEP
 
-RUN (pip show nvidia-nvshmem-cu12 >/dev/null 2>&1 || pip install nvidia-nvshmem-cu12==3.4.5) && \
+RUN --mount=type=secret,id=HTTPS_PROXY,env=https_proxy \
+    (pip show nvidia-nvshmem-cu12 >/dev/null 2>&1 || pip install nvidia-nvshmem-cu12==3.4.5) && \
     pip wheel -w ${DEEP_EP_DIR} -v --no-deps .
 
 # compile deep_gemm


### PR DESCRIPTION
The previous PR added a conditional pip install for nvidia-nvshmem-cu12 before DEEP_EP wheel build, but missed the  mount. This fixes it so pip install respects the proxy in restricted network environments.