### PR TITLE
[Loss] Split logging loss from backward loss

### DIFF
--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -216,7 +216,10 @@ class TrainEngine:
         micro_batch_results = []
 
         data_batch_info = self.model.pre_micro_batch_forward(data_batches)
-        total_loss = torch.tensor(0.0, device=DEVICE)
+        # Display total loss is accumulated from detached per-rank LOCAL loss components and restored
+        # to the global value by one cross-rank SUM below -- separate from the backward loss so the
+        # logged total stays global once backward carries only per-rank local losses (§5.4).
+        local_display_loss = torch.tensor(0.0, device=DEVICE)
 
         for i in range(0, len(data_batches), intra_layer_micro_batch):
             ProberList.set_micro_batch_iter(micro_batch_iter)
@@ -240,12 +243,14 @@ class TrainEngine:
 
             loss = self._get_total_loss(output)
             loss.backward()
-            total_loss += loss.detach()
+            local_display_loss += self.model.local_display_loss(output)
             # call dump_forward_records after backward to record the recomputed activations
             ProberList.after_micro_iter_forward()
 
+        if dist.is_initialized():
+            dist.all_reduce(local_display_loss, op=dist.ReduceOp.SUM)
         batch_forward_info = self.model.post_micro_batch_forward(micro_batch_results)
-        return TrainStepInfo(total_loss=total_loss.item(), **data_batch_info, **batch_forward_info)
+        return TrainStepInfo(total_loss=local_display_loss.item(), **data_batch_info, **batch_forward_info)
 
     def from_hf(self, hf_path: str | Path, strict: bool = False):
         self.model.from_hf(hf_path=hf_path, strict=strict)

--- a/xtuner/v1/loss/aux_loss.py
+++ b/xtuner/v1/loss/aux_loss.py
@@ -151,12 +151,27 @@ class AuxLossContext(nn.Module):
         balancing_ctx: list[BalancingLossContext] | BalancingLossContext | None,
         z_ctx: list[ZLossContext] | ZLossContext | None,
         non_pad_token: int,
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor]:
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
         """Finalize split auxiliary losses and expert counts from runtime
-        state."""
+        state.
+
+        Returns:
+            tuple: ``(balancing_loss, z_loss, tokens_per_expert_global, local_balancing_loss,
+            local_z_loss)``. The ``*_loss`` entries carry the backward graph / global display value;
+            the ``local_*`` entries are detached per-rank components for the logging pipeline (their
+            cross-rank SUM reproduces the corresponding global loss). ``local_*`` is ``None`` exactly
+            when its loss is ``None``.
+        """
         tokens_per_expert_local, tokens_per_expert_global = self._cal_tokens_per_expert()
 
         balancing_loss: torch.Tensor | None = None
+        local_balancing_loss: torch.Tensor | None = None
         balancing_list = _as_list(balancing_ctx)
         if balancing_list:
             partials = [
@@ -169,15 +184,22 @@ class AuxLossContext(nn.Module):
                 )
                 for ctx in balancing_list
             ]
-            balancing_loss = partials[0] if len(partials) == 1 else torch.stack(partials).sum(dim=0)
+            losses = [p[0] for p in partials]
+            locals_ = [p[1] for p in partials]
+            balancing_loss = losses[0] if len(losses) == 1 else torch.stack(losses).sum(dim=0)
+            local_balancing_loss = locals_[0] if len(locals_) == 1 else torch.stack(locals_).sum(dim=0)
 
         z_loss: torch.Tensor | None = None
+        local_z_loss: torch.Tensor | None = None
         z_list = _as_list(z_ctx)
         if z_list:
             partials = [ctx.finalize() for ctx in z_list]
-            z_loss = partials[0] if len(partials) == 1 else torch.stack(partials).sum(dim=0)
+            z_losses = [p[0] for p in partials]
+            z_locals = [p[1] for p in partials]
+            z_loss = z_losses[0] if len(z_losses) == 1 else torch.stack(z_losses).sum(dim=0)
+            local_z_loss = z_locals[0] if len(z_locals) == 1 else torch.stack(z_locals).sum(dim=0)
 
-        return balancing_loss, z_loss, tokens_per_expert_global
+        return balancing_loss, z_loss, tokens_per_expert_global, local_balancing_loss, local_z_loss
 
     def _cal_tokens_per_expert(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Stack per-layer expert counts and produce both local and globally

--- a/xtuner/v1/loss/moe_loss.py
+++ b/xtuner/v1/loss/moe_loss.py
@@ -126,7 +126,7 @@ class BalancingLossContext(nn.Module):
         n_routed_experts: int,
         num_experts_per_tok: int,
         non_pad_token: int,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Finalize balancing loss from accumulators.
 
         Args:
@@ -139,34 +139,49 @@ class BalancingLossContext(nn.Module):
             non_pad_token (int): Number of non-padding tokens on this rank.
 
         Returns:
-            torch.Tensor: Final balancing loss.
+            tuple[torch.Tensor, torch.Tensor]: ``(balancing_loss, local_balancing_loss)``. The first
+            carries the autograd graph used for backward; in the global-average branch it is reduced
+            across ranks via ``all_reduce_autograd``. The second is a detached, per-rank local
+            component for logging whose cross-rank SUM reproduces the first (used by the display
+            pipeline so that logged curves stay global once backward switches to the local component).
         """
         routing_weights_sum_list = self.routing_weights_sum_list
         self.routing_weights_sum_list = []
         if self.loss_cfg.balancing_loss_alpha == 0 or not routing_weights_sum_list:
