### PR TITLE
refine controller and worker concurrency

### DIFF
--- a/docs/en/rl/advanced_tutorial/efficiency.md
+++ b/docs/en/rl/advanced_tutorial/efficiency.md
@@ -11,23 +11,24 @@ During the Rollout phase of Xtuner, properly configuring concurrency-related par
    - Xtuner will provide recommended configurations for common models and context lengths in future releases.
 
 2. **RolloutConfig.allow_over_concurrency_ratio**
-   - Controls the over-concurrency ratio for HTTP requests to ensure the inference engine is fully loaded.
+   - Deprecated compatibility option. It no longer controls runtime rollout concurrency.
+   - If this option is set to a non-default value, Xtuner emits a warning and ignores it. Ray actor concurrency and HTTP client connection caps are now fixed to large internal values so requests do not queue before reaching the inference engine.
 
 3. **DataflowConfig.max_concurrent**
    - Controls the maximum number of concurrent tasks in Dataflow. Dataflow acts as a single controller, distributing data to all rollout workers.
    - Dataflow sends a batch of data each time; the actual number of data items sent at the same time is `max_concurrent * prompt_repeat_k`.
-   - It is recommended to set this slightly higher than the actual processing capability of the inference engine to ensure the inference queue always has tasks.
+   - It is recommended to start from the total inference capacity divided by `prompt_repeat_k`, then tune based on GPU utilization, inference queue length, and latency.
 
 4. **httpx max connections**
-   - Controls the maximum number of concurrent connections that the HTTP client (such as RolloutWorker) can initiate to the inference service.
-   - It is recommended to set this equal to or slightly higher than `rollout_max_batch_size_per_instance`.
+   - This is no longer a user-facing tuning parameter.
+   - Xtuner sets the RolloutWorker HTTP client connection cap to a large internal value so requests do not queue in httpx; the inference engine owns request scheduling and queueing.
 
 ## Configuration Relationships and Recommendations
 
 - **Recommended Configuration Process**:
-  1. Determine a reasonable value for `rollout_max_batch_size_per_instance` based on the model and hardware resources (e.g., 128, 256, 512, 1024). This parameter is optional; if not provided, Xtuner will use preset values based on `context_length`: concurrency is 1024 for `context_length` ≤ 4K, 512 for ≤ 16K, and 128 for ≤ 32K.
-  2. Set `DataflowConfig.max_concurrent`. It is recommended to use `rollout_max_batch_size_per_instance * num_of_infer_instance / prompt_repeat_k * allow_over_concurrency_ratio`, where `num_of_infer_instance` is the number of inference engine instances started (usually number of nodes / `tensor_parallel_size`).
-  3. The default httpx max connections should be set to `rollout_max_batch_size_per_instance * allow_over_concurrency_ratio`.
+  1. Determine a reasonable value for `rollout_max_batch_size_per_instance` based on the model and hardware resources (e.g., 128, 256, 512, 1024). This parameter is optional; if not provided, Xtuner will use preset values based on `context_length`: concurrency is 1024 for `context_length` ≤ 4K, 512 for ≤ 8K, and 128 for longer contexts.
+  2. Set `DataflowConfig.max_concurrent`. A practical starting point is `rollout_max_batch_size_per_instance * num_of_infer_instance / prompt_repeat_k`, where `num_of_infer_instance` is the number of inference engine instances started. Tune this value with runtime metrics.
+  3. Do not tune `allow_over_concurrency_ratio` or httpx max connections for rollout efficiency. `allow_over_concurrency_ratio` is deprecated, and httpx max connections are handled by Xtuner internals.
 
 - **Dynamic Adjustment**: You can dynamically adjust these parameters by monitoring the inference queue length, GPU utilization, and response latency to find the optimal concurrency configuration.
 
@@ -44,10 +45,10 @@ rollout = RolloutConfig(
 )
 
 dataflow = DataflowConfig(
-    max_concurrent=600, # int(1024 * (8 / 1) / 16 * 1.2)
+    max_concurrent=512, # int(1024 * (8 / 1) / 16)
     prompt_repeat_k=16,
     ...
 )
 
