### PR TITLE
fix: preserve multimodal image token counts

### DIFF
--- a/xtuner/v1/data_proto/rl_data.py
+++ b/xtuner/v1/data_proto/rl_data.py
@@ -62,6 +62,7 @@ class MultimodalInfo(TypedDict):
     # 使用TypedDict给出pixel_values的类型提示
     pixel_values: NotRequired[np.ndarray | RayObjectRef | None]
     image_grid_thw: NotRequired[np.ndarray | None]
+    num_img_tokens: NotRequired[list[int]]
 
 
 class RolloutFunctionCall(BaseModel):

--- a/xtuner/v1/data_proto/sequence_context.py
+++ b/xtuner/v1/data_proto/sequence_context.py
@@ -255,6 +255,7 @@ class SequenceContext:
         pixel_values = []
 
         image_grid_thw = []
+        num_img_tokens = []
         position_ids = []
         rollout_routed_experts = []
 
@@ -282,6 +283,8 @@ class SequenceContext:
                 pixel_values.append(seq_ctx.pixel_values)
             if seq_ctx.image_grid_thw is not None:
                 image_grid_thw.append(seq_ctx.image_grid_thw)
+            if seq_ctx.num_img_tokens is not None:
+                num_img_tokens.extend(seq_ctx.num_img_tokens)
             if seq_ctx.rollout_routed_experts is not None:
                 rollout_routed_experts.append(seq_ctx.rollout_routed_experts)
             position_ids.append(seq_ctx.position_ids)
@@ -304,6 +307,7 @@ class SequenceContext:
             inputs_embeds=torch.cat(inputs_embeds, dim=1) if inputs_embeds else None,  # type: ignore
             pixel_values=pixel_values,  # type: ignore
             image_grid_thw=torch.cat(image_grid_thw, dim=0) if image_grid_thw else None,  # type: ignore
+            num_img_tokens=num_img_tokens if num_img_tokens else None,
             position_ids=torch.cat(position_ids, dim=-1) if position_ids else None,  # type: ignore
             rollout_routed_experts=rollout_routed_experts if len(rollout_routed_experts) > 0 else None,  # type: ignore
         )

--- a/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/rl_tokenize_fn/qwen3_vl_tokenize_fn.py
@@ -113,6 +113,8 @@ class RLQwen3VLTokenizeFunction(Qwen3VLTokenizeFunction):
                     mm_info["pixel_values"] = _tensor_to_numpy(data["pixel_values"])  # for ray put into shared memory
                 if "image_grid_thw" in data:
                     mm_info["image_grid_thw"] = _tensor_to_numpy(data["image_grid_thw"])
+                if "num_img_tokens" in data:
+                    mm_info["num_img_tokens"] = data["num_img_tokens"]
 
             data_source = item.get("data_source")
             assert data_source is not None, "data_source is required in item"

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -206,6 +206,9 @@ def get_train_seq_ctx(
     if multimodal_train_info:
         seq_ctx.pixel_values = multimodal_train_info.get("pixel_values")
         seq_ctx.image_grid_thw = _to_cpu_tensor(multimodal_train_info.get("image_grid_thw"), dtype=torch.long)
+        num_img_tokens = multimodal_train_info.get("num_img_tokens")
+        if num_img_tokens is not None:
+            seq_ctx.num_img_tokens = [num_img_tokens]
     return seq_ctx
 
 


### PR DESCRIPTION
## 背景

在 Qwen3-VL / 多模态 RL 训练中，`pixel_values` 和 `image_grid_thw` 已经可以传到 training worker，但 `num_img_tokens` 没有完整传到训练侧的 `SequenceContext`。

这会导致真实多模态 batch 里明明包含图片，训练日志却显示：

```text
step_consumed_img_tokens=0
img_efficient_attn_ratio=0
```

## 修改内容
本 PR 补齐 num_img_tokens 在 RL 多模态训练链路中的传递：

在 MultimodalInfo 中加入 num_img_tokens
在 RLQwen3VLTokenizeFunction 中把 tokenizer 输出的 num_img_tokens 写入 mm_info
在 SequenceContext packing 时保留 num_img_tokens
在 RLColocateTrainer 构造训练 SequenceContext 时恢复 num_img_tokens

修复前：多模态 payload 能进入训练，但 step_consumed_img_tokens=0
修复后：step_consumed_img_tokens 变为非零，训练和 backward 能正常完成

<img width="1749" height="540" alt="image" src="https://github.com/user-attachments/assets/7fba1649-a66e-401a-bba1-d05bd03dd1a0" />
