### PR TITLE
Fix DSA top-k pinned buffer growth

### DIFF
--- a/ci/scripts/CI_ENV.sh
+++ b/ci/scripts/CI_ENV.sh
@@ -28,6 +28,7 @@ export ROLLOUT_DAPO_DATA_PATH=${CI_SHARE_DATA}/rl_test_judger_dapo_math_data.jso
 export GEO_ROLLOUT_DATA_PATH=${CI_SHARE_DATA}/rl_test_judge_geo_data.jsonl
 export TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=0
 export XTUNER_DETERMINISTIC=true
+export TORCHINDUCTOR_DYNAMIC_SCALE_RBLOCK=0
 export XTUNER_USE_LMDEPLOY=1
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 export PYTHONPYCACHEPREFIX=/tmp

--- a/tests/model/test_glm52_mtp_checkpoint_repro.py
+++ b/tests/model/test_glm52_mtp_checkpoint_repro.py
@@ -3,7 +3,7 @@
 TestGlm52CompiledMTPCheckpoint
     test_shared_mtp_depths_train_with_compile_and_topk_offload: 共享 MTP 深度可在 compile/offload 下训练。
 TestGlm52MicroBatchMTPCheckpoint
-    test_nested_micro_batch_inputs_preserve_gradients: EP2 micro2 的嵌套 embedding 梯度可正确反传。
+    test_nested_micro_batch_inputs_preserve_gradients: EP2 micro2 可反传且 pinned buffer 数量有界。
 """
 
 import math
@@ -23,6 +23,7 @@ from xtuner.v1.model.moe.glm52 import Glm52MoEConfig
 from xtuner.v1.module.attention import DSAMLAConfig
 from xtuner.v1.module.mtp import MTPConfig
 from xtuner.v1.module.router.noaux_router import NoAuxRouterConfig
+from xtuner.v1.utils.activation_offload import OffloadManager
 
 
 def _tiny_mtp_config(ep_size: int, mtp_num_layers: int, compile_model: bool) -> Glm52MoEConfig:
@@ -77,6 +78,7 @@ def _build_engine(
     ep_size: int,
     mtp_num_layers: int,
     compile_model: bool,
+    recompute_ratio: float = 0.0,
 ) -> TrainEngine:
     engine = TrainEngine(
         model_cfg=_tiny_mtp_config(ep_size, mtp_num_layers, compile_model),
@@ -84,7 +86,7 @@ def _build_engine(
         fsdp_cfg=FSDPConfig(
             ep_size=ep_size,
             cpu_offload=False,
-            recompute_ratio=0.0,
+            recompute_ratio=recompute_ratio,
             torch_compile=compile_model,
         ),
         intra_layer_micro_batch=intra_layer_micro_batch,
@@ -104,7 +106,7 @@ def _model_item(engine: TrainEngine, start: int) -> ModelItem:
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
 class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
     def test_shared_mtp_depths_train_with_compile_and_topk_offload(self):
-        # 验证默认 reentrant checkpoint 可训练共享 MTP 深度且 loss 有限。
+        # 验证默认 reentrant checkpoint 可训练共享 MTP 深度，且 pinned buffer 跨 step 复用。
         self.create_pg("cuda")
         engine = _build_engine(
             intra_layer_micro_batch=1,
@@ -112,16 +114,26 @@ class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
             mtp_num_layers=2,
             compile_model=True,
         )
+        offload_manager = OffloadManager()
+        offload_manager.clear(clear_pin_memory_cache=True)
         try:
+            cache_sizes = []
             with mock.patch.dict(
                 os.environ,
                 {"XTUNER_ACTIVATION_OFFLOAD": "0", "XTUNER_DSA_TOPK_OFFLOAD": "1"},
             ):
-                step_info = engine.train_step([_model_item(engine, 2)])
+                for step in range(2):
+                    step_info = engine.train_step([_model_item(engine, 2 + step * 12)])
+                    grad_norm = engine.clip_grad_norm()
+                    engine.step_optimizer(grad_norm)
+                    cache_sizes.append(sum(key.startswith("dsa_topk_") for key in offload_manager.pin_memory_cache))
 
             assert math.isfinite(step_info["total_loss"])
             assert math.isfinite(step_info["logs_info"]["reduced_mtp_loss"])
+            assert math.isfinite(float(grad_norm))
+            assert cache_sizes == [1, 1], cache_sizes
         finally:
+            offload_manager.clear(clear_pin_memory_cache=True)
             del engine
             torch.cuda.empty_cache()
 
@@ -133,29 +145,37 @@ class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
 @unittest.skipUnless(torch.cuda.device_count() >= 2, "requires 2 CUDA devices")
 class TestGlm52MicroBatchMTPCheckpoint(DeterministicDDPTestCase):
     def test_nested_micro_batch_inputs_preserve_gradients(self):
-        # 验证 EP2 micro2 的嵌套 future embedding 经 pytree checkpoint 后可完成真实训练步。
+        # 验证 EP2 micro2 的嵌套 embedding 可反传，且两个 slot 的 pinned buffer 跨 step 复用。
         self.create_pg("cuda")
         engine = _build_engine(
             intra_layer_micro_batch=2,
             ep_size=2,
             mtp_num_layers=1,
             compile_model=False,
+            recompute_ratio=1.0,
         )
+        offload_manager = OffloadManager()
+        offload_manager.clear(clear_pin_memory_cache=True)
         try:
+            cache_sizes = []
             with mock.patch.dict(
                 os.environ,
-                {"XTUNER_ACTIVATION_OFFLOAD": "0", "XTUNER_DSA_TOPK_OFFLOAD": "0"},
+                {"XTUNER_ACTIVATION_OFFLOAD": "0", "XTUNER_DSA_TOPK_OFFLOAD": "1"},
             ):
-                step_info = engine.train_step(
-                    [
-                        _model_item(engine, 2),
-                        _model_item(engine, 14),
-                    ]
-                )
+                for step in range(2):
+                    step_info = engine.train_step(
+                        [_model_item(engine, 2 + step * 48 + micro_batch * 12) for micro_batch in range(4)]
+                    )
+                    grad_norm = engine.clip_grad_norm()
+                    engine.step_optimizer(grad_norm)
+                    cache_sizes.append(sum(key.startswith("dsa_topk_") for key in offload_manager.pin_memory_cache))
 
             assert math.isfinite(step_info["total_loss"])
             assert math.isfinite(step_info["logs_info"]["reduced_mtp_loss"])
+            assert math.isfinite(float(grad_norm))
+            assert cache_sizes == [4, 4], cache_sizes
         finally:
+            offload_manager.clear(clear_pin_memory_cache=True)
             del engine
             torch.cuda.empty_cache()
 

--- a/tests/model/test_glm52_mtp_checkpoint_repro.py
+++ b/tests/model/test_glm52_mtp_checkpoint_repro.py
@@ -3,7 +3,7 @@
 TestGlm52CompiledMTPCheckpoint
     test_shared_mtp_depths_train_with_compile_and_topk_offload: 共享 MTP 深度可在 compile/offload 下训练。
 TestGlm52MicroBatchMTPCheckpoint
-    test_nested_micro_batch_inputs_preserve_gradients: EP2 micro2 可反传且 pinned buffer 数量有界。
+    test_nested_micro_batch_inputs_preserve_gradients: EP2 micro2 的嵌套 embedding 梯度可正确反传。
 """
 
 import math