-            return torch.tensor(0.0, device=tokens_per_expert_local.device, dtype=torch.float32)
+            zero = torch.tensor(0.0, device=tokens_per_expert_local.device, dtype=torch.float32)
+            return zero, zero
 
         local_gating_sum = torch.stack(routing_weights_sum_list, dim=0)
+        alpha = self.loss_cfg.balancing_loss_alpha
 
         if self.loss_cfg.balancing_loss_global_average and dist.is_initialized():
             group = dist.group.WORLD
             assert group is not None
             tokens_global = tokens_per_expert_global.sum(-1)
             seqlen_global = tokens_global // num_experts_per_tok
+            scale_global = n_routed_experts / tokens_global
 
             routing_weights_sum_global = all_reduce_autograd(local_gating_sum, "sum", group)
             routing_weights_mean_global = routing_weights_sum_global / seqlen_global.unsqueeze(-1)
-            scale_global = n_routed_experts / tokens_global
-            tokens_per_expert_for_loss = tokens_per_expert_global
+            loss_vec = scale_global * (tokens_per_expert_global * routing_weights_mean_global).sum(-1)
+
+            # Detached local component: same global denominators, but this rank's own gating sum in
+            # place of the cross-rank sum. Because `all_reduce_autograd` is a plain SUM and every
+            # other factor here (scale_global, seqlen_global, tokens_per_expert_global) is detached
+            # and global, summing `local_vec` over ranks reproduces `loss_vec` exactly.
+            routing_weights_mean_local = local_gating_sum.detach() / seqlen_global.unsqueeze(-1)
+            local_vec = scale_global * (tokens_per_expert_global * routing_weights_mean_local).sum(-1)
         else:
             valid_tokens = max(non_pad_token, 1)
             scale_global = n_routed_experts / (valid_tokens * num_experts_per_tok)
             routing_weights_mean_global = local_gating_sum / valid_tokens
-            tokens_per_expert_for_loss = tokens_per_expert_local
+            loss_vec = scale_global * (tokens_per_expert_local * routing_weights_mean_global).sum(-1)
+            # No cross-rank term in this branch; the loss is already a per-rank quantity.
+            local_vec = loss_vec.detach()
 
