### PR TITLE
fix: skip final rollout onload when no rollout is needed

### DIFF
--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1702,10 +1702,18 @@ class RLColocateTrainer(BaseRLTrainer):
         """Save state and switch colocated resources back to rollout
         workers."""
         should_sync_weights = train_step % self._sync_weights_interval == 0
+        will_evaluate = self._enable_evaluate and train_step % self._evaluate_step == 0
+        needs_rollout_ready = train_step < self._total_train_steps or will_evaluate
         with timer("save_ckpt", step_timer_dict):
             self.train_controller.offload(target="optimizer")
             asyncio_run(self._maybe_save_checkpoint(train_step))
             self._maybe_save_hf(train_step)
+
+        if not needs_rollout_ready:
+            with timer("final_offload", step_timer_dict):
+                self.train_controller.offload(target="model")
+            self.logger.info("Final train step reached without scheduled evaluation; skip rollout worker onload.")
+            return False
 
         timer_name = "sync_weight" if should_sync_weights else "switch_to_rollout"
         with timer(timer_name, step_timer_dict):


### PR DESCRIPTION
## 背景

共卡 RL 训练中，`_sync_weights_and_save()` 在每个 train step 结束后都会把资源切回 rollout worker。

但如果当前已经是最后一个 train step，并且该 step 不需要执行 evaluation，那么后面不会再有 rollout 或 eval 消费 rollout worker。此时继续执行 rollout worker onload 是不必要的。

实际训练中出现过：训练和 HF 保存已经完成，但最后一步仍然尝试 `rollout_controller.onload_weights()`，最终在 LMDeploy wakeup / onload 阶段失败，导致本来已经成功完成训练的任务被判失败。

## 修改内容

本 PR 在共卡 trainer 的 `_sync_weights_and_save()` 中增加判断：

- 如果当前 step 不是最后一步，需要继续准备 rollout worker
- 如果当前 step 会触发 eval，也需要继续准备 rollout worker
- 如果当前 step 是最后一步，并且不会 eval，则只 offload train model，跳过 rollout worker onload