### PR TITLE
[Fix] Authenticate claude-general workflow as the comment author

### DIFF
--- a/.github/workflows/claude-general.yml
+++ b/.github/workflows/claude-general.yml
@@ -123,7 +123,7 @@ jobs:
             const issue = context.payload.issue;
             const isPR = issue && issue.pull_request;
 
-            let author, headRef, headRepo;
+            let headRef, headRepo;
 
             if (isPR) {
               // This is a PR comment, fetch PR details
@@ -132,19 +132,21 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.issue.number,
               });
-              author = pr.data.user.login;
               headRef = pr.data.head.ref;
               headRepo = pr.data.head.repo.full_name;
-            } else {
-              // This is a pure issue comment
-              author = issue.user.login;
             }
 
+            // Authenticate as the commenter, never as the PR/issue author. This job is reachable by
+            // anyone (allowed_non_write_users: "*"), so keying the PAT off the PR author would let an
+            // arbitrary commenter drive Claude with that author's push credentials. CONTRIBUTOR_PATS
+            // doubles as the authorization allowlist: an unlisted commenter must not reach Claude.
+            const commenter = context.payload.comment.user.login;
+
             const pats = JSON.parse(process.env.CONTRIBUTOR_PATS);
-            const token = pats[author];
+            const token = pats[commenter];
 
             if (!token) {
-              core.setFailed(`No PAT found for user: ${author}`);
+              core.setFailed(`No PAT found for user: ${commenter}`);
               return;
             }
 


### PR DESCRIPTION
## Root Cause

The `claude-comment` job in `.github/workflows/claude-general.yml` selected a contributor PAT from `CONTRIBUTOR_PATS` keyed by the **PR/issue author**, not by the user who wrote the triggering comment:

```js
author = pr.data.user.login;   // PR branch
author = issue.user.login;     // issue branch
const token = pats[author];
```

The job is gated only by `contains(github.event.comment.body, "@claude")` and runs with `allowed_non_write_users: "*"`, so any user can trigger it. On a PR opened by a contributor who has a PAT registered, the comment author was never checked — the workflow resolved that contributor’s PAT and handed it to Claude, which is instructed to push with it. This let an arbitrary commenter act with another contributor’s push credentials.

## Fix

Key the PAT lookup off `context.payload.comment.user.login`. `CONTRIBUTOR_PATS` then serves as the authorization allowlist it was presumably meant to be: a commenter who is not listed fails the job before Claude runs.

The PR lookup is kept, since `head.ref` / `head.repo` are still needed for the fork-push instructions, but it no longer contributes to authentication. The issue/PR branches now share one identity rule, so the `else` branch is gone.

Note this intentionally tightens a second case: a listed contributor commenting on someone else’s fork PR now authenticates as themselves, so the fork push only succeeds if they actually have access to that fork.

## Test Plan

The step is inline `actions/github-script`, so it was extracted and executed directly against stubbed `github` / `context` / `core` objects, comparing `HEAD~1` vs. the fix with `CONTRIBUTOR_PATS = {victim, trusted}`:

| scenario | before | after |
| --- | --- | --- |
| unlisted user comments on victim’s PR | `token=PAT_OF_VICTIM` | job fails: `No PAT found for user: mallory` |
| listed `trusted` comments on victim’s PR | `token=PAT_OF_VICTIM` | `token=PAT_OF_TRUSTED` |
| victim comments on own PR | `token=PAT_OF_VICTIM` | `token=PAT_OF_VICTIM` (unchanged) |

The first row is the vulnerability, the third confirms the intended path is unaffected. YAML parse and JS syntax (inside the async wrapper `github-script` applies) also verified.

No benchmarks: CI-only change, no runtime path touched.