-        loss = scale_global * (tokens_per_expert_for_loss * routing_weights_mean_global).sum(-1)
-        loss = loss.sum() * self.loss_cfg.balancing_loss_alpha
-        return loss / self._batch_size
+        loss = loss_vec.sum() * alpha / self._batch_size
+        local_loss = local_vec.sum() * alpha / self._batch_size
+        return loss, local_loss.detach()
 
     @property
     def batch_size(self) -> int:
@@ -220,6 +235,10 @@ class ZLossContext(nn.Module):
         # accumulate() time, so we never need to keep per-layer logsum tensors around. This is
         # the memory-saving pattern adapted from Megatron's MoEAuxLossAutoScaler.
         self._running_loss_for_log: torch.Tensor | None = None
+        # Detached per-rank local component (the same running scalar but WITHOUT the `× world_size`
+        # global-average factor). The display pipeline restores the global value by SUM-reducing
+        # this across ranks, which keeps logged curves global once backward drops the factor.
+        self._local_running_loss_for_log: torch.Tensor | None = None
 
     @staticmethod
     def build_batches(
@@ -273,39 +292,62 @@ class ZLossContext(nn.Module):
         if self.loss_cfg.z_loss_alpha == 0:
             zero = torch.tensor(0.0, device=router_logits.device, dtype=torch.float32)
             self._update_running(zero)
+            self._update_local_running(zero)
             return zero
 
         denom_local = max(num_tokens_local, 1)
-        loss = torch.logsumexp(router_logits, dim=-1).square().sum() / denom_local
+        base = torch.logsumexp(router_logits, dim=-1).square().sum() / denom_local
 
+        local_loss = base
+        loss = base
         if self.loss_cfg.z_loss_global_average and num_tokens_global is not None:
-            # Equivalent to scaling each layer's local loss by num_tokens_local * world_size /
-            # num_tokens_global, matching the original list-based finalize formula.
+            # Local component: this rank's share of the global-average z-loss, without the
+            # `× world_size` factor. The backward path keeps `× world_size` (removed in the
+            # reduce-sum switch); summing `local_loss` over ranks reproduces the global z-loss.
             denom_global = torch.clamp(num_tokens_global, min=1)
-            loss = loss * num_tokens_local * world_size / denom_global
+            local_loss = base * num_tokens_local / denom_global
+            loss = local_loss * world_size
 
+        local_loss = local_loss * self.loss_cfg.z_loss_alpha / self._batch_size
         loss = loss * self.loss_cfg.z_loss_alpha / self._batch_size
         self._update_running(loss.detach())
+        self._update_local_running(local_loss.detach())
         return loss
 
-    def finalize(self) -> torch.Tensor:
-        """Return the accumulated z-loss as a detached scalar for logging only.
+    def finalize(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return the accumulated z-loss as detached scalars for logging only.
 
         The differentiable contribution has already been injected into the main forward graph at
-        each ``accumulate()`` call, so this value carries no autograd graph; it exists purely to
-        populate the logging field on the model output.
+        each ``accumulate()`` call, so these values carry no autograd graph; they exist purely to
+        populate logging.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor]: ``(z_loss, local_z_loss)``. The first is the current
+            global-average running scalar (kept for the ``z_loss`` output field); the second is the
+            detached per-rank local component (without ``× world_size``) whose cross-rank SUM equals
+            the first, used by the display pipeline.
         """
         value = self._running_loss_for_log
+        local_value = self._local_running_loss_for_log
         self._running_loss_for_log = None
-        if value is None:
-            return torch.tensor(0.0, device=DEVICE, dtype=torch.float32)
-        return value
+        self._local_running_loss_for_log = None
+        zero = torch.tensor(0.0, device=DEVICE, dtype=torch.float32)
+        return (
+            value if value is not None else zero,
+            local_value if local_value is not None else zero,
+        )
 
     def _update_running(self, value: torch.Tensor) -> None:
         if self._running_loss_for_log is None:
             self._running_loss_for_log = value.clone()
         else:
             self._running_loss_for_log = self._running_loss_for_log + value
+
+    def _update_local_running(self, value: torch.Tensor) -> None:
+        if self._local_running_loss_for_log is None:
+            self._local_running_loss_for_log = value.clone()
+        else:
+            self._local_running_loss_for_log = self._local_running_loss_for_log + value
 
     @property
     def batch_size(self) -> int:

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -620,6 +620,26 @@ class BaseModel(nn.Module):
                 module.set_gradient_divide_factor(1.0)  # type: ignore[operator]
                 module.set_force_sum_reduction_for_comms(True)  # type: ignore[operator]
 
+    def local_display_loss(self, output: ModelOutputs) -> torch.Tensor:
+        """Sum this output's detached per-rank local loss components for
+        display.
+
+        The caller restores the global display loss with a cross-rank SUM all_reduce over the
+        returned per-rank value. This is deliberately separate from ``_get_total_loss`` (the backward
+        loss) so the display and backward paths never share a tensor.
+
+        Args:
+            output (ModelOutputs): A single micro-batch model output whose ``extra_info`` carries the
+                per-loss-term ``local_*loss`` components.
+
+        Returns:
+            torch.Tensor: A 0-d tensor: this rank's summed local loss components.
+        """
+        total = torch.tensor(0.0, device=DEVICE)
+        for contribution in self._collect_local_display_losses(output).values():
+            total = total + contribution
+        return total
+
     def fully_shard(
         self,
         fsdp_config: FSDPConfig,
@@ -1341,40 +1361,53 @@ class BaseModel(nn.Module):
     def post_micro_batch_forward(self, batch_outputs: Sequence[ModelOutputs]) -> BatchForwardInfo:
         train_engine_extra_info = ModelForwardExtraLogInfo()
 
-        local_total_loss = torch.tensor(0.0, device=DEVICE)
-        reduced_other_losses: dict[str, float] = {}
-
+        # Restore each loss curve's global display value from its detached per-rank LOCAL component
+        # (carried on `output.extra_info` as `local_*loss`), reduced by a cross-rank SUM -- not a
+        # mean. Each term's cross-rank SUM equals the global loss, so this keeps logged curves global
+        # even after backward switches to per-rank local losses, and never reuses the backward loss
+        # tensors for display (§5.4).
+        local_reduced: dict[str, torch.Tensor] = {}
         for output in batch_outputs:
-            output_copy = output.model_copy()
-            for name in output_copy.model_fields:
-                obj = getattr(output_copy, name)
-                if "loss" in name and isinstance(obj, torch.Tensor):
-                    loss_item = obj.item()
-                    local_total_loss += loss_item
-                    reduced_name = f"reduced_{name}"
+            for reduced_name, contribution in self._collect_local_display_losses(output).items():
+                if reduced_name not in local_reduced:
+                    local_reduced[reduced_name] = contribution
+                else:
+                    local_reduced[reduced_name] = local_reduced[reduced_name] + contribution
 
-                    if reduced_name not in reduced_other_losses:
-                        reduced_other_losses[reduced_name] = loss_item
-                    else:
-                        reduced_other_losses[reduced_name] += loss_item
+            if "extra_info" in output:
+                train_engine_extra_info.append(output["extra_info"])
 
-            if "extra_info" in output_copy:
-                extra_info = output["extra_info"]
-                train_engine_extra_info.append(extra_info)
+        reduced_other_losses: dict[str, float] = {}
+        for name, value in local_reduced.items():
+            reduced = value.clone()
+            if dist.is_initialized():
+                dist.all_reduce(reduced, op=dist.ReduceOp.SUM)
+            reduced_other_losses[name] = reduced.item()
 
-        for name, loss in reduced_other_losses.items():
-            tensor_loss = torch.tensor(loss, device=DEVICE)
-            dist.all_reduce(tensor_loss.div_(dist.get_world_size()), op=dist.ReduceOp.SUM)
-            reduced_other_losses[name] = tensor_loss.item()
-
-        if "reduced_loss" in reduced_other_losses:
-            reduced_other_losses["reduced_llm_loss"] = reduced_other_losses.pop("reduced_loss")
+        # CE's local component is keyed `local_base_loss`; expose it under the historical curve name.
+        if "reduced_base_loss" in reduced_other_losses:
+            reduced_other_losses["reduced_llm_loss"] = reduced_other_losses.pop("reduced_base_loss")
 
         ret = BatchForwardInfo(
             logs_info=reduced_other_losses,
             extra_info=train_engine_extra_info,
         )
         return ret
+
+    def _collect_local_display_losses(self, output: ModelOutputs) -> dict[str, torch.Tensor]:
+        # Map each loss term's reduced-log name to this output's detached per-rank local component
+        # (summed over any intra-layer micro-batches). Loss terms register their local component on
+        # `extra_info` under a `local_*loss` key; see `xtuner.v1.model.moe.moe._store_local_display_losses`
+        # and CE's `local_base_loss`.
+        extra_info = output["extra_info"] if "extra_info" in output else None
+        result: dict[str, torch.Tensor] = {}
+        if extra_info is None:
+            return result
+        for key, value in extra_info.items():
+            if key.startswith("local_") and key.endswith("loss"):
+                reduced_name = "reduced_" + key[len("local_") :]
+                result[reduced_name] = value.detach().float().sum()
+        return result
 
     def _get_save_dtype(self, name: str, dtype: torch.dtype) -> torch.dtype:
         patterns = self.config.hf_save_cfg.fp32_keys_pattern

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -2,7 +2,7 @@
 import os
 import types
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal, Self, Sequence, TypedDict, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Self, Sequence, TypedDict, cast
 
 import torch
 import torch.distributed as dist
@@ -94,6 +94,27 @@ MOE_NON_EP_COMPILE_CFG: dict[str, TorchCompileOption] = {
 
 MOE_EP_COMPILE_CFG = MOE_NON_EP_COMPILE_CFG.copy()
 MOE_EP_COMPILE_CFG.pop("xtuner.v1.module.decoder_layer.moe_decoder_layer.MoEDecoderLayer.forward")
+
+
+def _store_local_display_losses(
+    extra_info: dict[str, Any],
+    local_balancing_loss: torch.Tensor | None,
+    local_z_loss: torch.Tensor | None,
+    local_mtp_loss: torch.Tensor | None = None,
+) -> None:
+    """Record detached per-rank local loss components on ``extra_info`` for the
+    display pipeline.
+
+    ``BaseModel.post_micro_batch_forward`` restores each global loss curve by SUM-reducing these
+    ``local_*`` components across ranks. This decouples the logged loss values from the backward
+    loss tensors, which become per-rank local components once gradient reduction switches to SUM.
+    """
+    if local_balancing_loss is not None:
+        extra_info["local_balancing_loss"] = local_balancing_loss
+    if local_z_loss is not None:
+        extra_info["local_z_loss"] = local_z_loss
+    if local_mtp_loss is not None:
+        extra_info["local_mtp_loss"] = local_mtp_loss
 
 
 class MoEModelOutputs(ModelOutputs):
@@ -553,6 +574,7 @@ class MoE(BaseModel):
 
         assert hidden_states_list, "XTuner Internal Error, found empty hidden states for domino EP"
 
+        local_mtp_loss: torch.Tensor | None = None
         if self.mtp_block is not None:
             assert self.config.mtp_config is not None
 
@@ -579,6 +601,9 @@ class MoE(BaseModel):
             )
 
             mtp_losses = torch.tensor(0.0, device=DEVICE)
+            # Detached local CE component of the MTP loss, mirroring `mtp_losses` term by term, so
+            # the display pipeline can restore the global MTP loss via a cross-rank SUM.
+            mtp_local_losses = torch.tensor(0.0, device=DEVICE)
             has_mtp_loss = False
             for micro_batch_idx, (loss_ctx_dict, mtp_outputs) in enumerate(zip(loss_ctx_list, mtp_outputs_per_mb)):
                 mtp_loss_ctx_list = loss_ctx_dict.get("mtp")
@@ -586,15 +611,18 @@ class MoE(BaseModel):
                     continue
 
                 micro_batch_mtp_losses = torch.tensor(0.0, device=DEVICE)
+                micro_batch_mtp_local = torch.tensor(0.0, device=DEVICE)
                 for mtp_idx, (mtp_hidden, mtp_ctx) in enumerate(zip(mtp_outputs, mtp_loss_ctx_list)):
                     mtp_hidden_states, mtp_router_results, _ = mtp_hidden
-                    mtp_loss, _ = self.lm_head(mtp_hidden_states, cast(MTPLossContext, mtp_ctx))
+                    mtp_loss, (_, mtp_extra) = self.lm_head(mtp_hidden_states, cast(MTPLossContext, mtp_ctx))
                     micro_batch_mtp_losses += mtp_loss
+                    micro_batch_mtp_local += mtp_extra["local_base_loss"]
 
                     if keep_router:
                         router_logits_list[micro_batch_idx][f"mtp_layer{mtp_idx}"] = mtp_router_results
 
                 mtp_losses += micro_batch_mtp_losses / len(mtp_loss_ctx_list)
+                mtp_local_losses += micro_batch_mtp_local / len(mtp_loss_ctx_list)
                 has_mtp_loss = True
 
             if has_mtp_loss:
@@ -634,6 +662,7 @@ class MoE(BaseModel):
                     )
 
                 output["mtp_loss"] = mtp_losses * self.config.mtp_config.loss_scaling_factor
+                local_mtp_loss = mtp_local_losses * self.config.mtp_config.loss_scaling_factor
 
         # Apply final norm to all micro-batches
         cat_hidden_states = torch.cat(hidden_states_list, dim=1)
@@ -657,12 +686,13 @@ class MoE(BaseModel):
             z_ctx=z_ctx,
             non_pad_token=non_pad_token,
         )
