### PR TITLE
[Test] Add backward coverage for DSA sparse_attn kernel and assembly

### DIFF
--- a/tests/module/dsa/test_dsa.py
+++ b/tests/module/dsa/test_dsa.py
@@ -242,6 +242,34 @@ class TestDeepSeekSparseAttention:
             atol=0.0,
         )
 
+    @pytest.mark.parametrize("compress_ratio", [0, 4])
+    def test_backward_smoke(self, compress_ratio: int) -> None:
+        # Assembly-level smoke: the DSA block wires hc_pre → q/kv projections →
+        # (compressor/indexer) → sparse_attn → grouped O-LoRA, and the whole
+        # chain must run backward without error, not just forward. Correctness
+        # of each piece is owned by the op/module tests; this guards the wiring
+        # so a shape or dtype regression in the backward graph fails here rather
+        # than only in whole-model training. The Indexer produces integer top-k
+        # indices with no gradient path, so we assert grads on the always-in-path
+        # attention weights (wo_b) and on the hidden input instead.
+        hidden_size = 128
+        seq_len = 64
+        dsa = _make_dsa(compress_ratio=compress_ratio, hidden_size=hidden_size, sliding_window=16)
+
+        torch.manual_seed(3)
+        hidden = torch.randn(1, seq_len, hidden_size, dtype=torch.float32, requires_grad=True)
+        cos, sin = _make_position_embeddings(seq_len, dsa.qk_rope_head_dim)
+        cos_c, sin_c = _make_position_embeddings(seq_len, dsa.qk_rope_head_dim, base=160000.0)
+        pe_compressed = None if compress_ratio == 0 else (cos_c, sin_c)
+        seq_ctx = _make_seq_ctx([0, seq_len])
+
+        out = dsa(hidden, (cos, sin), pe_compressed, seq_ctx)
+        out["projected_output"].sum().backward()
+
+        assert hidden.grad is not None and torch.isfinite(hidden.grad).all()
+        assert dsa.wo_b.weight.grad is not None and torch.isfinite(dsa.wo_b.weight.grad).all()
+        assert dsa.wo_b.weight.grad.abs().sum().item() > 0.0
+
     def test_attn_sink_absorbs_mass(self) -> None:
         # If KV is exactly zero and the sink logit dominates, the softmax
         # routes all mass to the sink slot which is dropped from the output,

--- a/tests/module/dsa/test_sparse_attn.py
+++ b/tests/module/dsa/test_sparse_attn.py
@@ -82,6 +82,44 @@ class TestSparseAttn:
         # output is ~zero.
         assert out_nz.abs().max() < 1e-3
 
+    def test_backward_matches_dense(self) -> None:
+        # sparse_attn is a differentiable production kernel (pure PyTorch gather
+        # + softmax), so it owns a backward test, not just forward. With a
+        # full top-k the gather path must produce the same gradients as the
+        # dense reference for all three differentiable inputs — q, kv, and the
+        # sink logit (the sink is dropped from the output but still shapes the
+        # softmax normaliser, so it carries a real gradient).
+        torch.manual_seed(4)
+        bsz, seq, num_heads, head_dim = 1, 8, 2, 16
+        t_total = seq
+        ref_inputs = (
+            torch.randn(bsz, seq, num_heads, head_dim, dtype=torch.float32),
+            torch.randn(bsz, t_total, head_dim, dtype=torch.float32),
+            torch.randn(num_heads, dtype=torch.float32),
+        )
+        ref_inputs = tuple(t.requires_grad_(True) for t in ref_inputs)
+        sparse_inputs = tuple(t.detach().clone().requires_grad_(True) for t in ref_inputs)
+
+        softmax_scale = head_dim**-0.5
+        topk_idxs = torch.arange(t_total).view(1, 1, t_total).expand(1, seq, t_total).contiguous().long()
+        cu = torch.tensor([0, seq], dtype=torch.int32)
+
+        out_dense = _dense_attention(ref_inputs[0], ref_inputs[1], ref_inputs[2], softmax_scale)
+        out_sparse = sparse_attn(sparse_inputs[0], sparse_inputs[1], sparse_inputs[2], topk_idxs, softmax_scale, cu)
+
+        grad_out = torch.randn_like(out_dense)
+        out_dense.backward(grad_out)
+        out_sparse.backward(grad_out)
+
+        names = ["grad_q", "grad_kv", "grad_attn_sink"]
+        for name, ref_t, sparse_t in zip(names, ref_inputs, sparse_inputs):
+            assert ref_t.grad is not None and sparse_t.grad is not None, f"{name} missing"
+            # Gather-vs-dense reductions reorder the same fp32 terms, so allow a
+            # small relative divergence rather than requiring bit-identity.
+            denom = ref_t.grad.abs().max().item() + 1e-9
+            rel = (ref_t.grad - sparse_t.grad).abs().max().item() / denom
+            assert rel < 1e-4, f"{name} rel diff {rel:.3e} too large"
+
     def test_masked_minus_one_ignored(self) -> None:
         # Marking half of topk_idxs as -1 should produce the same output as
         # running sparse_attn with the unmasked-half-only index list.


### PR DESCRIPTION
## Motivation

Review of the dsv4 branch's tests against the `submodule_tests` conventions surfaced two backward-coverage gaps in the DSA suite:

- **`sparse_attn` is a differentiable production kernel** (pure-PyTorch gather + softmax with autograd support), but its unit test only covered forward (`test_full_topk_matches_dense`, sink, masked-`-1`, shape). The convention mandates forward **and** backward vs a reference for an op/kernel. Whole-model parity does not close this: parity runs the eager `_sparse_attn_hf_parity` path, not the production gather kernel, so the production forward/backward is otherwise untested.
- **The DSA assembly smoke was forward-only.** The convention's smoke contract is "forward **and** backward run across a few shapes without error"; no `.backward()` was exercised on the DSA block anywhere.

## Changes

- `test_sparse_attn.py`: add `test_backward_matches_dense` — compares grads on `q` / `kv` / `attn_sink` against the existing dense reference at full top-k (relative tolerance for gather-vs-dense fp32 reduction reordering).
- `test_dsa.py`: add `test_backward_smoke` parametrized over `compress_ratio` ∈ {0, 4} (sliding + compressed-sparse paths) — runs the full hc_pre → projections → sparse_attn → grouped O-LoRA backward and asserts finite, non-zero grads on the always-in-path `wo_b` and on the hidden input.

## Test Plan

```
pytest tests/module/dsa/test_sparse_attn.py tests/module/dsa/test_dsa.py::TestDeepSeekSparseAttention
# 15 passed
```

CPU-only, native backend; no GPU required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)