### PR TITLE
[Fix] Add GLM-5.2 MuonSplit and AdamW-only gradient clipping

### DIFF
--- a/tests/optim/test_muon.py
+++ b/tests/optim/test_muon.py
@@ -26,7 +26,7 @@ from xtuner.v1.config.optim import MuonConfig
 from xtuner.v1.engine.train_engine import TrainEngine
 from xtuner.v1.model.base import BaseModel, XTunerBaseModelConfig
 from xtuner.v1.module.decoder_layer.dense_decoder_layer import DenseMLP
-from xtuner.v1.optim.muon import _muonsplit_newton_schulz, zeropower_via_newtonschulz5
+from xtuner.v1.optim.muon import Muon, _muonsplit_newton_schulz, zeropower_via_newtonschulz5
 
 
 # ─── Test: Newton-Schulz functions ───────────────────────────────────────────
@@ -409,12 +409,15 @@ class TestMuonSingleGPU(DeterministicDDPTestCase):
         adamw_squared = 0
         for group in optimizer.param_groups:
             is_muon = group["algorithm"] == "muon"
+            assert group["clip_grad"] is not is_muon
             grad_value = 2.0 if is_muon else 1.0
             for param in group["params"]:
                 param.grad = torch.full_like(param, grad_value)
                 total_squared += param.numel() * grad_value**2
                 if not is_muon:
                     adamw_squared += param.numel()
+            # The engine must consume only the generic policy, not optimizer-specific metadata.
+            group["algorithm"] = "test"
 
         engine = object.__new__(TrainEngine)
         engine.model = model
@@ -425,9 +428,32 @@ class TestMuonSingleGPU(DeterministicDDPTestCase):
         torch.testing.assert_close(grad_norm, torch.tensor(math.sqrt(total_squared), device=device))
         clip_coef = min(1.0, optim_config.max_grad_norm / (math.sqrt(adamw_squared) + 1e-6))
         for group in optimizer.param_groups:
-            expected = 2.0 if group["algorithm"] == "muon" else clip_coef
+            expected = clip_coef if group["clip_grad"] else 2.0
             for param in group["params"]:
                 torch.testing.assert_close(param.grad.to_local(), torch.full_like(param.grad.to_local(), expected))
+
+    def test_clip_grad_policy_is_preserved_on_load(self):
+        muon_param = nn.Parameter(torch.empty(4, 4))
+        adamw_param = nn.Parameter(torch.empty(4))
+        optimizer = Muon(
+            [
+                {"params": [muon_param]},
+                {"params": [adamw_param], "algorithm": "adamw"},
+            ]
+        )
+        assert [group["clip_grad"] for group in optimizer.param_groups] == [False, True]
+
+        state_dict = optimizer.state_dict()
+        assert all("clip_grad" not in group for group in state_dict["param_groups"])
+
+        state_dict["param_groups"][0]["clip_grad"] = True
+        state_dict["param_groups"][1]["clip_grad"] = False
+        optimizer.load_state_dict(state_dict)
+        assert [group["clip_grad"] for group in optimizer.param_groups] == [False, True]
+        assert [group["clip_grad"] for group in state_dict["param_groups"]] == [True, False]
+
+        optimizer.add_param_group({"params": [nn.Parameter(torch.empty(4, 4))]})
+        assert optimizer.param_groups[-1]["clip_grad"] is False
 
 
 # ─── Test: end-to-end FSDP ───────────────────────────────────────────────────

--- a/tests/optim/test_muon.py
+++ b/tests/optim/test_muon.py
@@ -23,9 +23,10 @@ import torch.nn.functional as F
 from xtuner._testing.testcase import DeterministicDDPTestCase
 from xtuner.v1.config import FSDPConfig
 from xtuner.v1.config.optim import MuonConfig
+from xtuner.v1.engine.train_engine import TrainEngine
 from xtuner.v1.model.base import BaseModel, XTunerBaseModelConfig
 from xtuner.v1.module.decoder_layer.dense_decoder_layer import DenseMLP