-        balancing_loss, z_loss, tokens_per_expert_global = split_aux_output
+        balancing_loss, z_loss, tokens_per_expert_global, local_balancing_loss, local_z_loss = split_aux_output
         if balancing_loss is not None:
             output["balancing_loss"] = balancing_loss
         if z_loss is not None:
             output["z_loss"] = z_loss
         output["tokens_per_expert_global"] = tokens_per_expert_global
+        _store_local_display_losses(moe_extra_info, local_balancing_loss, local_z_loss, local_mtp_loss)
 
         if keep_router:
             # TODO: Returning router logits is costly.
@@ -783,6 +813,7 @@ class MoE(BaseModel):
         output["extra_info"] = extra_info
 
         # MTP forward pass and loss computation
+        local_mtp_loss: torch.Tensor | None = None
         if (
             self.mtp_block is not None
             and loss_ctx is not None
@@ -810,6 +841,8 @@ class MoE(BaseModel):
 
             # Compute MTP losses for each depth
             mtp_losses = torch.tensor(0.0, device=DEVICE)
+            # Detached local CE component of the MTP loss, mirroring `mtp_losses` term by term.
+            mtp_local_losses = torch.tensor(0.0, device=DEVICE)
             for idx, (mtp_hidden, mtp_ctx) in enumerate(zip(mtp_outputs, mtp_loss_ctx_list)):
                 mtp_hidden_states, mtp_router_results, mtp_router_weights = mtp_hidden
 
@@ -830,8 +863,9 @@ class MoE(BaseModel):
                     num_tokens_global=mtp_num_tokens_global,
                     world_size=mtp_z_world_size,
                 )