@@ -23,7 +23,6 @@ from xtuner.v1.model.moe.glm52 import Glm52MoEConfig
 from xtuner.v1.module.attention import DSAMLAConfig
 from xtuner.v1.module.mtp import MTPConfig
 from xtuner.v1.module.router.noaux_router import NoAuxRouterConfig
-from xtuner.v1.utils.activation_offload import OffloadManager
 
 
 def _tiny_mtp_config(ep_size: int, mtp_num_layers: int, compile_model: bool) -> Glm52MoEConfig:
@@ -78,7 +77,6 @@ def _build_engine(
     ep_size: int,
     mtp_num_layers: int,
     compile_model: bool,
-    recompute_ratio: float = 0.0,
 ) -> TrainEngine:
     engine = TrainEngine(
         model_cfg=_tiny_mtp_config(ep_size, mtp_num_layers, compile_model),
@@ -86,7 +84,7 @@ def _build_engine(
         fsdp_cfg=FSDPConfig(
             ep_size=ep_size,
             cpu_offload=False,
-            recompute_ratio=recompute_ratio,
+            recompute_ratio=0.0,
             torch_compile=compile_model,
         ),
         intra_layer_micro_batch=intra_layer_micro_batch,
@@ -106,7 +104,7 @@ def _model_item(engine: TrainEngine, start: int) -> ModelItem:
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
 class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
     def test_shared_mtp_depths_train_with_compile_and_topk_offload(self):
-        # 验证默认 reentrant checkpoint 可训练共享 MTP 深度，且 pinned buffer 跨 step 复用。
+        # 验证默认 reentrant checkpoint 可训练共享 MTP 深度且 loss 有限。
         self.create_pg("cuda")
         engine = _build_engine(
             intra_layer_micro_batch=1,
@@ -114,26 +112,16 @@ class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
             mtp_num_layers=2,
             compile_model=True,
         )
-        offload_manager = OffloadManager()
-        offload_manager.clear(clear_pin_memory_cache=True)
         try:
-            cache_sizes = []
             with mock.patch.dict(
                 os.environ,
                 {"XTUNER_ACTIVATION_OFFLOAD": "0", "XTUNER_DSA_TOPK_OFFLOAD": "1"},
             ):
-                for step in range(2):
-                    step_info = engine.train_step([_model_item(engine, 2 + step * 12)])
-                    grad_norm = engine.clip_grad_norm()
-                    engine.step_optimizer(grad_norm)
-                    cache_sizes.append(sum(key.startswith("dsa_topk_") for key in offload_manager.pin_memory_cache))
+                step_info = engine.train_step([_model_item(engine, 2)])
 
             assert math.isfinite(step_info["total_loss"])
             assert math.isfinite(step_info["logs_info"]["reduced_mtp_loss"])
-            assert math.isfinite(float(grad_norm))
-            assert cache_sizes == [1, 1], cache_sizes
         finally:
-            offload_manager.clear(clear_pin_memory_cache=True)
             del engine
             torch.cuda.empty_cache()
 
@@ -145,37 +133,29 @@ class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
 @unittest.skipUnless(torch.cuda.device_count() >= 2, "requires 2 CUDA devices")
 class TestGlm52MicroBatchMTPCheckpoint(DeterministicDDPTestCase):
     def test_nested_micro_batch_inputs_preserve_gradients(self):
-        # 验证 EP2 micro2 的嵌套 embedding 可反传，且两个 slot 的 pinned buffer 跨 step 复用。
+        # 验证 EP2 micro2 的嵌套 future embedding 经 pytree checkpoint 后可完成真实训练步。
         self.create_pg("cuda")
         engine = _build_engine(
             intra_layer_micro_batch=2,
             ep_size=2,
             mtp_num_layers=1,
             compile_model=False,
-            recompute_ratio=1.0,
         )
-        offload_manager = OffloadManager()
-        offload_manager.clear(clear_pin_memory_cache=True)
         try:
-            cache_sizes = []
             with mock.patch.dict(
                 os.environ,
-                {"XTUNER_ACTIVATION_OFFLOAD": "0", "XTUNER_DSA_TOPK_OFFLOAD": "1"},
+                {"XTUNER_ACTIVATION_OFFLOAD": "0", "XTUNER_DSA_TOPK_OFFLOAD": "0"},
             ):
-                for step in range(2):
-                    step_info = engine.train_step(
-                        [_model_item(engine, 2 + step * 48 + micro_batch * 12) for micro_batch in range(4)]
-                    )
-                    grad_norm = engine.clip_grad_norm()
-                    engine.step_optimizer(grad_norm)
-                    cache_sizes.append(sum(key.startswith("dsa_topk_") for key in offload_manager.pin_memory_cache))
+                step_info = engine.train_step(
+                    [
+                        _model_item(engine, 2),
+                        _model_item(engine, 14),
+                    ]
+                )
 
             assert math.isfinite(step_info["total_loss"])
             assert math.isfinite(step_info["logs_info"]["reduced_mtp_loss"])
-            assert math.isfinite(float(grad_norm))
-            assert cache_sizes == [4, 4], cache_sizes
         finally:
-            offload_manager.clear(clear_pin_memory_cache=True)
             del engine
             torch.cuda.empty_cache()
 

--- a/xtuner/v1/data_proto/sequence_context.py
+++ b/xtuner/v1/data_proto/sequence_context.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import itertools
 from typing import cast
 
 import torch
@@ -7,9 +6,6 @@ from torch.distributed.device_mesh import DeviceMesh
 from typing_extensions import Self
 
 from .utils import gather_for_sequence_parallel, pad_to_multiple_of, split_for_sequence_parallel
-
-
-_DSA_TOPK_CONTEXT_IDS = itertools.count()
 
 
 class DSATopKCacheState:
@@ -29,7 +25,7 @@ class DSATopKCacheState:
     offloaded: dict[int, str]  # OffloadManager key for each CPU-resident source.
     released_sources: set[int]  # Sources whose backward replay lifetime has ended.
     checkpoint_active: bool  # Whether checkpoint forward retained this cache for replay.
-    context_id: int  # Process-local identifier used to make offload keys unique.
+    offload_slot: int  # Stable offload slot among concurrently active microbatches.
     mtp_forward_uses_remaining: dict[int, int]  # Original-forward MTP uses left per shared source.
     mtp_replays_remaining: dict[int, int]  # Backward MTP replays left per shared source.
 
@@ -40,7 +36,7 @@ class DSATopKCacheState:
         offloaded: dict[int, str] | None = None,
         released_sources: set[int] | None = None,
         checkpoint_active: bool = False,
-        context_id: int | None = None,
+        offload_slot: int = 0,
         mtp_forward_uses_remaining: dict[int, int] | None = None,
         mtp_replays_remaining: dict[int, int] | None = None,
     ) -> None:
@@ -50,7 +46,7 @@ class DSATopKCacheState:
         self.offloaded = {} if offloaded is None else offloaded
         self.released_sources = set() if released_sources is None else released_sources
         self.checkpoint_active = checkpoint_active
-        self.context_id = next(_DSA_TOPK_CONTEXT_IDS) if context_id is None else context_id
+        self.offload_slot = offload_slot
         self.mtp_forward_uses_remaining = {} if mtp_forward_uses_remaining is None else mtp_forward_uses_remaining
         self.mtp_replays_remaining = {} if mtp_replays_remaining is None else mtp_replays_remaining
 

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -496,6 +496,11 @@ class MoE(BaseModel):
             seq_ctx.position_ids is not None and seq_ctx.position_ids.shape[-1] == first_position_ids.shape[-1]
             for seq_ctx in seq_ctx_list
         ), "intra-layer micro-batches must have the same local sequence length"