-from xtuner.v1.optim.muon import zeropower_via_newtonschulz5
+from xtuner.v1.optim.muon import _muonsplit_newton_schulz, zeropower_via_newtonschulz5
 
 
 # ─── Test: Newton-Schulz functions ───────────────────────────────────────────
@@ -57,6 +58,34 @@ class TestNewtonSchulz(DeterministicDDPTestCase):
             assert not torch.isnan(result1).any()
             assert not torch.isnan(result2).any()
             torch.testing.assert_close(result1, result2, atol=3e-2, rtol=3e-2)
+
+    def test_muonsplit_matches_independent_blocks(self):
+        self.create_pg("cuda")
+        split_sizes = (6, 2, 6, 2)
+        logical_rows = sum(split_sizes)
+        G = torch.randn(logical_rows + 2, 4, device="cuda", dtype=torch.float32)
+
+        result = _muonsplit_newton_schulz(
+            G,
+            epsilon=1e-7,
+            num_experts=1,
+            newton_schulz_func=zeropower_via_newtonschulz5,
+            split_sizes=split_sizes,
+            adjust_lr="rms_norm",
+        )
+
+        expected_chunks = []
+        offset = 0
+        for size in split_sizes:
+            chunk = G.narrow(0, offset, size)
+            chunk = zeropower_via_newtonschulz5(chunk, epsilon=1e-7)
+            chunk.mul_(0.2 * math.sqrt(max(size, G.size(1))))
+            expected_chunks.append(chunk)
+            offset += size
+        expected_chunks.append(torch.zeros_like(G[logical_rows:]))
+        expected = torch.cat(expected_chunks)
+
+        torch.testing.assert_close(result, expected)
 
 
 # ─── Model for end-to-end tests ──────────────────────────────────────────────
@@ -362,6 +391,44 @@ class TestMuonSingleGPU(DeterministicDDPTestCase):
                 msg=f"mismatch on '{name}': max_abs={abs_diff.max().item():.2e}, max_rel={rel_diff.max().item():.2e}",
             )
 
+    def test_clip_grad_norm_only_clips_adamw(self):
+        self.create_pg("cuda")
+        device = "cuda"
+        model = ToyMoEModelConfig(compile_cfg=False).build().to(device)
+        model.fully_shard(
+            FSDPConfig(
+                param_dtype=torch.float32,
+                reduce_dtype=torch.float32,
+                torch_compile=False,
+            )
+        )
+
+        optim_config = MuonConfig(max_grad_norm=1.0)
+        optimizer = optim_config.build(model)
+        total_squared = 0
+        adamw_squared = 0
+        for group in optimizer.param_groups:
+            is_muon = group["algorithm"] == "muon"
+            grad_value = 2.0 if is_muon else 1.0
+            for param in group["params"]:
+                param.grad = torch.full_like(param, grad_value)
+                total_squared += param.numel() * grad_value**2
+                if not is_muon:
+                    adamw_squared += param.numel()
+
+        engine = object.__new__(TrainEngine)
+        engine.model = model
+        engine.optimizer = optimizer
+        engine.optim_cfg = optim_config
+        grad_norm = engine.clip_grad_norm()
+
+        torch.testing.assert_close(grad_norm, torch.tensor(math.sqrt(total_squared), device=device))
+        clip_coef = min(1.0, optim_config.max_grad_norm / (math.sqrt(adamw_squared) + 1e-6))
+        for group in optimizer.param_groups:
+            expected = 2.0 if group["algorithm"] == "muon" else clip_coef
+            for param in group["params"]:
+                torch.testing.assert_close(param.grad.to_local(), torch.full_like(param.grad.to_local(), expected))
+
 
 # ─── Test: end-to-end FSDP ───────────────────────────────────────────────────
 
@@ -430,7 +497,9 @@ class TestMuonFSDP(DeterministicDDPTestCase):
         fsdp_loss.backward()
 
         # ── Production Muon optimizer step ────────────────────────────────────