-                mtp_loss, _ = self.lm_head(mtp_hidden_states, cast(MTPLossContext, mtp_ctx))
+                mtp_loss, (_, mtp_extra) = self.lm_head(mtp_hidden_states, cast(MTPLossContext, mtp_ctx))
                 mtp_losses += mtp_loss
+                mtp_local_losses += mtp_extra["local_base_loss"]
 
             # Average MTP losses across depths and scale
             mtp_losses = mtp_losses / len(mtp_loss_ctx_list)
@@ -839,18 +873,20 @@ class MoE(BaseModel):
 
             # Add to total loss
             output["mtp_loss"] = scaled_mtp_loss
+            local_mtp_loss = mtp_local_losses / len(mtp_loss_ctx_list) * self.config.mtp_config.loss_scaling_factor  # type: ignore
 
         split_aux_output = self.aux_loss.finalize(
             balancing_ctx=balancing_ctx,
             z_ctx=z_ctx,
             non_pad_token=non_pad_token,
         )
-        balancing_loss, z_loss, tokens_per_expert_global = split_aux_output
+        balancing_loss, z_loss, tokens_per_expert_global, local_balancing_loss, local_z_loss = split_aux_output
         if balancing_loss is not None:
             output["balancing_loss"] = balancing_loss
         if z_loss is not None:
             output["z_loss"] = z_loss
         output["tokens_per_expert_global"] = tokens_per_expert_global