+        # A slot owns both runtime offload state and pinned storage. TrainEngine
+        # finishes backward before the next accumulation group, so only contexts
+        # in this call can be live concurrently and need distinct slots.
+        for offload_slot, seq_ctx in enumerate(seq_ctx_list):
+            seq_ctx.dsa_topk_cache.offload_slot = offload_slot
 
         # Prepare input embeddings for all micro-batches
         if seq_ctx_list[0].input_ids is None:
@@ -624,7 +629,9 @@ class MoE(BaseModel):
                         input_ids=seq_ctx.input_ids.clone() if seq_ctx.input_ids is not None else None,
                         position_ids=seq_ctx.position_ids.clone(),
                         inputs_embeds=seq_ctx.inputs_embeds.clone() if seq_ctx.inputs_embeds is not None else None,
-                        dsa_topk_cache=DSATopKCacheState(),
+                        dsa_topk_cache=DSATopKCacheState(
+                            offload_slot=seq_ctx.dsa_topk_cache.offload_slot,
+                        ),
                     )
                 )
 
@@ -747,6 +754,7 @@ class MoE(BaseModel):
         loss_ctx: MoELossContextDict | None,
         return_router_logits: bool = False,
     ) -> MoEModelOutputs:
+        seq_ctx.dsa_topk_cache.offload_slot = 0
         input_ids = seq_ctx.input_ids
         position_ids = seq_ctx.position_ids
 