-# Ray actor concurrency for RolloutController and RolloutWorker is computed automatically from rollout config.
+# Ray actor concurrency and RolloutWorker httpx max connections are handled by Xtuner internals.
 ```

--- a/docs/zh_cn/rl/advanced_tutorial/efficiency.md
+++ b/docs/zh_cn/rl/advanced_tutorial/efficiency.md
@@ -11,23 +11,24 @@
    - Xtuner 后续会提供常见模型与上下文长度下的推荐配置。
 
 2. **RolloutConfig.allow_over_concurrency_ratio**
-   - 控制 HTTP 请求的超额并发比例，用于保证能够打满推理引擎。
+   - 已废弃的兼容配置项，不再控制运行时 rollout 并发。
+   - 如果用户将该项设置为非默认值，Xtuner 会打印 warning 并忽略该值。Ray actor 并发和 HTTP 客户端连接上限现在由内部固定大值控制，避免请求在到达推理引擎前排队。
 
 3. **DataflowConfig.max_concurrent**
    - 控制 Dataflow 的最大并发任务数。Dataflow 为单一控制器，负责所有 rollout worker 的数据分发。
    - Dataflow 每次发送一组数据，实际同一时间内发送的数据条数为 `max_concurrent * prompt_repeat_k`。
-   - 建议设置为略高于推理引擎实际处理能力，以保证推理队列始终有任务。
+   - 建议从推理引擎总处理能力除以 `prompt_repeat_k` 开始设置，再根据 GPU 利用率、推理队列长度和延迟进行调整。
 
 4. **httpx 最大连接数**
-   - 控制 HTTP 客户端（如 RolloutWorker）发起到推理服务的最大并发连接数。
-   - 建议与 `rollout_max_batch_size_per_instance` 保持一致或略高。
+   - 该项不再是用户需要调节的参数。
+   - Xtuner 会将 RolloutWorker 的 HTTP 客户端连接上限设置为内部固定大值，避免请求在 httpx 侧排队；请求调度和排队由推理引擎负责。
 
 ## 配置关系与建议
 
 - **推荐配置流程**：
-  1. 根据模型和硬件资源，确定合理的 `rollout_max_batch_size_per_instance`（如 128、256、512、 1024）。该参数为可选，若用户不提供，Xtuner 会根据 `context_length` 提供预设值：`context_length` ≤ 4K 时并发度为 1024，≤ 16K 时并发度为 512，≤ 32K 时并发度为 128。
-  2. 设定 `DataflowConfig.max_concurrent`，建议为 `rollout_max_batch_size_per_instance * num_of_infer_instance / prompt_repeat_k * allow_over_concurrency_ratio`。其中 `num_of_infer_instance` 为启动的推理引擎实例数量，一般为节点数 / `tensor_parallel_size`。
-  3. httpx 最大连接数默认配置为 `rollout_max_batch_size_per_instance * allow_over_concurrency_ratio`。
+  1. 根据模型和硬件资源，确定合理的 `rollout_max_batch_size_per_instance`（如 128、256、512、1024）。该参数为可选，若用户不提供，Xtuner 会根据 `context_length` 提供预设值：`context_length` ≤ 4K 时并发度为 1024，≤ 8K 时并发度为 512，更长上下文时并发度为 128。
+  2. 设定 `DataflowConfig.max_concurrent`，一个实用的起点是 `rollout_max_batch_size_per_instance * num_of_infer_instance / prompt_repeat_k`。其中 `num_of_infer_instance` 为启动的推理引擎实例数量。之后根据运行时指标继续调整。
+  3. 不要再通过 `allow_over_concurrency_ratio` 或 httpx 最大连接数调节 rollout 效率。`allow_over_concurrency_ratio` 已废弃，httpx 最大连接数由 Xtuner 内部处理。
 
 - **动态调整**：可通过监控推理队列长度、GPU 利用率和响应延迟，动态调整上述参数，找到最优并发配置。
 
@@ -44,10 +45,10 @@ rollout = RolloutConfig(
 )
 
 dataflow = DataflowConfig(
-    max_concurrent=600, # int(1024 * (8 / 1) / 16 * 1.2)
+    max_concurrent=512, # int(1024 * (8 / 1) / 16)
     prompt_repeat_k=16,
     ...
 )
 
-# RolloutController 和 RolloutWorker 的 Ray actor 并发由 Xtuner 根据 rollout 配置自动计算。
+# RolloutController / RolloutWorker 的 Ray actor 并发以及 RolloutWorker 的 httpx 最大连接数由 Xtuner 内部处理。
 ```