+        _store_local_display_losses(extra_info, local_balancing_loss, local_z_loss, local_mtp_loss)
 
         if keep_router:
             # TODO: Moving router logits to CPU is costly.

--- a/xtuner/v1/model/moe/qwen3vl_text.py
+++ b/xtuner/v1/model/moe/qwen3vl_text.py
@@ -6,7 +6,7 @@ import torch
 from xtuner.v1.data_proto import SequenceContext
 from xtuner.v1.utils.activation_offload import async_save_on_cpu
 
-from .moe import MoELossContextDict, MoEModelOutputs
+from .moe import MoELossContextDict, MoEModelOutputs, _store_local_display_losses
 from .qwen3 import Qwen3MoE, Qwen3MoE30BA3Config, Qwen3MoE235BA22Config
 
 
@@ -215,7 +215,7 @@ class Qwen3VLTextMoE(Qwen3MoE):
         output["logits"] = logits
         output["extra_info"] = extra_info
 
-        balancing_loss, z_loss, tokens_per_expert_global = self.aux_loss.finalize(
+        balancing_loss, z_loss, tokens_per_expert_global, local_balancing_loss, local_z_loss = self.aux_loss.finalize(
             balancing_ctx=balancing_ctx,
             z_ctx=z_ctx,
             non_pad_token=non_pad_token,
@@ -225,6 +225,7 @@ class Qwen3VLTextMoE(Qwen3MoE):
         if z_loss is not None:
             output["z_loss"] = z_loss
         output["tokens_per_expert_global"] = tokens_per_expert_global
+        _store_local_display_losses(extra_info, local_balancing_loss, local_z_loss)
 
         if keep_router:
             # TODO: Moving router logits to CPU is costly.


### PR DESCRIPTION
**This PR (2/5)** — behavior-neutral. Routes displayed/logged losses through detached per-rank local components reduced by cross-rank **SUM**; the backward loss is still globally reduced. Isolates the display pipeline so the next PR flips gradients without touching logging.

Full stack (merge bottom-up, under #1959):
1. `reduce-sum-01-fsdp-helper` — [FSDP] Add reduce-sum gradient reduction helper
2. `reduce-sum-02-split-logging` — [Loss] Split logging loss from backward loss
3. `reduce-sum-03-switch-sum` — [FSDP][Loss] Switch gradient reduction to SUM
4. `reduce-sum-04-remove-world-size` — [Refactor] Remove unused world_size plumbing
5. `reduce-sum-05-drop-nonglobal` — [Refactor] Drop non-global aux-loss averaging mode