@@ -854,7 +862,9 @@ class MoE(BaseModel):
                 input_ids=input_ids.clone() if input_ids is not None else None,
                 position_ids=position_ids.clone(),
                 inputs_embeds=seq_ctx.inputs_embeds.clone() if seq_ctx.inputs_embeds is not None else None,
-                dsa_topk_cache=DSATopKCacheState(),
+                dsa_topk_cache=DSATopKCacheState(
+                    offload_slot=seq_ctx.dsa_topk_cache.offload_slot,
+                ),
             )
             # MTP uses its own mask; main mask's non-pad indices do not apply.
             mtp_nonpad_indices = torch.nonzero(mtp_seq_ctx.mask, as_tuple=True)[1]

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -475,6 +475,14 @@ class MoE(BaseModel):
         moe_info = cast(MoEBatchForwardInfo, base_info)
         return moe_info
 
+    @staticmethod
+    def _prepare_seq_ctx_topk_cache(seq_ctx_list: Sequence[SequenceContext]) -> None:
+        # A slot owns both runtime offload state and pinned storage. TrainEngine
+        # finishes backward before the next accumulation group, so only contexts
+        # in one model call can be live concurrently and need distinct slots.
+        for offload_slot, seq_ctx in enumerate(seq_ctx_list):
+            seq_ctx.dsa_topk_cache.offload_slot = offload_slot
+
     def _micro_batch_forward(
         self,
         seq_ctx_list: list[SequenceContext],
@@ -486,6 +494,7 @@ class MoE(BaseModel):
         This method processes multiple micro-batches in parallel, similar to how MoEDecoderLayer handles micro-batching
         at the layer level.
         """
+        self._prepare_seq_ctx_topk_cache(seq_ctx_list)
         if self.config.return_hidden_states:
             raise NotImplementedError
 
@@ -496,11 +505,6 @@ class MoE(BaseModel):
             seq_ctx.position_ids is not None and seq_ctx.position_ids.shape[-1] == first_position_ids.shape[-1]
             for seq_ctx in seq_ctx_list
         ), "intra-layer micro-batches must have the same local sequence length"
-        # A slot owns both runtime offload state and pinned storage. TrainEngine
-        # finishes backward before the next accumulation group, so only contexts
-        # in this call can be live concurrently and need distinct slots.
-        for offload_slot, seq_ctx in enumerate(seq_ctx_list):
-            seq_ctx.dsa_topk_cache.offload_slot = offload_slot
 
         # Prepare input embeddings for all micro-batches
         if seq_ctx_list[0].input_ids is None:
@@ -754,7 +758,7 @@ class MoE(BaseModel):
         loss_ctx: MoELossContextDict | None,
         return_router_logits: bool = False,
     ) -> MoEModelOutputs:
-        seq_ctx.dsa_topk_cache.offload_slot = 0
+        self._prepare_seq_ctx_topk_cache([seq_ctx])
         input_ids = seq_ctx.input_ids
         position_ids = seq_ctx.position_ids
 

--- a/xtuner/v1/module/attention/dsa_topk_sharing.py
+++ b/xtuner/v1/module/attention/dsa_topk_sharing.py
@@ -106,7 +106,7 @@ class GpuTopKResidency:
         seq_ctx.dsa_topk_cache.indices.pop(source_layer_idx, None)
 
     def _offload_key(self, seq_ctx: SequenceContext, source_layer_idx: int) -> str:
-        return f"dsa_topk_{seq_ctx.dsa_topk_cache.context_id}_{source_layer_idx}"
+        return f"dsa_topk_{seq_ctx.dsa_topk_cache.offload_slot}_{source_layer_idx}"
 
 
 class ActivationOffloadedTopKResidency(GpuTopKResidency):
@@ -178,13 +178,23 @@ class ActivationOffloadedTopKResidency(GpuTopKResidency):
             return
 
         key = self._offload_key(seq_ctx, source_layer_idx)
-        cpu_buffer = OffloadManager().get_or_create_pin_memory(key, topk_indices.shape, topk_indices.dtype)
+        manager = OffloadManager()
+        # A slot/source pair owns both the runtime entry and its reusable pinned
+        # storage. Reusing it while still live would overwrite the earlier D2H
+        # result, so fail loudly if the scheduling contract is violated.
+        if manager.has_runtime_key(key):
+            raise RuntimeError(f"DSA top-k offload slot is still active: {key}")
+        cpu_buffer = manager.get_or_create_pin_memory(
+            key,
+            topk_indices.shape,
+            topk_indices.dtype,
+        )
         swap_tensor = SwapTensor(topk_indices, key, tensor_cpu=cpu_buffer)
         stream = self._stream_for_device(topk_indices.device)
         stream.wait_stream(torch.cuda.current_stream(topk_indices.device))
         swap_tensor.launch_d2h(stream)
         swap_tensor.wait_d2h_finished(stream, True)
-        OffloadManager().put(key, swap_tensor)
+        manager.put(key, swap_tensor)
         cache.offloaded[source_layer_idx] = key
 
     # Pinned CPU buffers and stream-side effects must stay outside Inductor graphs.

--- a/xtuner/v1/module/attention/dsa_topk_sharing.py
+++ b/xtuner/v1/module/attention/dsa_topk_sharing.py
@@ -178,13 +178,12 @@ class ActivationOffloadedTopKResidency(GpuTopKResidency):
             return
 
         key = self._offload_key(seq_ctx, source_layer_idx)
-        manager = OffloadManager()
         # A slot/source pair owns both the runtime entry and its reusable pinned
         # storage. Reusing it while still live would overwrite the earlier D2H
         # result, so fail loudly if the scheduling contract is violated.
-        if manager.has_runtime_key(key):
+        if OffloadManager().has_runtime_key(key):
             raise RuntimeError(f"DSA top-k offload slot is still active: {key}")
-        cpu_buffer = manager.get_or_create_pin_memory(
+        cpu_buffer = OffloadManager().get_or_create_pin_memory(
             key,
             topk_indices.shape,
             topk_indices.dtype,
@@ -194,7 +193,7 @@ class ActivationOffloadedTopKResidency(GpuTopKResidency):
         stream.wait_stream(torch.cuda.current_stream(topk_indices.device))
         swap_tensor.launch_d2h(stream)
         swap_tensor.wait_d2h_finished(stream, True)
-        manager.put(key, swap_tensor)
+        OffloadManager().put(key, swap_tensor)
         cache.offloaded[source_layer_idx] = key
 
     # Pinned CPU buffers and stream-side effects must stay outside Inductor graphs.

--- a/xtuner/v1/ops/sparse_mla/pytorch.py
+++ b/xtuner/v1/ops/sparse_mla/pytorch.py
@@ -68,7 +68,7 @@ def torch_dsa_topk_indices(
     topk = min(index_topk, kv_len)
     topk_scores, topk_indices = index_scores.topk(topk, dim=-1)
     topk_indices = topk_indices.masked_fill(topk_scores == -torch.inf, -1)
-    return topk_indices.squeeze(0).unsqueeze(1)
+    return topk_indices.squeeze(0).unsqueeze(1).to(torch.int32)
 
 
 def _packed_causal_mask(seq_ctx: SequenceContext, query_len: int, kv_len: int, device: torch.device) -> torch.Tensor:

--- a/xtuner/v1/ops/sparse_mla/tilelang.py
+++ b/xtuner/v1/ops/sparse_mla/tilelang.py
@@ -170,7 +170,7 @@ def _tilelang_dsa_topk_indices_from_ranges(
     topk = min(index_topk, k.shape[0])
     topk_scores, topk_indices = logits.topk(topk, dim=-1)
     topk_indices = topk_indices.masked_fill(topk_scores == -torch.inf, -1)
-    return topk_indices.to(torch.int64).unsqueeze(1)
+    return topk_indices.to(torch.int32).unsqueeze(1)
 
 
 @_tilelang_dsa_topk_indices_from_ranges.register_fake
@@ -183,7 +183,7 @@ def _(
     index_topk: int,
 ) -> Tensor:
     topk = min(index_topk, k.shape[0])
-    return torch.empty((q.shape[0], 1, topk), device=q.device, dtype=torch.int64)
+    return torch.empty((q.shape[0], 1, topk), device=q.device, dtype=torch.int32)
 
 
 @functools.cache

--- a/xtuner/v1/utils/activation_offload.py
+++ b/xtuner/v1/utils/activation_offload.py
@@ -229,6 +229,10 @@ class OffloadManager(metaclass=SingletonMeta):
     def exist(self, key):
         return key in self.items
 
+    def has_runtime_key(self, key):
+        """Return whether an offload key still owns a live runtime entry."""
+        return key in self.items or key in self.may_npu_tensors
+
     def assert_not_exist(self, key):
         if key not in self.items:
             raise RuntimeError(f"Key {key} already exist in items")

--- a/xtuner/v1/utils/misc.py
+++ b/xtuner/v1/utils/misc.py
@@ -29,16 +29,33 @@ XTUNER_DETERMINISTIC = os.getenv("XTUNER_DETERMINISTIC") == "true"
 
 def set_deterministic():
     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
-    # Inductor 会在 torch.compile 前读取 dynamic_scale_rblock；确定性模式必须尽早关闭。
-    # torch.use_deterministic_algorithms(True) 只会让 reduction 的初始候选收敛成一个 config；
-    # dynamic rblock 仍可能在 precompile 后追加一个缩小 R*_BLOCK 的 launcher，并由 runtime
-    # benchmark 在多个 launcher 中选择。不同 rank/run 一旦选到不同 reduction 分块，浮点累加
-    # 顺序就会变化，最终可能得到 bitwise 不同的梯度。
+    # Inductor 有两个独立的 reduction 调优入口：dynamic rblock 会在 precompile 后调整
+    # launcher，而 INNER reduction 会在 deterministic 检查前返回 persistent/contiguous
+    # 多个候选，由 runtime benchmark 选出配置。确定性模式必须同时关闭前者并固定后者。
+    # Triton compile subprocess 不会继承 Python monkey patch，因此也要在当前进程串行编译，
+    # 避免不同 rank/run 采用不同的浮点累加顺序。
     os.environ["TORCHINDUCTOR_DYNAMIC_SCALE_RBLOCK"] = "0"
+    os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
     from torch._inductor import config as inductor_config
+    from torch._inductor.runtime import triton_heuristics
 
     inductor_config.dynamic_scale_rblock = False
+    inductor_config.compile_threads = 1
     torch.use_deterministic_algorithms(True, warn_only=True)
+
+    original_reduction_configs = triton_heuristics._reduction_configs
+    if not getattr(original_reduction_configs, "_xtuner_deterministic_patched", False):
+
+        def deterministic_reduction_configs(*args, **kwargs):
+            return original_reduction_configs(*args, **kwargs)[:1]
+
+        setattr(deterministic_reduction_configs, "_xtuner_deterministic_patched", True)
+        setattr(
+            deterministic_reduction_configs,
+            "_xtuner_original_reduction_configs",
+            original_reduction_configs,
+        )
+        triton_heuristics._reduction_configs = deterministic_reduction_configs
 
 
 # https://github.com/python/cpython/issues/82300#issuecomment-2169035092


### PR DESCRIPTION
## Summary

DSA top-k offload used a monotonically increasing context ID for pinned storage, creating new pinned buffers every training step instead of reusing them.

This change:

- assigns stable slots to concurrently active microbatches;
- uses one `(offload_slot, source_layer_idx)` key for both the live `SwapTensor` and its reusable pinned storage;
- rejects slot reuse while the previous runtime entry is still active;
- propagates the slot through main and MTP sequence contexts;
- removes the obsolete context ID counter;
- adds multi-step micro1 and EP2/micro2 regression coverage.

## Validation

- `pytest -q tests/model/test_glm52_mtp_checkpoint_repro.py`: 2 passed
- `pytest -q tests/module/attention/test_dsa_mla.py::TestDSAAttention`: 3 passed
- pre-commit hooks: passed, including ruff, mypy, and pydantic checks

## Result

Each slot/source pair has one live offload lifecycle and one reusable pinned buffer, so pinned memory remains bounded across optimizer steps.