### PR TITLE
[Refactor] Unify agent loop output protocol on AgentMessage

### DIFF
--- a/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
+++ b/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import importlib
-import json
 import traceback
 import uuid
 from typing import Any, Literal
@@ -59,14 +58,31 @@ def _load_eval_trace_segment(artifacts: dict[str, Any]) -> tuple[list[dict[str, 
     return messages, segment.get("tools")
 
 
-def _to_json_safe(value: Any) -> Any:
-    return json.loads(json.dumps(value, ensure_ascii=False, default=str))
+def _count_tool_turns(messages: list[dict[str, Any]]) -> int:
+    """Number of assistant turns that emitted at least one tool_call."""
+    return sum(
+        1 for m in messages if isinstance(m, dict) and isinstance(m.get("tool_calls"), list) and m["tool_calls"]
+    )
+
+
+def _extract_reward_payload(item: AgentRolloutItem) -> dict[str, Any] | None:
+    for record in item.judgers.values():
+        reward = record.metadata.get("reward")
+        if isinstance(reward, dict):
+            payload = dict(reward)
+            if item.reward is not None:
+                payload.setdefault("score", item.reward)
+            return payload
+    if item.reward is not None:
+        return {"score": item.reward}
+    return None
 
 
 class AgentInLocalhostLoopConfig(AgentLoopConfig):
     """Run a localhost agent runner from ``RolloutState.extra_fields``."""
 
     max_concurrent_samples: int | None = None
+    sample_timeout_s: float | None = None
     mode: Literal["train", "eval"] = "train"
 
     def build_local(
@@ -82,6 +98,7 @@ class AgentInLocalhostLoopConfig(AgentLoopConfig):
             judger=judger,
             logger=logger,
             max_concurrent_samples=self.max_concurrent_samples,
+            sample_timeout_s=self.sample_timeout_s,
             mode=self.mode,
         )
 
@@ -97,12 +114,14 @@ class AgentInLocalhostLoop(AgentLoop):
         judger: Judger | None = None,
         logger=None,
         max_concurrent_samples: int | None = None,
+        sample_timeout_s: float | None = None,
         mode: Literal["train", "eval"] = "train",
     ):
         if hf_checkpoint is None:
             raise ValueError("hf_checkpoint must be provided for AgentInLocalhostLoop.")
         super().__init__(rollout_ctl, sample_params, hf_checkpoint, judger, logger)
         self.max_concurrent_samples = max_concurrent_samples
+        self.sample_timeout_s = sample_timeout_s
         self._sample_semaphore = asyncio.Semaphore(max_concurrent_samples) if max_concurrent_samples else None
         self.mode = mode
 
@@ -113,34 +132,72 @@ class AgentInLocalhostLoop(AgentLoop):
             async with self._sample_semaphore:
                 return await self.generate_sample(state, **kwargs)
 
-        tasks = []
+        tasks: list[asyncio.Task[RolloutState]] = []
         for state in rollout_state:
             state.sample_params = self.sample_params
-            tasks.append(create_task(generate_one(state)))
+            task = create_task(generate_one(state))
+            tasks.append(task)
+
         return await asyncio.gather(*tasks)
 
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState:
         try:
-            item = rollout_state.extra_fields["rollout_item"].model_copy(deep=True)
-            if rollout_state.uid is None:
-                rollout_state.uid = uuid.uuid4().int
-            item.uid = rollout_state.uid
-            item.group_id = rollout_state.message_uid
-            result = await self._run_item(item)
-            await self._fill_rollout_state(rollout_state, result)
-            return rollout_state
+            if self.sample_timeout_s is not None and self.sample_timeout_s > 0:
+                return await asyncio.wait_for(
+                    self._generate_sample_impl(rollout_state),
+                    timeout=self.sample_timeout_s,
+                )
+            return await self._generate_sample_impl(rollout_state)
+        except asyncio.TimeoutError:
+            self.logger.warning(
+                f"[AgentInLocalhostLoop] sample timed out after {self.sample_timeout_s:.1f}s "
+                f"(uid={rollout_state.uid}, group_id={rollout_state.message_uid})."
+            )
+            return self._fail_rollout_state(
+                rollout_state,
+                finish_reason="timeout",
+                error_msg=f"TimeoutError: localhost agent sample exceeded {self.sample_timeout_s:.1f}s",
+                agent_status="timeout",
+            )
         except Exception as exc:
             if self.mode == "train" and _is_trace_key_mismatch(exc):
                 raise
-            rollout_state.status = Status.COMPLETED if self.mode == "eval" else Status.FAILED
-            rollout_state.finish_reason = "error"
-            if self.mode == "eval":
-                rollout_state.reward = {"score": 0.0}
-                rollout_state.response = ""
-                rollout_state.extra_fields["agent_status"] = "exception"
-            rollout_state.error_msg = f"{type(exc).__name__}: {exc}"
             self.logger.error(f"[AgentInLocalhostLoop] failed: {exc}\n{traceback.format_exc()}")
-            return rollout_state
+            return self._fail_rollout_state(
+                rollout_state,
+                finish_reason="error",
+                error_msg=f"{type(exc).__name__}: {exc}",
+                agent_status="exception",
+            )
+
+    async def _generate_sample_impl(self, rollout_state: RolloutState) -> RolloutState:
+        item = rollout_state.extra_fields["rollout_item"].model_copy(deep=True)
+        if rollout_state.uid is None:
+            rollout_state.uid = uuid.uuid4().int
+        item.uid = rollout_state.uid
+        item.group_id = rollout_state.message_uid
+        result = await self._run_item(item)
+        await self._fill_rollout_state(rollout_state, result)
+        return rollout_state
+
+    def _fail_rollout_state(
+        self,
+        rollout_state: RolloutState,
+        *,
+        finish_reason: str,
+        error_msg: str,
+        agent_status: str,
+    ) -> RolloutState:
+        if rollout_state.uid is None:
+            rollout_state.uid = uuid.uuid4().int
+        rollout_state.status = Status.COMPLETED if self.mode == "eval" else Status.FAILED
+        rollout_state.finish_reason = finish_reason
+        if self.mode == "eval":
+            rollout_state.reward = {"score": 0.0}
+            rollout_state.response = ""
+            rollout_state.extra_fields["agent_status"] = agent_status
+        rollout_state.error_msg = error_msg
+        return rollout_state
 
     async def _run_item(self, item: AgentRolloutItem) -> AgentRolloutItem:
         runner = _resolve_runner(item.pipeline)
@@ -154,10 +211,25 @@ class AgentInLocalhostLoop(AgentLoop):
             self._fill_eval_rollout_state(rollout_state, item)
             return
 
+        response_message = item.artifacts.get("response_message") or {}
         rollout_state.status = Status.COMPLETED if item.status == RolloutStatus.COMPLETED else Status.FAILED
-        rollout_state.finish_reason = "stop" if item.status == RolloutStatus.COMPLETED else "error"
-        rollout_state.reward = {"score": item.reward} if item.reward is not None else None
+        rollout_state.finish_reason = str(
+            response_message.get("finish_reason") or ("stop" if item.status == RolloutStatus.COMPLETED else "error")
+        )
+        rollout_state.reward = _extract_reward_payload(item)
+        rollout_state.extra_fields["agent_status"] = item.status.value
         rollout_state.extra_fields["agent_artifacts"] = item.artifacts
+        rollout_state.extra_fields["agent_judgers"] = {
+            name: record.model_dump(mode="json") for name, record in item.judgers.items()
+        }
+        messages, tools = _load_eval_trace_segment(item.artifacts)
+        if messages:
+            rollout_state.extra_fields["agent_messages"] = messages
+            rollout_state.extra_fields["agent_tools"] = tools
+            rollout_state.extra_fields["agent_tool_turns"] = _count_tool_turns(messages)
+        finish_info = response_message.get("finish_info")
+        if isinstance(finish_info, dict) and finish_info:
+            rollout_state.extra_fields["agent_finish_info"] = finish_info
         if item.error is not None:
             rollout_state.error_msg = f"{item.error.stage}/{item.error.category}: {item.error.message}"
         if item.status != RolloutStatus.COMPLETED:
@@ -180,13 +252,15 @@ class AgentInLocalhostLoop(AgentLoop):
         ]
         rollout_state.logprobs = data["logprobs"]
         rollout_state.routed_experts = data["routed_experts"]
-        rollout_state.response = str(item.artifacts.get("response") or "")
+        content = response_message.get("content")
+        rollout_state.response = content if isinstance(content, str) else (str(content) if content is not None else "")
         rollout_state.extra_fields["raw_prompt"] = prompt_text
 
     def _fill_eval_rollout_state(self, rollout_state: RolloutState, item: AgentRolloutItem) -> None:
         is_success = item.status == RolloutStatus.COMPLETED
+        response_message = item.artifacts.get("response_message") or {}
         rollout_state.status = Status.COMPLETED
-        rollout_state.finish_reason = "stop" if is_success else "error"
+        rollout_state.finish_reason = str(response_message.get("finish_reason") or ("stop" if is_success else "error"))
         rollout_state.reward = {"score": item.reward if is_success and item.reward is not None else 0.0}
         rollout_state.input_ids = None
         rollout_state.labels = None
@@ -200,9 +274,15 @@ class AgentInLocalhostLoop(AgentLoop):
             rollout_state.error_msg = f"{item.error.stage}/{item.error.category}: {item.error.message}"
 
         messages, tools = _load_eval_trace_segment(item.artifacts)
-        rollout_state.response = str(item.artifacts.get("response") or "")
+        content = response_message.get("content")
+        rollout_state.response = content if isinstance(content, str) else (str(content) if content is not None else "")
         if messages:
-            rollout_state.extra_fields["agent_trajectory"] = _to_json_safe({"messages": messages, "tools": tools})
+            rollout_state.extra_fields["agent_messages"] = messages
+            rollout_state.extra_fields["agent_tools"] = tools
+            rollout_state.extra_fields["agent_tool_turns"] = _count_tool_turns(messages)
+        finish_info = response_message.get("finish_info")
+        if isinstance(finish_info, dict) and finish_info:
+            rollout_state.extra_fields["agent_finish_info"] = finish_info
 
 
 __all__ = ["AgentInLocalhostLoop", "AgentInLocalhostLoopConfig"]

--- a/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
+++ b/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
@@ -254,7 +254,6 @@ class AgentInLocalhostLoop(AgentLoop):
         rollout_state.routed_experts = data["routed_experts"]
         content = response_message.get("content")
         rollout_state.response = content if isinstance(content, str) else (str(content) if content is not None else "")
-        rollout_state.extra_fields["raw_prompt"] = prompt_text
 
     def _fill_eval_rollout_state(self, rollout_state: RolloutState, item: AgentRolloutItem) -> None:
         is_success = item.status == RolloutStatus.COMPLETED

--- a/xtuner/v1/rl/agent_loop/localhost_agent_loop/judger.py
+++ b/xtuner/v1/rl/agent_loop/localhost_agent_loop/judger.py
@@ -43,20 +43,22 @@ class LocalhostJudgerStage:
         record.status = StageStatus.RUNNING
         record.started_at = record.started_at or time.monotonic()
         try:
+            # reward_model stays as-is (dataset-provided ground_truth/style etc.).
+            # Per-rollout artifacts (response message, agent trace) flow through extra_fields.
             reward_model = dict(item.reward_model or {})
+            segment = item.artifacts["messages"][-1]
+            response_message = item.artifacts.get("response_message") or {}
+            content = response_message.get("content")
+            response = content if isinstance(content, str) else (str(content) if content is not None else "")
 
-            messages = item.artifacts["messages"][-1]["messages"]
-            tool_turns = sum(
-                1 for message in messages if isinstance(message.get("tool_calls"), list) and message["tool_calls"]
-            )
-            reward_model.setdefault("agent_trace", messages)
-            reward_model.setdefault("num_turns", tool_turns)
-
-            response = str(item.artifacts.get("response") or "")
             rollout_state = RolloutState(
                 message=[{"role": "user", "content": item.instruction}],
                 response=response,
                 reward_model=reward_model,
+                extra_fields={
+                    "agent_messages": segment["messages"],
+                    "response_message": response_message,
+                },
                 status=Status.COMPLETED,
             )
             judged = await self.judger.judge(rollout_state)

--- a/xtuner/v1/rl/agent_loop/localhost_agent_loop/stage.py
+++ b/xtuner/v1/rl/agent_loop/localhost_agent_loop/stage.py
@@ -48,8 +48,10 @@ class LocalhostStage:
             spec = self._pick_agent(item, record)
             agent = create_object(deepcopy(_resolve_agent_config(spec.config)))
             output = await agent(item.instruction)
-            content = output.content if hasattr(output, "content") else output
-            item.artifacts["response"] = content if isinstance(content, str) else str(content)
+            response_message = output.model_dump(mode="json") if hasattr(output, "model_dump") else None
+            if response_message is None:
+                raise TypeError("Agent forward must return an AgentMessage-like object.")
+            item.artifacts["response_message"] = response_message
             messages = agent.get_messages()
             if not isinstance(messages, list) or not messages:
                 raise ValueError("Agent messages artifact must be a non-empty list.")
@@ -59,7 +61,9 @@ class LocalhostStage:
             if not isinstance(segment["messages"], list):
                 raise TypeError("Agent messages trace segment.messages must be a list.")
             item.artifacts["messages"] = messages
-            result = StageResult(stdout=item.artifacts["response"], return_code=0)
+            content = response_message.get("content")
+            stdout = content if isinstance(content, str) else (str(content) if content is not None else "")
+            result = StageResult(stdout=stdout, return_code=0)
             record.entry_result = result
             record.status = StageStatus.COMPLETED
             return result

--- a/xtuner/v1/rl/evaluator.py
+++ b/xtuner/v1/rl/evaluator.py
@@ -18,10 +18,18 @@ def default_compute_metric_func(samples: list[RolloutState]) -> dict[str, float]
         return {"accuracy": 0.0}
 
     positives = []
+    tool_turns_list: list[int] = []
     for s in samples:
         positives.append(1 if _reward_score(s) > 0 else 0)
+        turns = s.extra_fields.get("agent_tool_turns")
+        if isinstance(turns, int):
+            tool_turns_list.append(turns)
 
-    metrics = {"accuracy": sum(positives) / len(positives)}
+    metrics: dict[str, float] = {"accuracy": sum(positives) / len(positives)}
+    if tool_turns_list:
+        metrics["tool_turns/mean"] = sum(tool_turns_list) / len(tool_turns_list)
+        metrics["tool_turns/min"] = float(min(tool_turns_list))
+        metrics["tool_turns/max"] = float(max(tool_turns_list))
     metrics.update(_compute_grouped_pass_metrics(samples, positives))
     return metrics
 

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1376,8 +1376,7 @@ class BaseRLTrainer:
                 ground_truth = None
                 if data.reward_model is not None:
                     ground_truth = data.reward_model.get("ground_truth")
-                response_text_len = len(self.tokenizer.encode(response or "", add_special_tokens=False))
-                response_train_len = len(response_ids)
+                response_len = len(response_ids)
                 trajectory_items.append(
                     {
                         "uid": data.uid,
@@ -1390,14 +1389,9 @@ class BaseRLTrainer:
                         "prompt": data.message,
                         "label": ground_truth,
                         "response": response,
-                        # Backward-compatible scalar aliases for quick tables.
                         "reward": data.reward["score"],
-                        "response_len": response_train_len,
-                        "lengths": {
-                            "num_tokens": data.num_tokens,
-                            "response_train_tokens": response_train_len,
-                            "response_text_tokens": response_text_len,
-                        },
+                        "prompt_len": data.num_tokens,
+                        "response_len": response_len,
                         "reward_payload": data.reward,
                         "agent": {
                             "status": data.extra_fields.get("agent_status", None),
@@ -1441,8 +1435,7 @@ class BaseRLTrainer:
                 reward = data.reward["score"] if data.reward is not None and "score" in data.reward else 0.0
                 response = data.response or ""
                 response_ids = self._get_trajectory_response_ids(data)
-                response_len = len(self.tokenizer.encode(response, add_special_tokens=False))
-                response_train_len = len(response_ids)
+                response_len = len(response_ids)
                 rewards.append(reward)
                 ground_truth = None
                 if data.reward_model is not None:
@@ -1456,12 +1449,8 @@ class BaseRLTrainer:
                         "status": data.status.value if hasattr(data.status, "value") else str(data.status),
                         "prompt": data.message,
                         "response": response,
+                        "prompt_len": data.num_tokens,
                         "response_len": response_len,
-                        "lengths": {
-                            "num_tokens": data.num_tokens,
-                            "response_train_tokens": response_train_len,
-                            "response_text_tokens": response_len,
-                        },
                         "label": ground_truth,
                         "reward": reward,
                         "reward_payload": data.reward or {"score": reward},

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1007,6 +1007,7 @@ class BaseRLTrainer:
         advantages_list = []
         prompt_len_list = []
         response_len_list = []
+        tool_turns_list: list[int] = []
         training_tokens = 0
 
         data_batches = []
@@ -1033,6 +1034,9 @@ class BaseRLTrainer:
                     f"Reward is missing or does not contain 'score' key in data: {data}"
                 )
                 rewards.append(data.reward["score"])
+                turns = data.extra_fields.get("agent_tool_turns")
+                if isinstance(turns, int):
+                    tool_turns_list.append(turns)
 
             rewards_list.extend(rewards)
             rewards_tensor = torch.tensor(rewards, dtype=torch.float32)
@@ -1204,6 +1208,11 @@ class BaseRLTrainer:
             "prompt_len/min": prompt_len_t.min().item(),
             "prompt_len/max": prompt_len_t.max().item(),
         }
+        if tool_turns_list:
+            tool_turns_t = torch.tensor(tool_turns_list, dtype=torch.float32)
+            info_dict["tool_turns/mean"] = tool_turns_t.mean().item()
+            info_dict["tool_turns/min"] = float(tool_turns_t.min().item())
+            info_dict["tool_turns/max"] = float(tool_turns_t.max().item())
         return data_batches, info_dict
 
     def _compute_benchmark_metrics(
@@ -1367,15 +1376,37 @@ class BaseRLTrainer:
                 ground_truth = None
                 if data.reward_model is not None:
                     ground_truth = data.reward_model.get("ground_truth")
+                response_text_len = len(self.tokenizer.encode(response or "", add_special_tokens=False))
+                response_train_len = len(response_ids)
                 trajectory_items.append(
                     {
-                        "prompt": data.message,
-                        "raw_prompt": data.extra_fields.get("raw_prompt", None),
-                        "response": response,
-                        "response_len": len(response_ids),
-                        "label": ground_truth,
-                        "reward": data.reward["score"],
+                        "uid": data.uid,
+                        "message_uid": data.message_uid,
+                        "task_name": data.task_name,
+                        "data_source": data.data_source,
+                        "status": data.status.value if hasattr(data.status, "value") else str(data.status),
                         "finish_reason": data.finish_reason,
+                        "error_msg": data.error_msg,
+                        "prompt": data.message,
+                        "label": ground_truth,
+                        "response": response,
+                        # Backward-compatible scalar aliases for quick tables.
+                        "reward": data.reward["score"],
+                        "response_len": response_train_len,
+                        "lengths": {
+                            "num_tokens": data.num_tokens,
+                            "response_train_tokens": response_train_len,
+                            "response_text_tokens": response_text_len,
+                        },
+                        "reward_payload": data.reward,
+                        "agent": {
+                            "status": data.extra_fields.get("agent_status", None),
+                            "judgers": data.extra_fields.get("agent_judgers", None),
+                            "finish_info": data.extra_fields.get("agent_finish_info", None),
+                            "tool_turns": data.extra_fields.get("agent_tool_turns", None),
+                            "messages": data.extra_fields.get("agent_messages"),
+                            "tools": data.extra_fields.get("agent_tools"),
+                        },
                     }
                 )
 
@@ -1395,10 +1426,10 @@ class BaseRLTrainer:
                 "response_len_min": response_lens.min().item(),
                 "total_len": len(rewards),
             }
-            json.dump(summary, f, ensure_ascii=False, indent=2)
+            json.dump(summary, f, ensure_ascii=False, separators=(",", ":"))
             f.write("\n")
             for item in trajectory_items:
-                json.dump(item, f, ensure_ascii=False, indent=2)
+                json.dump(item, f, ensure_ascii=False, separators=(",", ":"))
                 f.write("\n")
 
     def _save_eval_trajectories(self, data_groups: list[list[RolloutState]], save_path: Path) -> None:
@@ -1409,22 +1440,40 @@ class BaseRLTrainer:
             for data in group:
                 reward = data.reward["score"] if data.reward is not None and "score" in data.reward else 0.0
                 response = data.response or ""
+                response_ids = self._get_trajectory_response_ids(data)
                 response_len = len(self.tokenizer.encode(response, add_special_tokens=False))
+                response_train_len = len(response_ids)
                 rewards.append(reward)
                 ground_truth = None
                 if data.reward_model is not None:
                     ground_truth = data.reward_model.get("ground_truth")
                 trajectory_items.append(
                     {
+                        "uid": data.uid,
+                        "message_uid": data.message_uid,
+                        "task_name": data.task_name,
+                        "data_source": data.data_source,
+                        "status": data.status.value if hasattr(data.status, "value") else str(data.status),
                         "prompt": data.message,
                         "response": response,
                         "response_len": response_len,
+                        "lengths": {
+                            "num_tokens": data.num_tokens,
+                            "response_train_tokens": response_train_len,
+                            "response_text_tokens": response_len,
+                        },
                         "label": ground_truth,
                         "reward": reward,
+                        "reward_payload": data.reward or {"score": reward},
                         "finish_reason": data.finish_reason,
                         "error_msg": data.error_msg,
-                        "agent_status": data.extra_fields.get("agent_status", None),
-                        "agent_trajectory": data.extra_fields.get("agent_trajectory", None),
+                        "agent": {
+                            "status": data.extra_fields.get("agent_status", None),
+                            "finish_info": data.extra_fields.get("agent_finish_info", None),
+                            "tool_turns": data.extra_fields.get("agent_tool_turns", None),
+                            "messages": data.extra_fields.get("agent_messages"),
+                            "tools": data.extra_fields.get("agent_tools"),
+                        },
                     }
                 )
 
@@ -1444,10 +1493,10 @@ class BaseRLTrainer:
                 "response_len_min": response_lens.min().item(),
                 "total_len": len(rewards),
             }
-            json.dump(summary, f, ensure_ascii=False, indent=2)
+            json.dump(summary, f, ensure_ascii=False, separators=(",", ":"))
             f.write("\n")
             for item in trajectory_items:
-                json.dump(item, f, ensure_ascii=False, indent=2)
+                json.dump(item, f, ensure_ascii=False, separators=(",", ":"))
                 f.write("\n")
 
     def _get_trajectory_response_ids(self, data: RolloutState) -> list[int]:


### PR DESCRIPTION
- Stage surfaces full AgentMessage dump as artifacts["response_message"]; judger / _fill_rollout_state read finish_info / content from it directly.
- Move tool_turns counting into agent_in_localhost_loop (single source); trainer / evaluator just read extra_fields["agent_tool_turns"] and emit tool_turns/{mean,min,max} to tensorboard.
- Trajectory dump: drop redundant fields (final_assistant_finish_reason, raw_prompt, lengths.input_tokens) and helper chain; messages/tools/tool_turns moved under agent.* sub-key. Switch to one-line JSONL records.
- Drop _to_json_safe / _dump_jsonl_record wrappers; explicit model_dump only where needed (StageRecord). Remove dead isinstance(Tensor) branches.
- Drop local _TokenBucket (use lagent.utils.rate_limiter.FairAsyncTokenBucket via API-level rate limiting in tools).