### PR TITLE
support swap optimizer of RL

### DIFF
--- a/examples/v1/config/agentic_rl_qwen3p5vl_mtp_ep_code.py
+++ b/examples/v1/config/agentic_rl_qwen3p5vl_mtp_ep_code.py
@@ -128,6 +128,7 @@ skip_load_weights = True
 checkpoint_interval = 50
 enable_initial_evaluate = os.environ.get("ENABLE_INITIAL_EVALUATE", False)
 evaluate_step = 5
+swap_optimizer = os.environ.get("SWAP_OPTIMIZER", False).lower() in ("1", "true", "yes", "on")
 
 resources = AcceleratorResourcesConfig(
     accelerator="GPU",
@@ -232,6 +233,7 @@ optim_cfg = AdamWConfig(
     foreach=False,
     skip_grad_norm_threshold=5,
     eps=1e-15,
+    swap_optimizer=swap_optimizer,
 )
 loss_cfg = GRPOLossConfig(
     policy_loss_cfg=dict(

--- a/examples/v1/config/agentic_rl_qwen3p5vl_mtp_ep_code.py
+++ b/examples/v1/config/agentic_rl_qwen3p5vl_mtp_ep_code.py
@@ -128,7 +128,7 @@ skip_load_weights = True
 checkpoint_interval = 50
 enable_initial_evaluate = os.environ.get("ENABLE_INITIAL_EVALUATE", False)
 evaluate_step = 5
-swap_optimizer = os.environ.get("SWAP_OPTIMIZER", False).lower() in ("1", "true", "yes", "on")
+swap_optimizer = os.environ.get("SWAP_OPTIMIZER", "0").lower() in ("1", "true", "yes", "on")
 
 resources = AcceleratorResourcesConfig(
     accelerator="GPU",

--- a/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
+++ b/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
@@ -61,6 +61,8 @@ hf_interval = 15
 checkpoint_interval = 50
 evaluate_step = 5
 enable_initial_evaluate = os.environ.get("ENABLE_INITIAL_EVALUATE", False)
+train_ep_size=4
+swap_optimizer = os.environ.get("SWAP_OPTIMIZER", False).lower() in ("1", "true", "yes", "on")
 
 # 1. resources
 resources = AcceleratorResourcesConfig(
@@ -210,7 +212,7 @@ judger_config = ComposedJudgerConfig(
 # 5. train worker
 model_cfg = Qwen3_5_VLMoE35BA3Config(freeze_vision=True, freeze_projector=True)
 model_cfg.float8_cfg = None
-model_cfg.text_config.ep_size = 1
+model_cfg.text_config.ep_size = train_ep_size
 model_cfg.text_config.z_loss_cfg = None
 model_cfg.text_config.balancing_loss_cfg = None
 model_cfg.text_config.freeze_routers = True
@@ -221,7 +223,7 @@ model_cfg.text_config.mtp_config = MTPConfig(
     detach_mtp_inputs=True,
     share_weights=True,
 )
-optim_cfg = AdamWConfig(lr=1e-6, betas=(0.9, 0.999), max_grad_norm=1.0, weight_decay=0.1, foreach=False)
+optim_cfg = AdamWConfig(lr=1e-6, betas=(0.9, 0.999), max_grad_norm=1.0, weight_decay=0.1, foreach=False, swap_optimizer=swap_optimizer)
 loss_cfg = GRPOLossConfig(
     policy_loss_cfg=dict(
         cliprange_high=0.28,
@@ -246,7 +248,7 @@ loss_cfg = GRPOLossConfig(
     ),
 )
 lr_cfg = LRConfig(lr_type="constant", warmup_ratio=0, lr_min=1e-6)
-fsdp_cfg = FSDPConfig(torch_compile=False, cpu_offload=False, ep_size=1, fp32_lm_head=True)
+fsdp_cfg = FSDPConfig(torch_compile=False, cpu_offload=False, ep_size=train_ep_size, fp32_lm_head=True)
 train_worker_cfg = WorkerConfig(
     model_cfg=model_cfg,
     load_from=model_path,

--- a/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
+++ b/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
@@ -62,7 +62,7 @@ checkpoint_interval = 50
 evaluate_step = 5
 enable_initial_evaluate = os.environ.get("ENABLE_INITIAL_EVALUATE", False)
 train_ep_size=4
-swap_optimizer = os.environ.get("SWAP_OPTIMIZER", False).lower() in ("1", "true", "yes", "on")
+swap_optimizer = os.environ.get("SWAP_OPTIMIZER", "0").lower() in ("1", "true", "yes", "on")
 
 # 1. resources
 resources = AcceleratorResourcesConfig(

--- a/xtuner/v1/config/fsdp.py
+++ b/xtuner/v1/config/fsdp.py
@@ -18,6 +18,15 @@ class FSDPConfig(BaseModel):
     recompute_ratio: Annotated[float, Parameter(help="Gradient checkpointing ratio for memory optimization")] = 1.0
     vision_recompute_ratio: Annotated[float, Parameter(help="Recompute ratio for vision modules")] = 1.0
     checkpoint_preserve_rng_state: Annotated[bool, Parameter(help="Preserve RNG state during checkpointing")] = True
+    # Training-time FSDP CPU offload is version-sensitive for XTuner model configs
+    # that keep selected fp32 trainable parameters outside FSDP via
+    # fp32_keys_pattern. The Qwen3.5-VL MoE RL path was verified to run on Torch
+    # 2.9, but on PyTorch 2.12.x the combination of ignored fp32 params,
+    # checkpointed forward/backward, and CPU offload can trigger autograd's
+    # internal stream assertion:
+    #   opt_ready_stream && opt_parent_stream
+    # Keep this disabled unless the target model/config has explicitly validated
+    # the full-offload path on the target PyTorch version.
     cpu_offload: Annotated[bool, Parameter(help="Enable CPU offloading for memory optimization")] = False
     # TODO: (caoweihan) Convert `torch.dtype` to `Annotated` for compatibility with cyclopts
     param_dtype: Annotated[torch.dtype, Parameter(help="Data type for model parameters")] = torch.bfloat16

--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -535,24 +535,24 @@ class TrainEngine:
                 options=set_options,
             )
 
-    def put_model_to_device(self, device: torch.device | str):
+    def put_model_to_device(self, device: torch.device | str) -> bool:
         """Put the model to the given device."""
         self.model.to_device(device)
-        return
+        return True
 
-    def put_optimizer_to_device(self, device: torch.device | str):
+    def put_optimizer_to_device(self, device: torch.device | str) -> bool:
         """Put the optimizer to the given device."""
-        if self.fsdp_cfg.cpu_offload or self.optim_cfg.swap_optimizer:
-            return
+        if getattr(self.optim_cfg, "swap_optimizer", False):
+            return False
         if not self.optimizer.state:
-            return
+            return False
         for state in self.optimizer.state.values():
             if isinstance(state, dict):
                 for key, val in state.items():
                     if isinstance(val, torch.Tensor):
                         state[key] = val.to(device, non_blocking=True)
         DEVICE_MODULE.synchronize()
-        return
+        return True
 
     def _maybe_precompute_float8_dynamic_scale_for_fsdp(self):
         for model in self.model.modules():

--- a/xtuner/v1/rl/trainer/worker.py
+++ b/xtuner/v1/rl/trainer/worker.py
@@ -956,8 +956,11 @@ class TrainingWorker(SingleAcceleratorWorker):
 
     @ray_method
     def offload_model(self):
-        self._engine.put_model_to_device("cpu")
+        model_moved = self._engine.put_model_to_device("cpu")
         DEVICE_MODULE.empty_cache()
+        if not model_moved:
+            self.logger.info("Skip model offload because model placement is unchanged.")
+            return
         self.logger.info(
             f"Offloaded model to CPU. Current allocate {DEVICE_MODULE.memory_allocated() / (1024**2)} MB, reserved: {DEVICE_MODULE.memory_reserved() / (1024**2)} MB"
         )
@@ -965,8 +968,16 @@ class TrainingWorker(SingleAcceleratorWorker):
     @ray_method
     def offload_optimizer(self):
         """Offload the optimizer of the training worker."""
-        self._engine.put_optimizer_to_device("cpu")
+        optimizer_moved = self._engine.put_optimizer_to_device("cpu")
         DEVICE_MODULE.empty_cache()
+        if not optimizer_moved:
+            if getattr(self.config.optim_cfg, "swap_optimizer", False):
+                self.logger.info(
+                    "Skip optimizer offload because swap_optimizer=True; optimizer states are already CPU-resident."
+                )
+            else:
+                self.logger.info("Skip optimizer offload because optimizer state is empty.")
+            return
         self.logger.info(
             f"Offloaded optimizer to CPU. Current allocate {DEVICE_MODULE.memory_allocated() / (1024**2)} MB, "
             f"reserved: {DEVICE_MODULE.memory_reserved() / (1024**2)} MB"
@@ -974,11 +985,20 @@ class TrainingWorker(SingleAcceleratorWorker):
 
     @ray_method
     def onload_model(self):
-        self._engine.put_model_to_device(DEVICE)
+        model_moved = self._engine.put_model_to_device(DEVICE)
+        if not model_moved:
+            self.logger.info("Skip model onload because model placement is unchanged.")
 
     @ray_method
     def onload_optimizer(self):
-        self._engine.put_optimizer_to_device(DEVICE)
+        optimizer_moved = self._engine.put_optimizer_to_device(DEVICE)
+        if not optimizer_moved:
+            if getattr(self.config.optim_cfg, "swap_optimizer", False):
+                self.logger.info(
+                    "Skip optimizer onload because swap_optimizer=True; optimizer states stay on CPU and are swapped per step."
+                )
+            else:
+                self.logger.info("Skip optimizer onload because optimizer state is empty.")
 
     @ray_method
     def save(self, checkpoint_path: Path | str, no_save_optimizer: bool = False):


### PR DESCRIPTION
支持 swap optimizer 从而可以减少至少一倍的卡数，且训练吞吐下降较少。

最节省显存的方法是 swap all，也就是 fsdp 自带的 offload_cpu 功能。不过在 torch2.12.1 中，当存在部分参数例如 qwen3.5 的 ignore fp32 不被 fsdp2 管理时候，在 backward 时会出现 `opt_ready_stream && opt_parent_stream 错误`。在 torch2.9 则不会，这通常是 torch 本身的问题。因此在当前 pr 中并没有实现 swap all 功能。后续如果有必要，则可以更新 torch 版本或者修改掉 ignore fp32 的写法