--- a/examples/v1/config/agentic_rl_qwen3p5vl_mtp_ep_code.py
+++ b/examples/v1/config/agentic_rl_qwen3p5vl_mtp_ep_code.py
@@ -153,7 +153,6 @@ rollout_config = RolloutConfig(
     context_length=max_response_length,
     enable_return_routed_experts=True,
     rollout_max_batch_size_per_instance=128,
-    allow_over_concurrency_ratio=2.0,
     rollout_timeout=1200,
     session_server_timeout=1200,
     health_check_interval_seconds=300.0,

--- a/tests/rl/test_qwen35_vl_moe_async_train_2step.py
+++ b/tests/rl/test_qwen35_vl_moe_async_train_2step.py
@@ -181,9 +181,9 @@ class TestQwen35VLMoEAsyncTrain2Step(unittest.TestCase):
             expert_parallel_size=2,
             gpu_memory_utilization=0.8,
             context_length=MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH,
-            # Keep this comfortably above the per-server request concurrency
-            # required by train_batch_size * prompt_repeat_k * (1 + over_sample_threshold) / 8 servers.
             rollout_max_batch_size_per_instance=128,
+            # Deprecated compatibility option; fixed rollout constants now
+            # keep Ray/httpx from queueing before the inference engine.
             allow_over_concurrency_ratio=1.0,
             enable_return_routed_experts=True,
             extra_rollout_config={

--- a/tests/rl/test_rl_trainer_checkpoint.py
+++ b/tests/rl/test_rl_trainer_checkpoint.py
@@ -218,12 +218,6 @@ class TestRLTrainerCheckpoint(unittest.TestCase):
             patch("xtuner.v1.train.rl_trainer.BaseRLTrainer._release_trace_store", return_value=None),
             patch.object(WorkerConfig, "build", autospec=True, side_effect=build_train_controller),
             patch.object(RolloutConfig, "build", autospec=True, side_effect=build_rollout_controller),
-            patch.object(
-                RolloutConfig,
-                "get_controller_generate_concurrency",
-                autospec=True,
-                side_effect=lambda rollout_cfg, placement_group: rollout_cfg.generate_concurrency_per_instance,
-            ),
         ):
             yield runtime
 

--- a/tests/rl/test_rollout_config_dist_port_base_patch.py
+++ b/tests/rl/test_rollout_config_dist_port_base_patch.py
@@ -25,3 +25,23 @@ def test_rollout_config_default_dist_port_base_is_staggered(monkeypatch):
     assert second.dist_port_base == base + 24
     assert explicit.dist_port_base == 45678
     assert third.dist_port_base == base + 48
+
+
+def test_rollout_config_warns_for_deprecated_allow_over_concurrency_ratio(monkeypatch):
+    monkeypatch.delenv("XTUNER_USE_SGLANG", raising=False)
+    monkeypatch.delenv("XTUNER_USE_VLLM", raising=False)
+    monkeypatch.setenv("XTUNER_USE_LMDEPLOY", "1")
+
+    warnings = []
+
+    class _FakeLogger:
+        def warning(self, message):
+            warnings.append(message)
+
+    monkeypatch.setattr("xtuner.v1.rl.rollout.worker.get_logger", lambda *args, **kwargs: _FakeLogger())
+
+    _build_rollout_config(allow_over_concurrency_ratio=2.0)
+
+    assert len(warnings) == 1
+    assert "allow_over_concurrency_ratio is deprecated" in warnings[0]
+    assert "will be ignored" in warnings[0]

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import math
 from abc import ABC, abstractmethod
 from typing import Any, TypeAlias, cast, overload
 
@@ -13,6 +12,7 @@ from ray.util.placement_group import PlacementGroup
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
+from xtuner.v1.rl.rollout.constants import AGENT_LOOP_RAY_GENERATE_MAX_CONCURRENCY
 from xtuner.v1.rl.utils import (
     JUDGER_PAUSE_JUDGE_TASK_TIMEOUT_S,
     CPUActorLauncher,
@@ -43,12 +43,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 logger=logger,
             )
 
-        get_generate_concurrency = rollout_controller.get_generate_concurrency
-        if hasattr(get_generate_concurrency, "remote"):
-            total_generate_concurrency = ray.get(get_generate_concurrency.remote())
-        else:
-            total_generate_concurrency = get_generate_concurrency()
-        concurrency = max(1, math.ceil(total_generate_concurrency / self.cpu_resources.num_workers))
+        concurrency = AGENT_LOOP_RAY_GENERATE_MAX_CONCURRENCY
 
         register_cpu_resources(
             name=f"agent_loop:{self.__class__.__name__}",

--- a/xtuner/v1/rl/rollout/constants.py
+++ b/xtuner/v1/rl/rollout/constants.py
@@ -12,7 +12,7 @@ ROLLOUT_HTTP_MAX_CONNECTIONS = 100_000
 # Ray actor method concurrency cap for rollout generate paths. This is
 # intentionally far above expected producer fan-out so RolloutController and
 # RolloutWorker actors do not become the queueing point.
-ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY = 100_000_000
+ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY = 1_000_000
 
 # Agent-loop actors should also avoid adding an independent queue in front of
 # rollout generation. Producer pending limits remain the effective fan-out

--- a/xtuner/v1/rl/rollout/constants.py
+++ b/xtuner/v1/rl/rollout/constants.py
@@ -1,0 +1,21 @@
+"""Rollout-wide constants.
+
+Producer strategies control the real rollout fan-out with their scheduled
+pending task targets. These large caps keep Ray actors and HTTP client pools
+from introducing extra queues before requests reach the inference engine.
+"""
+
+# Per-rollout-worker HTTP connection cap. httpx does not pre-open these
+# connections; this only keeps its connection pool from becoming the normal
+# rollout queue. The inference engine should own request scheduling.
+ROLLOUT_HTTP_MAX_CONNECTIONS = 100_000
+
+# Ray actor method concurrency cap for rollout generate paths. This is
+# intentionally far above expected producer fan-out so RolloutController and
+# RolloutWorker actors do not become the queueing point.
+ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY = 100_000_000
+
+# Agent-loop actors should also avoid adding an independent queue in front of
+# rollout generation. Producer pending limits remain the effective fan-out
+# control.
+AGENT_LOOP_RAY_GENERATE_MAX_CONCURRENCY = ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY

--- a/xtuner/v1/rl/rollout/constants.py
+++ b/xtuner/v1/rl/rollout/constants.py
@@ -1,8 +1,7 @@
 """Rollout-wide constants.
 
-Producer strategies control the real rollout fan-out with their scheduled
-pending task targets. These large caps keep Ray actors and HTTP client pools
-from introducing extra queues before requests reach the inference engine.
+Producer strategies control the real rollout fan-out with their scheduled pending task targets. These large caps keep
+Ray actors and HTTP client pools from introducing extra queues before requests reach the inference engine.
 """
 
 # Per-rollout-worker HTTP connection cap. httpx does not pre-open these

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -11,6 +11,7 @@ from xtuner.v1.data_proto.rl_data import RolloutState, Status
 from xtuner.v1.rl.utils import AutoAcceleratorWorkers
 from xtuner.v1.utils import XTUNER_DETERMINISTIC, get_logger
 
+from .constants import ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY
 from .health_manager import ROLLOUT_RAY_GET_TIMEOUT, RolloutHealthManager
 from .parser.factory import build_reasoning_parser, build_tool_call_parser
 from .parser.reasoning_parser import ReasoningParser
@@ -49,9 +50,6 @@ class RolloutController:
         self.num_gpus_per_engine = self.config.num_gpus_per_engine
         self.logger = get_logger(log_dir=infer_config.worker_log_dir, tag="RolloutController")
         self.registry = self._init_workers(placement_group)
-        # Cache the exact controller concurrency chosen at build time so
-        # downstream components observe the same limit as the Ray actor.
-        self._generate_concurrency = self.config.get_controller_generate_concurrency(placement_group)
         # The timeout for the environment to wait for the rollout controller's response.
         # This should be longer than the controller's internal timeout (`rollout_timeout`)
         # to account for potential queuing delays and other overheads.
@@ -89,9 +87,6 @@ class RolloutController:
             reasoning_parser = build_reasoning_parser(self.config.reasoning_parser, tokenizer)
 
         return tool_call_parser, reasoning_parser
-
-    def get_generate_concurrency(self) -> int:
-        return self._generate_concurrency
 
     @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     async def generate(self, rollout_state: RolloutState) -> RolloutState:
@@ -218,13 +213,9 @@ class RolloutController:
         assert self.config.rollout_max_batch_size_per_instance is not None, (
             "rollout_max_batch_size_per_instance must be set before building RolloutWorker."
         )
-        worker_generate_max_concurrency = max(
-            1000,  # Ray async actor default max_concurrency.
-            self.config.generate_concurrency_per_instance,
-        )
         return ray.remote(
             concurrency_groups={
-                ROLLOUT_CONCURRENCY_GROUP_GENERATE: worker_generate_max_concurrency,
+                ROLLOUT_CONCURRENCY_GROUP_GENERATE: ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY,
             },
         )(worker_base_cls)
 

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -432,6 +432,15 @@ class RolloutConfig(BaseModel):
         return self.expert_parallel_size if self.expert_parallel_size > 1 else self.tensor_parallel_size
 
     def model_post_init(self, __context: Any) -> None:
+        default_allow_over_concurrency_ratio = type(self).model_fields["allow_over_concurrency_ratio"].default
+        if self.allow_over_concurrency_ratio != default_allow_over_concurrency_ratio:
+            get_logger().warning(
+                "rollout_config.allow_over_concurrency_ratio is deprecated and no longer controls runtime "
+                "rollout concurrency. The configured value "
+                f"{self.allow_over_concurrency_ratio} will be ignored; fixed rollout concurrency caps from "
+                "xtuner.v1.rl.rollout.constants are used instead."
+            )
+
         if self.model_name is None:
             model_name_from_config = None
             config_json_path = Path(self.model_path) / "config.json"

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -1,7 +1,6 @@
 import asyncio
 import copy
 import json
-import math
 import multiprocessing
 import os
 import threading
@@ -39,6 +38,7 @@ from xtuner.v1.rl.utils import (
 from xtuner.v1.utils import get_logger
 from xtuner.v1.utils.httpx_utils import HttpRequestErrorType, HttpRequestResult
 
+from .constants import ROLLOUT_HTTP_MAX_CONNECTIONS, ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY
 from .health_manager import ROLLOUT_RAY_GET_TIMEOUT
 from .session_server import SessionServerActor
 from .utils import PartialRolloutHandler
@@ -146,8 +146,8 @@ class RolloutConfig(BaseModel):
         rollout_cross_node_comm (bool): Enable cross-node communication. Defaults to False.
         rollout_max_batch_size_per_instance (int): Maximum batch size for the rollout worker. If not set, it
             will be determined automatically based on `context_length`. Defaults to 512.
-        allow_over_concurrency_ratio (float): Factor to allow over-concurrency in HTTP requests for the
-            rollout worker to improve GPU utilization. Defaults to 1.2.
+        allow_over_concurrency_ratio (float): Deprecated compatibility option. Rollout runtime concurrency is
+            controlled by fixed caps in xtuner.v1.rl.rollout.constants. Defaults to 1.2.
         tensor_parallel_size (int): GPUs per inference engine (tensor parallelism). Defaults to 1.
         expert_parallel_size (int): Experts per inference engine (expert parallelism). Defaults to 1.
         enable_chunked_prefill (bool): Enable chunked prefill for memory efficiency. Defaults to False.
@@ -234,7 +234,10 @@ class RolloutConfig(BaseModel):
         float,
         Parameter(
             group=infer_group,
-            help="Factor to allow over concurrency in the http request for rollout worker to improve GPU utilization.",
+            help=(
+                "Deprecated compatibility option. Rollout runtime concurrency is controlled by fixed caps in "
+                "xtuner.v1.rl.rollout.constants."
+            ),
         ),
     ] = 1.2
     tensor_parallel_size: Annotated[
@@ -428,24 +431,6 @@ class RolloutConfig(BaseModel):
     def num_gpus_per_engine(self) -> int:
         return self.expert_parallel_size if self.expert_parallel_size > 1 else self.tensor_parallel_size
 
-    @property
-    def generate_concurrency_per_instance(self) -> int:
-        assert self.rollout_max_batch_size_per_instance is not None, (
-            "rollout_max_batch_size_per_instance must be set before computing generate concurrency."
-        )
-        return math.ceil(self.rollout_max_batch_size_per_instance * self.allow_over_concurrency_ratio)
-
-    def get_controller_generate_concurrency(self, placement_group: "PlacementGroup") -> int:
-        worker_base_cls = get_rollout_worker_base_cls(self)
-        sorted_bundle_idxs, _, _, _ = AutoAcceleratorWorkers.get_spmd_info(placement_group)
-        rank_bundle_idx_list = [(rank, bundle_idx) for rank, bundle_idx in enumerate(sorted_bundle_idxs)]
-        engine_launch_specs = worker_base_cls.build_engine_launch_specs(self, rank_bundle_idx_list)
-        request_entrypoint_count = sum(
-            len(engine_spec.request_entrypoint_servers) for engine_spec in engine_launch_specs
-        )
-        generate_max_concurrency = request_entrypoint_count * self.generate_concurrency_per_instance
-        return generate_max_concurrency
-
     def model_post_init(self, __context: Any) -> None:
         if self.model_name is None:
             model_name_from_config = None
@@ -506,12 +491,10 @@ class RolloutConfig(BaseModel):
             name="rollout_controller",
             cpu_resources=CPUResourcesConfig(num_workers=num_workers),
         )
-        generate_max_concurrency = self.get_controller_generate_concurrency(placement_group)
-        get_logger().info(f"Calculated RolloutController generate concurrency: {generate_max_concurrency}")
         return (
             ray.remote(
                 concurrency_groups={
-                    ROLLOUT_CONCURRENCY_GROUP_GENERATE: generate_max_concurrency,
+                    ROLLOUT_CONCURRENCY_GROUP_GENERATE: ROLLOUT_RAY_GENERATE_MAX_CONCURRENCY,
                 },
             )(RolloutController)
             .options(num_cpus=num_workers)
@@ -558,8 +541,10 @@ class RolloutWorker(SingleAcceleratorWorker):
         self.endpoints: dict[str, str] = dict()
         self.engine_rank_mesh_array: list[list[int]] = []
         self.engine_launch_spec: EngineLaunchSpec | None = None
-        # http_concurrency is calculated based on the max batch size per engine and the total number of engines
-        http_concurrency = config.generate_concurrency_per_instance
+        # Keep this deliberately large so requests do not queue in the
+        # RolloutWorker/httpx client; the inference engine owns rollout request
+        # scheduling and queueing.
+        http_concurrency = ROLLOUT_HTTP_MAX_CONNECTIONS
         limits = httpx.Limits(max_connections=http_concurrency, max_keepalive_connections=100)
         self.client = httpx.AsyncClient(limits=limits, timeout=self.config.rollout_timeout)
         self.server_task = None

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -659,51 +659,6 @@ class BaseRLTrainer:
             )
         self._rollout_config = cfg.rollout_config
 
-    def _ensure_rollout_http_concurrency(
-        self,
-        cfg: BaseRLTrainerConfig,
-        rollout_pg,
-    ) -> None:
-        rollout_max_batch_size = cfg.rollout_config.rollout_max_batch_size_per_instance
-        if rollout_max_batch_size is None or rollout_max_batch_size <= 0:
-            return
-
-        current_http_concurrency = math.ceil(rollout_max_batch_size * cfg.rollout_config.allow_over_concurrency_ratio)
-        if current_http_concurrency <= 0:
-            return
-
-        total_generate_concurrency = cfg.rollout_config.get_controller_generate_concurrency(rollout_pg)
-        active_rollout_worker_count = total_generate_concurrency // current_http_concurrency
-        if active_rollout_worker_count <= 0:
-            return
-
-        tasks = cfg.agent_loop_manager_cfg.tasks
-        task_cfgs = tasks if isinstance(tasks, list) else [tasks]
-        total_weight = sum(task.weight for task in task_cfgs)
-        if total_weight <= 0:
-            return
-
-        scheduled_http_requests = 0.0
-        for task in task_cfgs:
-            task_batch_size = cfg.train_batch_size * task.weight / total_weight
-            over_sample_threshold = float(getattr(task.produce_strategy_config, "over_sample_threshold", 0.0))
-            scheduled_http_requests += (
-                task_batch_size * task.sampler_config.prompt_repeat_k * (1 + over_sample_threshold)
-            )
-
-        required_http_concurrency = math.ceil(scheduled_http_requests / active_rollout_worker_count)
-        if current_http_concurrency >= required_http_concurrency:
-            return
-
-        new_ratio = required_http_concurrency / rollout_max_batch_size
-        cfg.rollout_config.allow_over_concurrency_ratio = new_ratio
-        self.logger.warning(
-            "Increasing rollout_config.allow_over_concurrency_ratio because httpx max_connections is smaller "
-            "than the expected per-worker rollout request concurrency: "
-            f"max_connections={current_http_concurrency}, "
-            f"required_connections={required_http_concurrency}"
-        )
-
     def _init_runtime_flags(self, cfg: BaseRLTrainerConfig) -> None:
         self._enable_evaluate = cfg.enable_evaluate
         self._enable_initial_evaluate = cfg.enable_initial_evaluate and cfg.enable_evaluate
@@ -1597,7 +1552,6 @@ class RLColocateTrainer(BaseRLTrainer):
         self._cpu_resource_manager = CPUResourceManager(self._pg)
         self._cpu_resource_manager.log_initial_snapshot()
         set_cpu_resource_manager(self._cpu_resource_manager)
-        self._ensure_rollout_http_concurrency(cfg, self._pg)
 
         if self._debug_rollout:
             if self._rollout_config.skip_load_weights:
@@ -1820,7 +1774,6 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
         self._cpu_resource_manager = CPUResourceManager([self._train_pg, self._rollout_pg])
         self._cpu_resource_manager.log_initial_snapshot()
         set_cpu_resource_manager(self._cpu_resource_manager)
-        self._ensure_rollout_http_concurrency(cfg, self._rollout_pg)
         self.train_controller = self._train_worker_cfg.build(self._train_pg)
         self.rollout_controller = self._rollout_config.build(self._rollout_pg)
         if _trainer_config_needs_routed_api_proxy(cfg):

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import math
 import os
 import random
 import re


### PR DESCRIPTION
考虑到并发设置不合理会导致推理引擎并发数不够，同时可能存在 abort 阶段状态难以控制的难题。因此在优化前核心逻辑是：
- rollout controller 和 worker 的 generate 方法并发尽可能大一点，不允许在 ray 中排队
- 推理引擎的最大并发数不能小于在给定 global batch size，防止在 xtuner 的 httpx client 中出现排队现象，造成 abort 状态难以追踪的问题

但是之前实现过于复杂，实际上可以简化
- rollout controller 和 worker 的 generate 方法可以直接设置超大并发数，不允许在 ray 中排队
- 推理引擎的最大并发数也设置为超大，防止在 xtuner 的 httpx client 中出现排队现象，造成 abort 状态难以追踪的问题

同时因为 producer 会从 global batch size 源头控制 task 数，因此上述的并发数设置为超大并不会导致说推理引擎压力过大的问题。整个优化没有破坏之前的核心原则。