### PR TITLE
[Fix] Match fp32-keep patterns against post-mapping HF keys

### DIFF
--- a/tests/model/test_qwen3_5_dense.py
+++ b/tests/model/test_qwen3_5_dense.py
@@ -472,4 +472,4 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
 
     @property
     def world_size(self) -> int:
-        return int(os.getenv("XTUNER_TEST_WORLD_SIZE", "1"))
+        return int(os.getenv("XTUNER_TEST_WORLD_SIZE", "4"))

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -627,7 +627,15 @@ class BaseModel(nn.Module):
             for name, param in module.named_parameters(recurse=False):
                 full_name = full_param_name_mapping[id(param)]
                 full_name = self._clean_param_name(full_name)
-                hf_name_list = self.to_hf_key_list(full_name)
+                # Match fp32 patterns against the post-mapping HF keys (the names that actually land
+                # in the saved checkpoint), so this FSDP-ignore decision stays consistent with the
+                # save path (`_split_ignored_params` / `_get_save_dtype`). `load_spec_mapping` is
+                # built in `_init_load_spec` during __init__ (and rebuilt after fp8 padding), both
+                # of which run before `fully_shard`, so the lookup is always populated here.
+                load_spec = self.load_spec_mapping.get(full_name)
+                if load_spec is None:
+                    raise ValueError(f"Internal Error. Parameter {full_name} not found in load_spec_mapping.")
+                hf_name_list = load_spec.hf_keys
 
                 for hf_name in hf_name_list:
                     if any(re.search(p, hf_name) for p in patterns):  # type: ignore
@@ -951,7 +959,9 @@ class BaseModel(nn.Module):
             local_tensor[:non_pad_len].copy_(loaded_tensor_slice)
 
             if non_pad_len < local_tensor.shape[self.FSDP_SHARD_DIM]:
-                assert self.config.float8_cfg is not None
+                assert self.config.float8_cfg is not None, (
+                    f"Shape mismatched! xtuner param shape: {param_name}, hf param {loaded_tensor.shape}"
+                )
                 local_tensor[non_pad_len:].copy_(0.0)  # type: ignore  # padded part must be set to 0
         else:
             local_tensor.copy_(loaded_tensor)


### PR DESCRIPTION
The fp32-keep mechanism (kept in fp32 and excluded from FSDP sharding,
e.g. Qwen3.5 dense linear_attn.norm.weight / A_log) classified params
inconsistently: `_fully_shard` matched `fp32_keys_pattern` against the
pre-mapping `to_hf_key_list` output (model.layers...), while the save
path matched the post-mapping hf_keys (model.language_model.layers...).
For models whose `hf_key_mapping` rewrites the namespace, the patterns
never matched at shard time, so the fp32 params were not excluded from
FSDP.

Align `_fully_shard` to the post-mapping hf_keys via load_spec_mapping
so all consumers (sharding, _split_ignored_params, _get_save_dtype)
classify against the same keys that land in the saved checkpoint.