-        muon_config = MuonConfig(lr=LR, momentum=MU, weight_decay=WD, eps=EPSILON, betas=BETAS, enable_all2all=enable_all2all)
+        muon_config = MuonConfig(
+            lr=LR, momentum=MU, weight_decay=WD, eps=EPSILON, betas=BETAS, enable_all2all=enable_all2all
+        )
         optim = muon_config.build(model)
         optim.step()
 

--- a/xtuner/v1/config/optim.py
+++ b/xtuner/v1/config/optim.py
@@ -83,6 +83,12 @@ class MuonConfig(OptimConfig):
         trainable_parameters_names = model.trainable_parameters()
         trainable_names = {name for name, _ in trainable_parameters_names}
 
+        muon_split_sizes = {}
+        for module in model.modules():
+            get_muon_split_sizes = getattr(module, "get_muon_split_sizes", None)
+            if callable(get_muon_split_sizes):
+                muon_split_sizes.update(get_muon_split_sizes())
+
         untrainable_names = []
         num_total = 0
         num_total_requires_grad = 0
@@ -201,6 +207,7 @@ class MuonConfig(OptimConfig):
             use_triton=False,
             epsilon=self.eps,
             enable_all2all=self.enable_all2all,
+            muon_split_sizes=muon_split_sizes,
         )
 
         return optimizer

--- a/xtuner/v1/config/optim.py
+++ b/xtuner/v1/config/optim.py
@@ -155,14 +155,14 @@ class MuonConfig(OptimConfig):
         # Build parameter groups
         param_groups = []
         if muon_params_regular:
-            param_groups.append(dict(params=muon_params_regular))
+            param_groups.append(dict(params=muon_params_regular, clip_grad=False))
         # fused_w1w3: w1 and w3 are fused, so num_experts = 2 * n_routed_experts
         if muon_params_moe_fused_w1w3:
-            param_groups.append(dict(params=muon_params_moe_fused_w1w3, num_experts=2 * num_experts))
+            param_groups.append(dict(params=muon_params_moe_fused_w1w3, num_experts=2 * num_experts, clip_grad=False))
         # Other expert params: num_experts = n_routed_experts
         if muon_params_moe_other:
-            param_groups.append(dict(params=muon_params_moe_other, num_experts=num_experts))
-        param_groups.append(dict(params=adamw_params, algorithm="adamw"))
+            param_groups.append(dict(params=muon_params_moe_other, num_experts=num_experts, clip_grad=False))
+        param_groups.append(dict(params=adamw_params, algorithm="adamw", clip_grad=True))
 
         # Sanity check: ensure all trainable parameters are assigned to optimizer
         total_assigned = (

--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -257,11 +257,28 @@ class TrainEngine:
     def clip_grad_norm(self, do_clip: bool = True, dtype=torch.float32):
         ProberList.before_clip_grad_norm(self.model)
         self.model.scale_and_reduce_grad()
+
         params = self.model.trainable_parameters()
         grads = [p.grad for _, p in params if p.grad is not None]
         grad_norm, grouped_grads = cal_grad_norm(grads, dtype=dtype)
+
         if do_clip:
-            clip_coef = self.optim_cfg.max_grad_norm / (grad_norm + 1e-6)
+            if any(group.get("algorithm") == "muon" for group in self.optimizer.param_groups):
+                clip_params = (
+                    p
+                    for group in self.optimizer.param_groups
+                    if group.get("algorithm") != "muon"
+                    for p in group["params"]
+                )
+                clip_grads = [p.grad for p in clip_params if p.grad is not None]
+                if clip_grads:
+                    clip_grad_norm, grouped_grads = cal_grad_norm(clip_grads, dtype=dtype)
+                else:
+                    clip_grad_norm = torch.zeros((), device=DEVICE, dtype=dtype)
+                    grouped_grads = {}
+            else:
+                clip_grad_norm = grad_norm
+            clip_coef = self.optim_cfg.max_grad_norm / (clip_grad_norm + 1e-6)
             clip_coef_clamped = torch.clamp(clip_coef, max=1.0)
             for grads in grouped_grads.values():
                 device = grads[0].device

--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -22,6 +22,7 @@ from torch.distributed.checkpoint.state_dict import (
     set_model_state_dict,
     set_optimizer_state_dict,
 )
+from torch.distributed.tensor import DTensor
 from torch.nn.utils.clip_grad import _no_grad
 from torch.utils._foreach_utils import (
     _device_has_foreach_support,
@@ -258,38 +259,52 @@ class TrainEngine:
         ProberList.before_clip_grad_norm(self.model)
         self.model.scale_and_reduce_grad()
 
-        params = self.model.trainable_parameters()
-        grads = [p.grad for _, p in params if p.grad is not None]
-        grad_norm, grouped_grads = cal_grad_norm(grads, dtype=dtype)
+        trainable_params = [p for _, p in self.model.trainable_parameters()]
+        all_grads = [p.grad for p in trainable_params if p.grad is not None]
+        total_grad_norm, grouped_all_grads = cal_grad_norm(all_grads, dtype=dtype)
 
         if do_clip:
-            if any(group.get("algorithm") == "muon" for group in self.optimizer.param_groups):
-                clip_params = (
-                    p
-                    for group in self.optimizer.param_groups
-                    if group.get("algorithm") != "muon"
-                    for p in group["params"]
-                )
-                clip_grads = [p.grad for p in clip_params if p.grad is not None]
-                if clip_grads:
-                    clip_grad_norm, grouped_grads = cal_grad_norm(clip_grads, dtype=dtype)
-                else:
-                    clip_grad_norm = torch.zeros((), device=DEVICE, dtype=dtype)
-                    grouped_grads = {}
+            clip_param_ids = {
+                id(p) for group in self.optimizer.param_groups if group.get("clip_grad", True) for p in group["params"]
+            }
+            clip_grads = [
+                cast(DTensor, p.grad) for p in trainable_params if id(p) in clip_param_ids and p.grad is not None
+            ]
+            clip_all_grads = len(clip_param_ids) == len(trainable_params) and clip_param_ids == {
+                id(p) for p in trainable_params
+            }
+            self._clip_gradients(
+                clip_grads,
+                max_norm=self.optim_cfg.max_grad_norm,
+                dtype=dtype,
+                precomputed_grad_info=(total_grad_norm, grouped_all_grads) if clip_all_grads else None,
+            )
+        ProberList.after_clip_grad_norm(self.model, total_grad_norm)
+        return total_grad_norm
+
+    @staticmethod
+    def _clip_gradients(
+        grads: list[DTensor],
+        max_norm: float,
+        dtype: torch.dtype,
+        precomputed_grad_info: tuple[torch.Tensor, dict[Any, list[DTensor]]] | None = None,
+    ) -> None:
+        if not grads:
+            return
+
+        if precomputed_grad_info is not None:
+            grad_norm, grouped_grads = precomputed_grad_info
+        else:
+            grad_norm, grouped_grads = cal_grad_norm(grads, dtype=dtype)
+        clip_coef = torch.clamp(max_norm / (grad_norm + 1e-6), max=1.0)
+        for device_grads in grouped_grads.values():
+            device = device_grads[0].device
+            device_clip_coef = clip_coef.to(device)
+            if _device_has_foreach_support(device):
+                torch._foreach_mul_(cast(list[torch.Tensor], device_grads), device_clip_coef)
             else:
-                clip_grad_norm = grad_norm
-            clip_coef = self.optim_cfg.max_grad_norm / (clip_grad_norm + 1e-6)
-            clip_coef_clamped = torch.clamp(clip_coef, max=1.0)
-            for grads in grouped_grads.values():
-                device = grads[0].device
-                if _device_has_foreach_support(device):
-                    torch._foreach_mul_(grads, clip_coef_clamped.to(device))
-                else:
-                    clip_coef_clamped_device = clip_coef_clamped.to(device)
-                    for g in grads:
-                        g.mul_(clip_coef_clamped_device)
-        ProberList.after_clip_grad_norm(self.model, grad_norm)
-        return grad_norm
+                for grad in device_grads:
+                    grad.mul_(device_clip_coef)
 
     def step_optimizer(self, grad_norm):
         """Step the optimizer to update the model parameters."""

--- a/xtuner/v1/module/attention/dsa_mla.py
+++ b/xtuner/v1/module/attention/dsa_mla.py
@@ -276,6 +276,14 @@ class DSAMultiLatentAttention(MultiLatentAttention):
             indexer_backend=self.sparse_mla_backend,
         )
 
+    def get_muon_split_sizes(self) -> dict[nn.Parameter, tuple[int, ...]]:
+        """Return the logical row blocks used by GLM MuonSplit."""
+        return {
+            self.q_b_proj.weight: (self.qk_nope_head_dim, self.qk_rope_head_dim) * self.num_attention_heads,
+            self.kv_a_proj_with_mqa.weight: (self.kv_lora_rank, self.qk_rope_head_dim),
+            self.kv_b_proj.weight: (self.qk_nope_head_dim, self.v_head_dim) * self.num_attention_heads,
+        }
+
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/xtuner/v1/module/attention/dsa_mla.py
+++ b/xtuner/v1/module/attention/dsa_mla.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Literal
+from typing import Literal, cast
 
 import torch
 from torch import nn
@@ -279,9 +279,11 @@ class DSAMultiLatentAttention(MultiLatentAttention):
     def get_muon_split_sizes(self) -> dict[nn.Parameter, tuple[int, ...]]:
         """Return the logical row blocks used by GLM MuonSplit."""
         return {
-            self.q_b_proj.weight: (self.qk_nope_head_dim, self.qk_rope_head_dim) * self.num_attention_heads,
-            self.kv_a_proj_with_mqa.weight: (self.kv_lora_rank, self.qk_rope_head_dim),
-            self.kv_b_proj.weight: (self.qk_nope_head_dim, self.v_head_dim) * self.num_attention_heads,
+            cast(nn.Parameter, self.q_b_proj.weight): (self.qk_nope_head_dim, self.qk_rope_head_dim)
+            * self.num_attention_heads,
+            cast(nn.Parameter, self.kv_a_proj_with_mqa.weight): (self.kv_lora_rank, self.qk_rope_head_dim),
+            cast(nn.Parameter, self.kv_b_proj.weight): (self.qk_nope_head_dim, self.v_head_dim)
+            * self.num_attention_heads,
         }
 
     def forward(

--- a/xtuner/v1/optim/muon.py
+++ b/xtuner/v1/optim/muon.py
@@ -24,6 +24,7 @@
 
 import math
 from collections import defaultdict
+from functools import partial
 from itertools import chain, product
 from typing import Callable, Generator, Iterator, Literal, Sequence, cast, overload
 
@@ -43,7 +44,11 @@ def maybe_to_local(tensor: list[Tensor]) -> list[Tensor]:
     return [t.to_local() if isinstance(t, DTensor) else t for t in tensor]
 
 
-def create_param_batches(params: Sequence[Tensor], batch_size: int) -> Generator[list[Tensor], None, None]:
+def create_param_batches(
+    params: Sequence[Tensor],
+    batch_size: int,
+    extra_group_key: Callable[[Tensor], object] | None = None,
+) -> Generator[list[Tensor], None, None]:
     """Batch parameters into groups of size `batch_size`.
 
     Tensors in each batch will have identical shape, sharding, and dtype.
@@ -52,13 +57,26 @@ def create_param_batches(params: Sequence[Tensor], batch_size: int) -> Generator
     groups = defaultdict(list)
     for p in params:
         sharding = p.placements if isinstance(p, DTensor) else None
-        groups[(p.shape, sharding, p.dtype)].append(p)
+        extra_key = extra_group_key(p) if extra_group_key is not None else None
+        groups[(p.shape, sharding, p.dtype, extra_key)].append(p)
 
     # Create batches from grouped parameters
     for group in groups.values():
         for i in range(0, len(group), batch_size):
             batch = group[i : i + batch_size]
             yield batch
+
+
+def _get_muon_lr_ratio(
+    fan_out: int,
+    fan_in: int,
+    adjust_lr: Literal["rms_norm", "spectral_norm", "none"],
+) -> float:
+    if adjust_lr == "none":
+        return 1.0
+    if adjust_lr == "spectral_norm":
+        return math.sqrt(fan_out / fan_in)
+    return 0.2 * math.sqrt(max(fan_out, fan_in))
 
 
 def pad_batch(batch: list[Tensor], batch_size: int) -> list[Tensor]:
@@ -275,6 +293,8 @@ class Muon(Optimizer):
         remainder_strategy (str): Communication strategy for parameter batches smaller than world size.
             ``"agrs"`` uses all-gather + reduce-scatter without batch padding. ``"pad_all2all"`` restores
             the original FSDP2 Muon behavior by zero-padding the batch to world size and using all-to-all.
+        muon_split_sizes (dict[Tensor, tuple[int, ...]] | None): Logical row blocks that Muon should
+            orthogonalize and scale independently. Used by GLM MuonSplit attention projections.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/
     FSDP2 Muon uses all-to-all communications: https://www.essential.ai/blog/infra
@@ -295,6 +315,7 @@ class Muon(Optimizer):
         newton_schulz_func: Callable | None = None,
         enable_all2all: bool = True,
         remainder_strategy: Literal["agrs", "pad_all2all"] = "agrs",
+        muon_split_sizes: dict[Tensor, tuple[int, ...]] | None = None,
     ):
         # Check hyperparameters
         if lr < 0.0:
@@ -328,6 +349,7 @@ class Muon(Optimizer):
         super().__init__(params, defaults)
         self._enable_all2all = enable_all2all
         self._remainder_strategy = remainder_strategy
+        self._muon_split_sizes = muon_split_sizes or {}
 
         # Pre-compute lr adjustment ratios for each Muon parameter based on global shape.
         # This must happen at init time because DTensor.shape here is guaranteed to be
@@ -340,16 +362,18 @@ class Muon(Optimizer):
             ne = group.get("num_experts", 1)
             for p in group["params"]:
                 state = self.state[p]
-                if adj == "none":
+                split_sizes = self._muon_split_sizes.get(p)
+                if split_sizes is not None:
+                    if p.ndim != 2 or ne != 1:
+                        raise ValueError("MuonSplit only supports regular 2D Muon parameters.")
+                    if not split_sizes or any(size <= 0 for size in split_sizes):
+                        raise ValueError(f"Invalid MuonSplit sizes: {split_sizes}")
+                    if sum(split_sizes) > p.shape[-2]:
+                        raise ValueError(f"MuonSplit sizes {split_sizes} exceed parameter shape {tuple(p.shape)}")
+                    # Each logical block applies its own ratio inside the orthogonalization callback.
                     state["lr_ratio"] = 1.0
-                elif adj == "spectral_norm":
-                    fan_out = p.shape[-2] // ne
-                    fan_in = p.shape[-1]
-                    state["lr_ratio"] = math.sqrt(fan_out / fan_in)
-                elif adj == "rms_norm":
-                    A = p.shape[-2] // ne
-                    B = p.shape[-1]
-                    state["lr_ratio"] = 0.2 * math.sqrt(max(A, B))
+                else:
+                    state["lr_ratio"] = _get_muon_lr_ratio(p.shape[-2] // ne, p.shape[-1], adj)
 
         # Newton-Schulz configuration
         if newton_schulz_func is not None:
@@ -664,15 +688,30 @@ class Muon(Optimizer):
                 group_world_size = group_process_group.size() if group_process_group is not None else 1
 
                 # Create batches within this mesh group
-                for params in create_param_batches(mesh_params, batch_size=group_world_size):
+                for params in create_param_batches(
+                    mesh_params,
+                    batch_size=group_world_size,
+                    extra_group_key=self._muon_split_sizes.get,
+                ):
                     gradients: list[Tensor] = [g for p in params if (g := p.grad) is not None]
                     assert len(gradients) == len(params), "Some gradients became None after filtering"
 
                     states = [self._get_or_initialize_state(p, algo_name) for p in params]
 
                     momentums = [s["momentum"] for s in states]
-                    lr_ratios = [s["lr_ratio"] for s in states]
+                    lr_ratios = [1.0 if p in self._muon_split_sizes else s["lr_ratio"] for p, s in zip(params, states)]
                     assert len(set(lr_ratios)) == 1, f"Found different lr_ratios: {set(lr_ratios)}"
+
+                    split_sizes = self._muon_split_sizes.get(params[0])
+                    assert all(self._muon_split_sizes.get(p) == split_sizes for p in params)
+                    newton_schulz_func = self._newton_schulz_func
+                    if split_sizes is not None:
+                        newton_schulz_func = partial(
+                            _muonsplit_newton_schulz,
+                            newton_schulz_func=self._newton_schulz_func,
+                            split_sizes=split_sizes,
+                            adjust_lr=group["adjust_lr"],
+                        )
 
                     is_remainder = len(params) < group_world_size
                     # When all-to-all is disabled, every sharded batch uses AGRS. Otherwise remainder
@@ -698,7 +737,7 @@ class Muon(Optimizer):
                                 epsilon=epsilon,
                                 nesterov=nesterov,
                                 flatten=flatten,
-                                newton_schulz_func=self._newton_schulz_func,
+                                newton_schulz_func=newton_schulz_func,
                                 comm_strategy="agrs",
                                 shard_dim=sharded_tensor_dim,
                                 process_group=group_process_group,
@@ -735,7 +774,7 @@ class Muon(Optimizer):
                                 epsilon=epsilon,
                                 nesterov=nesterov,
                                 flatten=flatten,
-                                newton_schulz_func=self._newton_schulz_func,
+                                newton_schulz_func=newton_schulz_func,
                                 comm_strategy=comm_strategy,
                                 shard_dim=sharded_tensor_dim,
                                 process_group=comm_pg,
@@ -1423,6 +1462,45 @@ def muon_update_newton_schulz(
         X = X.flatten(end_dim=-3)
 
     return newton_schulz_func(X, epsilon=epsilon, num_experts=num_experts).reshape(original_shape)
+
+
+def _muonsplit_newton_schulz(
+    X: Tensor,
+    epsilon: float | Tensor,
+    num_experts: int,
+    *,
+    newton_schulz_func: Callable,
+    split_sizes: tuple[int, ...],
+    adjust_lr: Literal["rms_norm", "spectral_norm", "none"],
+) -> Tensor:
+    """Orthogonalize and scale unequal logical row blocks independently."""
+    if X.ndim != 2 or num_experts != 1:
+        raise ValueError(f"MuonSplit expects one 2D matrix, got shape={tuple(X.shape)}, num_experts={num_experts}")
+
+    logical_rows = sum(split_sizes)
+    if logical_rows > X.size(-2):
+        raise ValueError(f"MuonSplit sizes {split_sizes} exceed input shape {tuple(X.shape)}")
+
+    chunks = X.narrow(-2, 0, logical_rows).split(split_sizes, dim=-2)
+    chunks_by_size: dict[int, list[tuple[int, Tensor]]] = defaultdict(list)
+    for index, (size, chunk) in enumerate(zip(split_sizes, chunks)):
+        chunks_by_size[size].append((index, chunk))
+
+    results: dict[int, Tensor] = {}
+    for size, indexed_chunks in chunks_by_size.items():
+        batch = torch.cat([chunk for _, chunk in indexed_chunks], dim=-2)
+        batch = newton_schulz_func(batch, epsilon=epsilon, num_experts=len(indexed_chunks))
+        lr_ratio = _get_muon_lr_ratio(size, X.size(-1), adjust_lr)
+        if lr_ratio != 1.0:
+            batch.mul_(lr_ratio)
+        for (index, _), result in zip(indexed_chunks, batch.split(size, dim=-2)):
+            results[index] = result
+
+    output = torch.cat([results[index] for index in range(len(split_sizes))], dim=-2)
+    if logical_rows < X.size(-2):
+        padding = torch.zeros_like(X.narrow(-2, logical_rows, X.size(-2) - logical_rows))
+        output = torch.cat([output, padding], dim=-2)
+    return output
 
 
 def zeropower_via_newtonschulz5(G: Tensor, epsilon: float = 1e-7, num_experts: int = 1):

--- a/xtuner/v1/optim/muon.py
+++ b/xtuner/v1/optim/muon.py
@@ -26,7 +26,7 @@ import math
 from collections import defaultdict
 from functools import partial
 from itertools import chain, product
-from typing import Callable, Generator, Iterator, Literal, Sequence, cast, overload
+from typing import Any, Callable, Generator, Iterator, Literal, Sequence, cast, overload
 
 import torch
 import torch.distributed as dist
@@ -350,6 +350,8 @@ class Muon(Optimizer):
         self._enable_all2all = enable_all2all
         self._remainder_strategy = remainder_strategy
         self._muon_split_sizes = muon_split_sizes or {}
+        self.register_state_dict_post_hook(self._remove_clip_grad_policy)
+        self.register_load_state_dict_pre_hook(self._restore_clip_grad_policy)
 
         # Pre-compute lr adjustment ratios for each Muon parameter based on global shape.
         # This must happen at init time because DTensor.shape here is guaranteed to be
@@ -399,6 +401,27 @@ class Muon(Optimizer):
         # This must happen in __init__ so that all ranks call dist.new_group collectively.
         self._subgroup_cache: dict[tuple[int, int, int], ProcessGroup] = {}
         self._init_moe_subgroups()
+
+    def add_param_group(self, param_group: dict[str, Any]) -> None:
+        param_group.setdefault("clip_grad", param_group.get("algorithm", "muon") != "muon")
+        super().add_param_group(param_group)
+
+    @staticmethod
+    def _remove_clip_grad_policy(_optimizer: Optimizer, state_dict: dict[str, Any]) -> dict[str, Any]:
+        for group in state_dict["param_groups"]:
+            group.pop("clip_grad", None)
+        return state_dict
+
+    @staticmethod
+    def _restore_clip_grad_policy(optimizer: Optimizer, state_dict: dict[str, Any]) -> dict[str, Any]:
+        if len(state_dict["param_groups"]) != len(optimizer.param_groups):
+            return state_dict
+
+        state_dict = state_dict.copy()
+        state_dict["param_groups"] = [group.copy() for group in state_dict["param_groups"]]
+        for loaded_group, current_group in zip(state_dict["param_groups"], optimizer.param_groups):
+            loaded_group["clip_grad"] = current_group.get("clip_grad", True)
+        return state_dict
 
     @overload
     def step(self, closure: None = None) -> None: ...


### PR DESCRIPTION
## Summary

- Apply Muon independently to GLM-5.2 MLA head/component blocks, including per-block LR scaling ([GLM-5](https://arxiv.org/html/2602.15763v2#S2.SS1.SSS0.Px4), [reference implementation](https://github.com/PaddlePaddle/PaddleFormers/blob/327a4340e6c4f6fd1e3b525fb891993d23d6785a/paddleformers/transformers/glm_moe_dsa/modeling.py#L139-L252)).
- Clip only auxiliary AdamW gradients while retaining the full gradient norm for safety checks. This is motivated by Muon's scale-invariant orthogonalization, `Ortho(cG) = Ortho(G)` ([rationale](https://kellerjordan.github.io/posts/muon/#proving-that-ns-iteration-orthogonalizes-the-update)).

## Tests

- Full pre-commit suite for `xtuner/v1`, including mypy
- GPU unit tests pending maintainer approval