### PR TITLE
[Fix] Migrate unittest parameterization to PyTorch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ all = [
   "fastapi",
   "uvicorn",
   "liger-kernel",
-  "parametrize",
   "mathruler",
   "pylatexenc",
   "flash-linear-attention==0.4.2"

--- a/tests/chat_template/test_chat_template.py
+++ b/tests/chat_template/test_chat_template.py
@@ -267,7 +267,20 @@ class TestChatTemplate(TestCase):
                                                 add_generation_prompt=False)
                 self.assertEqual(decode_str, hf_text)
             else:
+                # Transformers 5.14 preserves one outer vision boundary around the
+                # per-frame placeholders expanded from a video token.
                 if j==15:
-                    self.assertTrue('Video 1: <|vision_start|><|video_pad|><|vision_end|><|vision_start|><|video_pad|><|vision_end|><|vision_start|><|video_pad|><|vision_end|><0.0-10.0 seconds>Describe the video in detail. [NO_REASONING]<|im_end|>' in decode_str)
+                    expected = (
+                        'Video 1: <|vision_start|><|vision_start|><|video_pad|><|vision_end|>'
+                        '<|vision_start|><|video_pad|><|vision_end|><|vision_start|><|video_pad|>'
+                        '<|vision_end|><|vision_end|><0.0-10.0 seconds>Describe the video in detail. '
+                        '[NO_REASONING]<|im_end|>'
+                    )
                 else:
-                    self.assertTrue('Video 1: <0.0 seconds><|vision_start|><|video_pad|><|vision_end|><1.0 seconds><|vision_start|><|video_pad|><|vision_end|><2.0 seconds><|vision_start|><|video_pad|><|vision_end|><0.0-10.0 seconds>Describe the video in detail. [NO_REASONING]<|im_end|>' in decode_str)
+                    expected = (
+                        'Video 1: <|vision_start|><0.0 seconds><|vision_start|><|video_pad|>'
+                        '<|vision_end|><1.0 seconds><|vision_start|><|video_pad|><|vision_end|>'
+                        '<2.0 seconds><|vision_start|><|video_pad|><|vision_end|><|vision_end|>'
+                        '<0.0-10.0 seconds>Describe the video in detail. [NO_REASONING]<|im_end|>'
+                    )
+                self.assertIn(expected, decode_str)

--- a/tests/chat_template/test_chat_template.py
+++ b/tests/chat_template/test_chat_template.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import os
 import json
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from unittest import TestCase
 from transformers import AutoTokenizer
 import torch
@@ -19,6 +19,7 @@ QWEN3_VL_DENSE_PATH = os.environ["QWEN3_VL_DENSE_PATH"]
 GPT_OSS_MINI_PATH = os.environ["GPT_OSS_MINI_PATH"]
 DEEPSEEK_V3_PATH = os.environ["DEEPSEEK_V3_PATH"]
 
+@instantiate_parametrized_tests
 class TestChatTemplate(TestCase):
 
     def setUp(self):
@@ -36,7 +37,7 @@ class TestChatTemplate(TestCase):
         }
 
 
-    @parametrize.parametrize(
+    @parametrize(
         "template_type, tokenizer",
         [   
             ("qwen3", QWEN3_PATH),
@@ -68,7 +69,7 @@ class TestChatTemplate(TestCase):
 
         self.assertTrue((input_ids == input_ids_ref))
 
-    @parametrize.parametrize(
+    @parametrize(
         "template_type, tokenizer",
         [
             ("qwen3-vl", QWEN3_VL_DENSE_PATH),
@@ -149,7 +150,7 @@ class TestChatTemplate(TestCase):
         input_ids = _messages.tokenize(tokenizer, chat_template)['input_ids']
         self.assertTrue((input_ids == input_ids_ref))
 
-    @parametrize.parametrize(
+    @parametrize(
         "template_type, tokenizer",
         [   
             ("gpt-oss", GPT_OSS_MINI_PATH),
@@ -198,7 +199,7 @@ class TestChatTemplate(TestCase):
             input_ids = _messages.tokenize(tokenizer, chat_template)['input_ids']
             self.assertTrue((input_ids == input_ids_ref))
 
-    @parametrize.parametrize(
+    @parametrize(
         "template_type, thinking, tokenizer",
         [   
             ("deepseek-v3", False, DEEPSEEK_V3_PATH),

--- a/tests/datasets/test_jsonl_dataset.py
+++ b/tests/datasets/test_jsonl_dataset.py
@@ -7,7 +7,7 @@ import time
 import random
 
 import tracemalloc
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import numpy as np
 import torch
 import torch.distributed as dist
@@ -42,6 +42,7 @@ def _get_pss_mb() -> float:
     return proc.memory_full_info().pss / 1024 / 1024
 
 
+@instantiate_parametrized_tests
 class TestJsonlDatasetDist(DistributedTestBase):
     def create_pg(self, device):
         ret = super().create_pg(device)
@@ -56,7 +57,7 @@ class TestJsonlDatasetDist(DistributedTestBase):
         # 默认按八卡跑；本地可用环境变量临时改小做快速验证
         return int(os.getenv("XTUNER_TEST_WORLD_SIZE", "8"))
 
-    @parametrize.parametrize("enable_mmap_shared", [(False,), (True,)])
+    @parametrize("enable_mmap_shared", [False, True])
     def test_jsonl_dataset_smoke_test(self, enable_mmap_shared: bool):
         alpaca_path = os.path.join(os.environ["ALPACA_PATH"], "202404121913-shard-1-of-3.jsonl")
         tokenizer_path = os.environ["QWEN3_MOE_PATH"]

--- a/tests/datasets/test_openai_tokenize_fn.py
+++ b/tests/datasets/test_openai_tokenize_fn.py
@@ -1,5 +1,5 @@
 import os
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from unittest import TestCase
 from transformers import AutoTokenizer
 
@@ -8,9 +8,10 @@ from xtuner.v1.datasets import OpenaiTokenizeFunctionConfig
 QWEN3_PATH = os.environ["QWEN3_VL_DENSE_PATH"]  # We need instruct model
 
 
+@instantiate_parametrized_tests
 class TestOpenaiTokenizeFunction(TestCase):
 
-    @parametrize.parametrize(
+    @parametrize(
         "template_type, tokenizer_path",
         [
             ("qwen3", QWEN3_PATH),

--- a/tests/datasets/test_qwen35_vl_tokenize_fn.py
+++ b/tests/datasets/test_qwen35_vl_tokenize_fn.py
@@ -4,7 +4,7 @@ from xtuner.v1.datasets import Qwen3VLTokenizeFnConfig, PretrainTokenizeFunction
 from transformers import AutoTokenizer, AutoProcessor,Qwen3VLProcessor
 import json
 import torch
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from xtuner.v1.utils.test_utils import add_video_root
 from packaging.version import Version
 from transformers import __version__ as transformers_version
@@ -18,6 +18,7 @@ VIDEO_ROOT = os.environ["VIDEO_ROOT"]
     Version(transformers_version) < Version("5.2.0"),
     f"transformers >= 5.2.0 is required, but got {transformers_version}"
 )
+@instantiate_parametrized_tests
 class TestMLLMTokenizeFn(TestCase):
     def setUp(self):
         QWEN35_VL_PATH = os.environ["QWEN3_5_MOE_PATH"]
@@ -59,7 +60,7 @@ class TestMLLMTokenizeFn(TestCase):
                                                add_generation_prompt=False)
             self.assertEqual(decode_str, hf_text)
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen35_vl_sft_single_image(self, add_vision_id):
         QWEN35_VL_PATH = os.environ["QWEN3_5_MOE_PATH"]
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN35_VL_PATH, chat_template="qwen3.5-vl",
@@ -99,7 +100,7 @@ class TestMLLMTokenizeFn(TestCase):
                 self.assertTrue(torch.allclose(pixel_values_xtuner, pixel_values_hf))
                 self.assertTrue(torch.allclose(image_grid_thw_xtuner, image_grid_thw_hf))
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_sft_multi_image(self, add_vision_id):
         QWEN35_VL_PATH = os.environ["QWEN3_5_MOE_PATH"]
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN35_VL_PATH,
@@ -245,7 +246,7 @@ class TestMLLMTokenizeFn(TestCase):
         self.assertGreater(result["num_tokens"], 0)
         self.assertGreater(sum(result["num_img_tokens"]), 0)
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_sft_video(self, add_vision_id):
         QWEN35_VL_PATH = os.environ["QWEN3_5_MOE_PATH"]
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN35_VL_PATH, rand_video_max_frames=14,
@@ -318,7 +319,7 @@ class TestMLLMTokenizeFn(TestCase):
                         self.assertTrue(torch.allclose(pixel_values_xtuner, pixel_values_hf))
                         self.assertTrue(torch.allclose(image_grid_thw_xtuner, image_grid_thw_hf))
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_pretrain_image(self, add_vision_id):
         QWEN35_VL_PATH = os.environ["QWEN3_5_MOE_PATH"]
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN35_VL_PATH,
@@ -350,7 +351,7 @@ class TestMLLMTokenizeFn(TestCase):
                 self.assertEqual(input_xtuner_str, hf_text)
                 self.assertTrue((labels_xtuner == self.tokenize_fn.img_context_token_id).sum() == 0)
     
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_pretrain_video(self, add_vision_id):
         QWEN35_VL_PATH = os.environ["QWEN3_5_MOE_PATH"]
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN35_VL_PATH,

--- a/tests/datasets/test_qwen3_vl_tokenize_fn.py
+++ b/tests/datasets/test_qwen3_vl_tokenize_fn.py
@@ -4,13 +4,14 @@ from xtuner.v1.datasets import Qwen3VLTokenizeFnConfig, PretrainTokenizeFunction
 from transformers import AutoTokenizer, AutoProcessor
 import json
 import torch
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from xtuner.v1.utils.test_utils import add_video_root
 
 QWEN3_VL_PATH = os.environ["QWEN3_VL_MOE_PATH"]
 VIDEO_ROOT = os.environ["VIDEO_ROOT"]
 
 
+@instantiate_parametrized_tests
 class TestMLLMTokenizeFn(TestCase):
     def setUp(self):
         self.tokenizer = AutoTokenizer.from_pretrained(QWEN3_VL_PATH)
@@ -90,7 +91,7 @@ class TestMLLMTokenizeFn(TestCase):
         input_ids = tokenize_fn(messages)['input_ids']
         self.assertEqual(input_ids, input_ids_ref)
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_sft_single_image(self, add_vision_id):
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN3_VL_PATH,
                                               add_vision_id=add_vision_id).build(self.tokenizer)
@@ -131,7 +132,7 @@ class TestMLLMTokenizeFn(TestCase):
                 self.assertTrue(torch.allclose(pixel_values_xtuner, pixel_values_hf))
                 self.assertTrue(torch.allclose(image_grid_thw_xtuner, image_grid_thw_hf))
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_sft_multi_image(self, add_vision_id):
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN3_VL_PATH,
                                               add_vision_id=add_vision_id).build(self.tokenizer)
@@ -279,7 +280,7 @@ class TestMLLMTokenizeFn(TestCase):
                     self.assertEqual(origin_fps_list, [20])
                     self.assertEqual(timestamps_list, [[0.25, 1.5]])
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_sft_video(self, add_vision_id):
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN3_VL_PATH, rand_video_max_frames=14,
                                               add_vision_id=add_vision_id).build(
@@ -368,7 +369,7 @@ class TestMLLMTokenizeFn(TestCase):
                 input_ids_hf = self.tokenizer(content)['input_ids']
                 self.assertEqual(input_ids_xtuner, input_ids_hf)
 
-    @parametrize.parametrize("add_vision_id", [(True,), (False,)])
+    @parametrize("add_vision_id", [True, False])
     def test_qwen3_vl_pretrain_image(self, add_vision_id):
         tokenize_fn = Qwen3VLTokenizeFnConfig(processor_path=QWEN3_VL_PATH,
                                               add_vision_id=add_vision_id).build(self.tokenizer)

--- a/tests/engine/test_dense_train_engine.py
+++ b/tests/engine/test_dense_train_engine.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import shutil
 import time
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 import torch.distributed as dist
 from xtuner._testing import DeterministicDDPTestCase
@@ -25,6 +25,7 @@ QWEN3_PATH = os.environ["QWEN3_PATH"]
 DEVICE = get_device()
 
 
+@instantiate_parametrized_tests
 class TestDenseEngine(DeterministicDDPTestCase):
     def _run_dense_engine_train_case(self, device, tp_size, sp_size, swap_optimizer: bool = False):
         pg = self.create_pg(device)
@@ -98,7 +99,7 @@ class TestDenseEngine(DeterministicDDPTestCase):
         except:
             pass
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size,sp_size",
         [
             ("cuda", 1, 1),
@@ -108,7 +109,7 @@ class TestDenseEngine(DeterministicDDPTestCase):
     def test_dense_engine_train(self, device, tp_size, sp_size):
         self._run_dense_engine_train_case(device, tp_size, sp_size, swap_optimizer=False)
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size,sp_size",
         [
             ("cuda", 1, 1),
@@ -118,7 +119,7 @@ class TestDenseEngine(DeterministicDDPTestCase):
     def test_dense_engine_train_swap_optimizer(self, device, tp_size, sp_size):
         self._run_dense_engine_train_case(device, tp_size, sp_size, swap_optimizer=True)
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size,hsdp_sharding_size",
         [
             ("cuda", 1, 8),  # todo: test ep8 and hsdp, OOM in 8 gpus

--- a/tests/engine/test_moe_train_engine.py
+++ b/tests/engine/test_moe_train_engine.py
@@ -4,7 +4,7 @@ import tempfile
 import shutil
 import time
 from torch.distributed.device_mesh import init_device_mesh
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 import torch.distributed as dist
 from torch.distributed.tensor import DTensor
@@ -33,8 +33,9 @@ QWEN3_MOE_FOPE_PATH = os.environ["QWEN3_MOE_FOPE_PATH"]
 DEVICE = get_device()
 
 
+@instantiate_parametrized_tests
 class TestMoEEngine(DeterministicDDPTestCase):
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size,sp_size",
         [
             ("cuda", 1, 1),
@@ -115,7 +116,7 @@ class TestMoEEngine(DeterministicDDPTestCase):
         except:
             pass
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size,sp_size",
         [
             ("cuda", 1, 1),
@@ -212,7 +213,7 @@ class TestMoEEngine(DeterministicDDPTestCase):
         except:
             pass
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size,hsdp_sharding_size",
         [
             ("cuda", 1, 8),  # todo: test ep8 and hsdp, OOM in 8 gpus
@@ -281,7 +282,7 @@ class TestMoEEngine(DeterministicDDPTestCase):
         except:
             pass
     
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size,load_from_type",
         [
             ("cuda", None, 1, "qwen3"),
@@ -363,10 +364,10 @@ class TestMoEEngine(DeterministicDDPTestCase):
         except:
             pass
     
-    @parametrize.parametrize(
+    @parametrize(
         "device",
         [
-            ("cuda",),
+            "cuda",
         ],
     )
     def test_load_optimizer_with_new_lr(self, device):

--- a/tests/engine/test_moe_train_engine_float8.py
+++ b/tests/engine/test_moe_train_engine_float8.py
@@ -4,7 +4,7 @@ import shutil
 import time
 from pathlib import Path
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 import torch.distributed as dist
 from xtuner._testing import DeterministicDDPTestCase
@@ -29,9 +29,10 @@ QWEN3_MOE_PATH = os.environ["QWEN3_MOE_PATH"]
 DEVICE = get_device()
 
 
+@instantiate_parametrized_tests
 class TestMoEEngineFloat8(DeterministicDDPTestCase):
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size,hsdp_sharding_size,sim_tol,rtol",
         [
             ("cuda", 1, int(os.getenv("XTUNER_TEST_WORLD_SIZE", "8")), 0.01, 0.01),
@@ -116,7 +117,7 @@ class TestMoEEngineFloat8(DeterministicDDPTestCase):
         except:
             pass
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size,hsdp_sharding_size",
         [
             ("cuda", 1, int(os.getenv("XTUNER_TEST_WORLD_SIZE", "8"))),  # todo: test ep8 and hsdp, OOM in 8 gpus
@@ -195,7 +196,7 @@ class TestMoEEngineFloat8(DeterministicDDPTestCase):
         except:
             pass
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size,hsdp_sharding_size",
         [
             ("cuda", 1, int(os.getenv("XTUNER_TEST_WORLD_SIZE", "8"))),  # todo: test ep8 and hsdp, OOM in 8 gpus
@@ -295,7 +296,7 @@ class TestMoEEngineFloat8(DeterministicDDPTestCase):
         except:
             pass
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size",
         [
             ("cuda", 1),
@@ -399,9 +400,10 @@ class TestMoEEngineFloat8(DeterministicDDPTestCase):
         return False
 
 
+@instantiate_parametrized_tests
 class TestMoEEngineFloat8Case2(DeterministicDDPTestCase):
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,ep_size,hsdp_sharding_size",
         [
             ("cuda", 1, int(os.getenv("XTUNER_TEST_WORLD_SIZE", "6"))),  # todo: test ep8 and hsdp, OOM in 8 gpus

--- a/tests/loss/test_ce_loss.py
+++ b/tests/loss/test_ce_loss.py
@@ -10,10 +10,11 @@ import os
 import torch.distributed as dist
 from xtuner.v1.data_proto.utils import pad_to_multiple_of, split_for_sequence_parallel
 from xtuner.v1.utils.test_utils import init_data_mesh
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from functools import wraps
 
 
+@instantiate_parametrized_tests
 class TestCELoss(TestCase):
     def setUp(self) -> None:
         self.device = 'cuda'  # liger loss must be tested on GPU
@@ -24,7 +25,7 @@ class TestCELoss(TestCase):
         self.lm_head2 = nn.Linear(self.input_dim, self.vocab_size, bias=False).to(device=self.device, dtype=self.dtype)
         self.lm_head2.weight.data = self.lm_head1.weight.data.clone()
 
-    @parametrize.parametrize(
+    @parametrize(
         "loss_mode, grad_accumulation_steps, chunk_size, atol, rtol",
         [
             ("eager", 1, -1, 1e-4, 5e-2),
@@ -111,7 +112,7 @@ class TestCELoss(TestCase):
         self.lm_head2.weight.grad.zero_()
         self.lm_head1.weight.grad.zero_()
 
-    @parametrize.parametrize(
+    @parametrize(
         "loss_reduction, loss_mode, grad_accumulation_steps, chunk_size, atol, rtol",
         [
             ('square', "eager", 1, -1, 1e-4, 5e-2),
@@ -245,6 +246,7 @@ def prepare(fn):
     return wrapper
 
 
+@instantiate_parametrized_tests
 class TestCELossWithSP(DistributedTestBase):
 
     def create_pg(self, device):
@@ -252,7 +254,7 @@ class TestCELossWithSP(DistributedTestBase):
         os.environ["LOCAL_RANK"] = str(dist.get_rank())
         return ret
 
-    @parametrize.parametrize(
+    @parametrize(
         "loss_mode, sp_size, grad_accumulation_steps, chunk_size, atol, rtol",
         [
             ("eager", 1, 1, -1, 1e-4, 5e-2),
@@ -325,7 +327,7 @@ class TestCELossWithSP(DistributedTestBase):
         loss2 = out[0]
         assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
 
-    @parametrize.parametrize(
+    @parametrize(
         "loss_reduction, loss_mode, sp_size, grad_accumulation_steps, chunk_size, atol, rtol",
         [
             ('square', "eager", 1, 1, -1, 1e-4, 5e-2),

--- a/tests/loss/test_grpo_loss.py
+++ b/tests/loss/test_grpo_loss.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import random
 import os
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 from torch.testing._internal.common_distributed import DistributedTestBase
 import torch
@@ -13,9 +13,10 @@ from xtuner.v1.rl.utils import gather_logprobs
 from xtuner.v1.utils.test_utils import init_data_mesh
 
 
+@instantiate_parametrized_tests
 class TestGRPOLoss(DistributedTestBase):
     
-    @parametrize.parametrize(
+    @parametrize(
         "grad_acc, sp_size, kl_loss_coef, loss_mode, chunk_size, atol, rtol",
         [
             (1, 1, 0, "eager", None, 1e-4, 1e-4),

--- a/tests/loss/test_oreal_loss.py
+++ b/tests/loss/test_oreal_loss.py
@@ -3,7 +3,7 @@ import random
 import os
 from pydantic import BaseModel, ConfigDict, model_validator
 from typing import TYPE_CHECKING, Literal, Union, Any
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 from torch.testing._internal.common_distributed import DistributedTestBase
 import torch
@@ -27,9 +27,10 @@ def policy_loss(logprobs, old_logprobs, advantages, loss_weights, cliprange_low,
     return loss
 
 
+@instantiate_parametrized_tests
 class TestOrealLoss(DistributedTestBase):
 
-    @parametrize.parametrize(
+    @parametrize(
         "grad_acc, sp_size, kl_loss_coef, loss_mode, chunk_size, atol, rtol",
         [
             (1, 1, 0, "eager", None, 1e-3, 1e-3),

--- a/tests/model/test_gpt_oss_moe.py
+++ b/tests/model/test_gpt_oss_moe.py
@@ -4,7 +4,7 @@ import torch.distributed as dist
 from safetensors import safe_open
 import json
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 from xtuner._testing import DeterministicDDPTestCase, patch_hf_rms_norm
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
@@ -29,8 +29,9 @@ def prepare(fn):
     return wrapper
 
 
+@instantiate_parametrized_tests
 class TestGptOss(DeterministicDDPTestCase):
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size,compile,tol,loss_class",
         [
             # TODO(chenchiyu): The tolerance is relatively high, need to investigate the reason.
@@ -93,7 +94,7 @@ class TestGptOss(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size",
         [
             ("cuda", "all2all", 4),
@@ -158,7 +159,7 @@ class TestGptOss(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=5e-2, rtol=5e-2))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size",
         [
             ("cuda", None, 1),

--- a/tests/model/test_intern_s1.py
+++ b/tests/model/test_intern_s1.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from packaging.version import Version
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 from xtuner._testing import patch_hf_rms_norm, DeterministicDDPTestCase
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig, __version__ as transformers_version
@@ -31,8 +31,9 @@ INTERNS1_DENSE_PATH = os.environ["INTERNS1_DENSE_PATH"]
     "intern-s1 model is break for transformers 5.x, "
     f"skip until model is updated. Current transformers version: {transformers_version}"
 )
+@instantiate_parametrized_tests
 class TestInternS1(DeterministicDDPTestCase):
-    @parametrize.parametrize(
+    @parametrize(
         "device,tol",
         [
             ("cuda", 1e-2),
@@ -99,7 +100,7 @@ class TestInternS1(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,sp_size,tol",
         [
             ("cuda", 1, 1e-2),
@@ -207,7 +208,7 @@ class TestInternS1(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tol",
         [
             ("cuda", 1e-2),
@@ -277,7 +278,7 @@ class TestInternS1(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,sp_size, compile, tol",
         [
             ("cuda", 1, False, 1e-2),
@@ -391,7 +392,7 @@ class TestInternS1(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size",
         [
             ("cuda", 1),

--- a/tests/model/test_moe.py
+++ b/tests/model/test_moe.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from xtuner.v1.model.moe.moe import MoEConfig, MoE, SequenceContext
 from xtuner.v1.module.router import NoAuxRouterConfig
@@ -12,9 +13,10 @@ from xtuner.v1.utils.compile import maybe_compile
 from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 
-@instantiate_parametrized_tests
 class TestMoE:
-    @parametrize("dtype,device", [(torch.bfloat16, "cuda")])
+    # PyTorch's parametrize utility is unittest-specific. This is intentionally a
+    # plain pytest class, so pytest must own parameter injection for this method.
+    @pytest.mark.parametrize("dtype,device", [(torch.bfloat16, "cuda")])
     def test_moe_config(self, dtype, device):
         router_config = NoAuxRouterConfig(
             scoring_func="sigmoid",

--- a/tests/model/test_moe.py
+++ b/tests/model/test_moe.py
@@ -9,11 +9,12 @@ from xtuner.v1.loss.ce_loss import CELossContext, CELossConfig
 
 from xtuner._testing import DeterministicDDPTestCase
 from xtuner.v1.utils.compile import maybe_compile
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 
+@instantiate_parametrized_tests
 class TestMoE:
-    @parametrize.parametrize("dtype,device", [(torch.bfloat16, "cuda")])
+    @parametrize("dtype,device", [(torch.bfloat16, "cuda")])
     def test_moe_config(self, dtype, device):
         router_config = NoAuxRouterConfig(
             scoring_func="sigmoid",
@@ -70,8 +71,9 @@ class TestMoE:
         model(seq_ctx=seq_ctx, loss_ctx={"lm": loss_ctx})
 
 
+@instantiate_parametrized_tests
 class TestDistributedMoE(DeterministicDDPTestCase):
-    @parametrize.parametrize(
+    @parametrize(
         "dtype,device,dispatcher,n_shared_experts,first_k_dense_replace",
         [
             # (torch.bfloat16, "cuda", "deepep", 1, 2),

--- a/tests/model/test_qwen3_5.py
+++ b/tests/model/test_qwen3_5.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 from packaging.version import Version
 from transformers import __version__ as transformers_version
@@ -30,11 +30,18 @@ VIDEO_ROOT = os.environ["VIDEO_ROOT"]
     Version(transformers_version) < Version("5.2.0"),
     f"transformers >= 5.2.0 is required, but got {transformers_version}"
 )
+@instantiate_parametrized_tests
 class TestQwen3_5_VL(DeterministicDDPTestCase):
     def _patch_xtuner_fast_pos_embed_interpolate(self) -> None:
         from xtuner.v1.model.compose.qwen3_vl.modeling_vision import Qwen3VLVisionModel
         from transformers.models.qwen3_5_moe import Qwen3_5MoeVisionModel
-        Qwen3VLVisionModel.fast_pos_embed_interpolate = Qwen3_5MoeVisionModel.fast_pos_embed_interpolate
+
+        # Transformers returns interpolation weights in fp32, while XTuner's vision forward expects
+        # positional embeddings to keep the model dtype before entering LayerNorm.
+        def _interp(self, grid_thw):
+            return Qwen3_5MoeVisionModel.fast_pos_embed_interpolate(self, grid_thw).to(self.pos_embed.weight.dtype)
+
+        Qwen3VLVisionModel.fast_pos_embed_interpolate = _interp
 
     def _forward(self, model, type, device, sp_size):
         QWEN3_VL_MOE_PATH = os.environ["QWEN3_5_MOE_PATH"]
@@ -168,7 +175,7 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
             loss = output["loss"]
             return loss
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,sp_size,tol",
         [
             ("cuda", 1, 2e-2),
@@ -244,7 +251,7 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
         self.assertTrue(torch.allclose(loss_xtuner_image_fsdp, loss_xtuner_image, atol=tol, rtol=tol))
         self.assertTrue(torch.allclose(loss_xtuner_video_fsdp, loss_xtuner_video, atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,sp_size,tol",
         [
             ("cuda", 1, 1e-2),
@@ -305,7 +312,7 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
             )
 
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,sp_size",
         [
             ("cuda", 1),

--- a/tests/model/test_qwen3_5.py
+++ b/tests/model/test_qwen3_5.py
@@ -27,19 +27,25 @@ from safetensors import safe_open
 VIDEO_ROOT = os.environ["VIDEO_ROOT"]
 
 @unittest.skipIf(
-    Version(transformers_version) < Version("5.2.0"),
-    f"transformers >= 5.2.0 is required, but got {transformers_version}"
+    Version(transformers_version) < Version("5.14.0"),
+    f"transformers >= 5.14.0 is required, but got {transformers_version}"
 )
 @instantiate_parametrized_tests
 class TestQwen3_5_VL(DeterministicDDPTestCase):
     def _patch_xtuner_fast_pos_embed_interpolate(self) -> None:
-        from xtuner.v1.model.compose.qwen3_vl.modeling_vision import Qwen3VLVisionModel
-        from transformers.models.qwen3_5_moe import Qwen3_5MoeVisionModel
+        from transformers.vision_utils import get_vision_bilinear_indices_and_weights
 
-        # Transformers returns interpolation weights in fp32, while XTuner's vision forward expects
-        # positional embeddings to keep the model dtype before entering LayerNorm.
+        from xtuner.v1.model.compose.qwen3_vl.modeling_vision import Qwen3VLVisionModel
+
+        # Follow the current Transformers vision path: accumulate interpolation in fp32,
+        # then return to the model dtype before XTuner's first LayerNorm.
         def _interp(self, grid_thw):
-            return Qwen3_5MoeVisionModel.fast_pos_embed_interpolate(self, grid_thw).to(self.pos_embed.weight.dtype)
+            indices, weights = get_vision_bilinear_indices_and_weights(
+                grid_thw,
+                num_grid_per_side=self.num_grid_per_side,
+                spatial_merge_size=self.config.spatial_merge_size,
+            )
+            return (self.pos_embed(indices) * weights[:, :, None]).sum(0).to(self.pos_embed.weight.dtype)
 
         Qwen3VLVisionModel.fast_pos_embed_interpolate = _interp
 
@@ -221,8 +227,23 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
         loss_xtuner_image = self._forward(qwen3vl_model, type='image',device=device, sp_size=sp_size)
         loss_xtuner_video = self._forward(qwen3vl_model, type='video',device=device, sp_size=sp_size)
         
-        self.assertTrue(torch.allclose(loss_xtuner_text, loss_hf_text.to(loss_xtuner_text.dtype), atol=tol, rtol=tol))
-        self.assertTrue(torch.allclose(loss_xtuner_image, loss_hf_image.to(loss_xtuner_image.dtype), atol=tol, rtol=tol))
+        self.assertTrue(
+            torch.allclose(loss_xtuner_text, loss_hf_text.to(loss_xtuner_text.dtype), atol=tol, rtol=tol),
+            f"Text loss mismatch: HF={loss_hf_text.item()}, XTuner={loss_xtuner_text.item()}, tol={tol}",
+        )
+        # Transformers 5.14 changed Qwen3.5's fused GatedDeltaNet/MoE path. The vision output and
+        # language-model input remain bitwise equal, but the fused language kernels accumulate a
+        # small numerical drift over 40 layers on the longer image sequence.
+        image_tol = 3e-2
+        self.assertTrue(
+            torch.allclose(
+                loss_xtuner_image,
+                loss_hf_image.to(loss_xtuner_image.dtype),
+                atol=image_tol,
+                rtol=image_tol,
+            ),
+            f"Image loss mismatch: HF={loss_hf_image.item()}, XTuner={loss_xtuner_image.item()}, tol={image_tol}",
+        )
         # self.assertTrue(torch.allclose(loss_xtuner_video, loss_hf_video.to(loss_xtuner_video.dtype), atol=tol, rtol=tol))
         
         del qwen3vl_model
@@ -262,12 +283,13 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
         self.create_pg(device)
         self._patch_xtuner_fast_pos_embed_interpolate()
 
-        # pt29 + transformers 5.2.0 with XTUNER_DETERMINISTIC=true, which pins Triton autotune.
-        # The 11.5k-token video has a stable SP-specific LM-loss baseline on this path.
+        # pt29 + transformers 5.14.1 with XTUNER_DETERMINISTIC=true, which pins Triton autotune.
+        # Transformers now preserves the outer vision boundary around each video, so the resulting
+        # 11.5k-token supervision sequence has a new stable, SP-specific LM-loss baseline.
         loss_reference = {
             "text": 1.4981,
-            "image": 3.6109,
-            "video": {1: 9.3212, 4: 8.6532}[sp_size],
+            "image": 3.6325,
+            "video": {1: 7.1987, 4: 6.8464}[sp_size],
         }
 
         QWEN3_VL_MOE_PATH = os.environ["QWEN3_5_MOE_PATH"]
@@ -296,6 +318,7 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
         losses["text"] = loss_xtuner_text
         losses["image"] = loss_xtuner_image
         losses["video"] = loss_xtuner_video
+        actual_losses = {key: loss.item() for key, loss in losses.items()}
 
         for key, loss in losses.items():
             self.assertTrue(
@@ -308,7 +331,8 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
                     atol=tol,
                     rtol=tol
                 ),
-                f"Expected text loss around {key}, but got {loss.item()}"
+                f"Expected {key} loss around {loss_reference[key]}, but got {actual_losses[key]}; "
+                f"all losses: {actual_losses}"
             )
 
 

--- a/tests/model/test_qwen3_5_dense.py
+++ b/tests/model/test_qwen3_5_dense.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 import torch.distributed as dist
 from packaging.version import Version
@@ -27,8 +27,9 @@ QWEN3_5_DENSE_4B_PATH = os.environ["QWEN3_5_DENSE_4B_PATH"]
     Version(transformers_version) < Version("5.9.0"),
     f"transformers >= 5.9.0 is required, but got {transformers_version}",
 )
+@instantiate_parametrized_tests
 class TestQwen3_5_VLDense(DeterministicDDPTestCase):
-    @parametrize.parametrize("device,layer_idx", [("cuda", 3), ("cuda", 0)])
+    @parametrize("device,layer_idx", [("cuda", 3), ("cuda", 0)])
     def test_decoder_layer_bitwise_parity(self, device, layer_idx):
         # One decoder layer (full=3 / linear=0) -> final norm -> lm_head -> CE loss -> backward.
         # Under XTUNER_HF_IMPL (eager) the layer output, the loss, and the input gradient dL/dx must all
@@ -112,7 +113,7 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
         self.assertEqual(grad_diff, 0.0, f"layer {layer_idx} [{layer_type}] dL/dx not bitwise: max diff {grad_diff}")
         dist.barrier()
 
-    @parametrize.parametrize("device", [("cuda",)])
+    @parametrize("device", ["cuda"])
     def test_vision_tower_bitwise_parity(self, device):
         # Vision tower (patch_embed + blocks + merger) bitwise vs HF, eager on both sides. Loads ONLY the
         # vision tower on each side (standalone; weights are the checkpoint's `model.visual.*`), not the
@@ -185,7 +186,7 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
         self.assertEqual(grad_diff, 0.0, f"vision tower dL/d(pixel_values) not bitwise: max diff {grad_diff}")
         dist.barrier()
 
-    @parametrize.parametrize("device", [("cuda",)])
+    @parametrize("device", ["cuda"])
     def test_vl_forward_parity(self, device):
         # Whole-model (compose VLM) forward + backward parity vs HF on an image prompt — the VLM is the
         # real model, so this is the end-to-end integration check across vision + projector + text.
@@ -269,7 +270,7 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
         self.assertEqual(grad_diff, 0.0, f"VL dL/d(pixel_values) not bitwise: max diff {grad_diff}")
         dist.barrier()
 
-    @parametrize.parametrize("device", [("cuda",)])
+    @parametrize("device", ["cuda"])
     def test_model_forward_bitwise_reduced_layers(self, device):
         # Whole-model bitwise parity that runs the real `compose.forward` / `Dense.forward` orchestration
         # — embed_tokens, rotary_emb call site, the layer loop, `_prepare_llm_inputs` image-embed
@@ -369,7 +370,7 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
         self.assertEqual(grad_diff, 0.0, f"reduced-layer VL dL/d(pixel_values) not bitwise: max diff {grad_diff}")
         dist.barrier()
 
-    @parametrize.parametrize("device", [("cuda",)])
+    @parametrize("device", ["cuda"])
     def test_save_hf_round_trip(self, device):
         # MTP is deferred for the dense port, so the 15 ``mtp.*`` checkpoint keys are
         # neither loaded nor re-saved. The round-trip is therefore asserted over the

--- a/tests/model/test_qwen3_5_dense.py
+++ b/tests/model/test_qwen3_5_dense.py
@@ -24,8 +24,8 @@ QWEN3_5_DENSE_4B_PATH = os.environ["QWEN3_5_DENSE_4B_PATH"]
 
 
 @unittest.skipIf(
-    Version(transformers_version) < Version("5.9.0"),
-    f"transformers >= 5.9.0 is required, but got {transformers_version}",
+    Version(transformers_version) < Version("5.14.0"),
+    f"transformers >= 5.14.0 is required, but got {transformers_version}",
 )
 @instantiate_parametrized_tests
 class TestQwen3_5_VLDense(DeterministicDDPTestCase):
@@ -100,7 +100,7 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
             loss_hf.backward()
 
             x_xt = base.clone().requires_grad_(True)
-            o_xt = xt_layer(x_xt, (cos, sin), seq_ctx)
+            o_xt = xt_layer(x_xt, position_embeddings=(cos, sin), seq_ctx=seq_ctx)
             loss_xt = F.cross_entropy(F.linear(model.norm(o_xt), model.lm_head.weight).reshape(-1, cfg.vocab_size), labels)
             loss_xt.backward()
 
@@ -442,15 +442,19 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
         dist.barrier()
 
     def _patch_fast_pos_embed_interpolate(self) -> None:
-        # HF's fast_pos_embed_interpolate returns fp32; the reused XTuner vision forward adds
-        # pos_embeds without a cast, so cast the result back to the pos_embed dtype here to
-        # avoid an fp32/bf16 LayerNorm mismatch.
-        from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5VisionModel
+        from transformers.vision_utils import get_vision_bilinear_indices_and_weights
 
         from xtuner.v1.model.compose.qwen3_vl.modeling_vision import Qwen3VLVisionModel
 
+        # Follow the current Transformers vision path: accumulate interpolation in fp32,
+        # then return to the model dtype before XTuner's first LayerNorm.
         def _interp(self, grid_thw):
-            return Qwen3_5VisionModel.fast_pos_embed_interpolate(self, grid_thw).to(self.pos_embed.weight.dtype)
+            indices, weights = get_vision_bilinear_indices_and_weights(
+                grid_thw,
+                num_grid_per_side=self.num_grid_per_side,
+                spatial_merge_size=self.config.spatial_merge_size,
+            )
+            return (self.pos_embed(indices) * weights[:, :, None]).sum(0).to(self.pos_embed.weight.dtype)
 
         Qwen3VLVisionModel.fast_pos_embed_interpolate = _interp
 

--- a/tests/model/test_qwen3_dense.py
+++ b/tests/model/test_qwen3_dense.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 from torch.testing._internal.common_distributed import DistributedTestBase
 import torch.distributed as dist
@@ -22,8 +22,9 @@ from xtuner._testing import patch_hf_rms_norm, DeterministicDDPTestCase
 QWEN3_PATH = os.environ["QWEN3_PATH"]
 
 
+@instantiate_parametrized_tests
 class TestQwen3Dense(DeterministicDDPTestCase):
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size,compile,tol,loss_class",
         [
             ("cuda", 1, False, 1e-2, "cross_entropy"),
@@ -80,7 +81,7 @@ class TestQwen3Dense(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size",
         [
             ("cuda", 1),
@@ -136,7 +137,7 @@ class TestQwen3Dense(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=1e-2, rtol=1e-2))
 
-    @parametrize.parametrize(
+    @parametrize(
         "use_sliding_window, max_window_layers, sliding_window",
         [
             (False, 6, 1024),
@@ -211,7 +212,7 @@ class TestQwen3Dense(DeterministicDDPTestCase):
                 )
             assert "loss" in output
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size",
         [
             ("cuda", 1),

--- a/tests/model/test_qwen3_moe.py
+++ b/tests/model/test_qwen3_moe.py
@@ -3,7 +3,7 @@ import json
 import unittest
 
 import inspect
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 import torch.distributed as dist
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -30,12 +30,13 @@ QWEN3_MOE_PATH = os.environ["QWEN3_MOE_PATH"]
 QWEN3_MOE_FOPE_PATH = os.environ["QWEN3_MOE_FOPE_PATH"]
 
 
+@instantiate_parametrized_tests
 class TestQwen3MoE(DeterministicDDPTestCase):
     def prepare(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_dir.cleanup()
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size,compile,tol,loss_mode, model_type",
         [
             # ("cuda", "deepep", 8, False, 1e-2, "eager", "qwen3_moe"),
@@ -116,7 +117,7 @@ class TestQwen3MoE(DeterministicDDPTestCase):
             losses.append(loss)
         self._check_loss_curve( losses=torch.tensor(losses), losses_ref=torch.tensor(expected_losses), sim_tol=tol, rtol=tol,)
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size,model_type",
         [
             ("cuda", "all2all", 4, "qwen3_moe"),
@@ -201,7 +202,7 @@ class TestQwen3MoE(DeterministicDDPTestCase):
 
         self._check_loss_curve(losses=torch.tensor(losses), losses_ref=torch.tensor(expected_losses), sim_tol=3e-2, rtol=3e-2)
 
-    @parametrize.parametrize(
+    @parametrize(
         "use_sliding_window, max_window_layers, sliding_window",
         [
             (False, 6, 1024),
@@ -276,7 +277,7 @@ class TestQwen3MoE(DeterministicDDPTestCase):
                 )
             assert "loss" in output
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size",
         [
             ("cuda", None, 1),
@@ -348,7 +349,7 @@ class TestQwen3MoE(DeterministicDDPTestCase):
                 self.assertListEqual(safetensor_keys, model_index_keys)
         dist.barrier()
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size",
         [
             ("cuda", None, 1),
@@ -504,7 +505,7 @@ class TestQwen3MoE(DeterministicDDPTestCase):
         dist.destroy_process_group()
 
     
-    @parametrize.parametrize(
+    @parametrize(
         "device,dispatcher,ep_size",
         [
             ("cuda", None, 1),

--- a/tests/model/test_qwen3_tile_embedding.py
+++ b/tests/model/test_qwen3_tile_embedding.py
@@ -1,7 +1,8 @@
 import os
 import json
 
-import parametrize
+# Unlike the third-party decorator, PyTorch parameterization does not inspect globals and trigger lazy imports.
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 from torch.testing._internal.common_distributed import DistributedTestBase
 import torch.distributed as dist
@@ -30,9 +31,10 @@ QWEN3_VL_DENSE_PATH = os.environ["QWEN3_VL_DENSE_PATH"]
 DEVICE = get_device()
 
 
+@instantiate_parametrized_tests
 class TestQwen3Dense4B(DistributedTestBase):
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size",
         [
             ("cuda", 1),
@@ -100,7 +102,7 @@ class TestQwen3Dense4B(DistributedTestBase):
             pass
 
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size",
         [
             ("cuda", 1),
@@ -174,7 +176,7 @@ class TestQwen3Dense4B(DistributedTestBase):
         except:
             pass
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size",
         [
             ("cuda", 1),

--- a/tests/model/test_qwen3_vl.py
+++ b/tests/model/test_qwen3_vl.py
@@ -1,6 +1,6 @@
 import os
 from packaging import version
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 from xtuner._testing import patch_hf_rms_norm, DeterministicDDPTestCase, patch_hf_rope
 from transformers import AutoTokenizer, AutoModelForImageTextToText
@@ -24,6 +24,7 @@ QWEN3_VL_DENSE_PATH = os.environ["QWEN3_VL_DENSE_PATH"]
 VIDEO_ROOT = os.environ["VIDEO_ROOT"]
 
 
+@instantiate_parametrized_tests
 class TestQwen3VL(DeterministicDDPTestCase):
 
     # 在没有 sp 情况下，可以实现和 hf loss 完全一致
@@ -155,7 +156,7 @@ class TestQwen3VL(DeterministicDDPTestCase):
         loss = output["loss"]
         self.assertTrue(torch.allclose(loss, expected_loss.to(loss.dtype), atol=tol, rtol=tol))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,sp_size,tol",
         [
             ("cuda", 1, 1e-2),
@@ -187,7 +188,7 @@ class TestQwen3VL(DeterministicDDPTestCase):
         self._test_all(hf_model, qwen3vl_model, 'video', device, sp_size, tol)
 
     # TODO: sp+ compile
-    @parametrize.parametrize(
+    @parametrize(
         "device,sp_size,compile,tol",
         [
             ("cuda", 1, False, 1e-2),
@@ -225,7 +226,7 @@ class TestQwen3VL(DeterministicDDPTestCase):
         self._test_all(hf_model, qwen3vl_model, 'image', device, sp_size, tol)
         self._test_all(hf_model, qwen3vl_model, 'video', device, sp_size, tol)
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,tp_size",
         [
             ("cuda", 1),

--- a/tests/module/dispatcher/test_agrs_all2all.py
+++ b/tests/module/dispatcher/test_agrs_all2all.py
@@ -3,7 +3,7 @@ import torch
 from torch.testing._internal.common_distributed import DistributedTestBase
 from xtuner.v1.module.dispatcher.base import NaiveDispatcher, DispacherInterface
 from xtuner.v1.module.dispatcher.torch_all2all import TorchAll2AllDispatcher
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from xtuner.v1.module.dispatcher.agrs import MoEAGRSDispatcher
 from xtuner.v1.module.router.greedy import GreedyGroupedRouter
 
@@ -18,8 +18,9 @@ def mock_experts(hidden_states: torch.Tensor, tokens_per_exprts: torch.Tensor):
     return hidden_states
 
 
+@instantiate_parametrized_tests
 class TestNoETorchAll2AllDispatcher(DistributedTestBase):
-    @parametrize.parametrize("dtype,device", [(torch.bfloat16, "cuda")])
+    @parametrize("dtype,device", [(torch.bfloat16, "cuda")])
     # @unittest.skipIf(True, "none")
     def test_dispatch_and_combine(self, dtype, device):
         self.create_pg(device)

--- a/tests/module/dispatcher/test_deepep.py
+++ b/tests/module/dispatcher/test_deepep.py
@@ -8,7 +8,7 @@ from torch.testing._internal.common_distributed import DistributedTestBase
 from xtuner.v1.module.dispatcher.deepep import DeepEPDispatcher
 from xtuner.v1.model.base import TransformerConfig
 from xtuner.v1.module.dispatcher.base import NaiveDispatcher, GenericDispatcher
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 
 import os
@@ -18,8 +18,9 @@ def mock_experts(hidden_states: torch.Tensor, tokens_per_exprts: torch.Tensor):
     return hidden_states
 
 
+@instantiate_parametrized_tests
 class TestMoETorchAll2AllDispatcher(DistributedTestBase):
-    @parametrize.parametrize(
+    @parametrize(
         "dtype,device,async_op",
         [
             (torch.bfloat16, "cuda", False),

--- a/tests/module/dispatcher/test_noep.py
+++ b/tests/module/dispatcher/test_noep.py
@@ -2,13 +2,14 @@ from unittest import TestCase
 
 import torch
 from xtuner.v1.module.dispatcher.base import NaiveDispatcher
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 
 def mock_experts(hidden_states: torch.Tensor, tokens_per_exprts: torch.Tensor):
     return hidden_states
 
 
+@instantiate_parametrized_tests
 class TestNoEPDispatcher(TestCase):
     def setUp(self):
         n_routed_experts = 4
@@ -16,7 +17,7 @@ class TestNoEPDispatcher(TestCase):
             n_routed_experts=n_routed_experts,
         )
 
-    @parametrize.parametrize("dtype,device", [(torch.bfloat16, "cuda")])
+    @parametrize("dtype,device", [(torch.bfloat16, "cuda")])
     def test_dispatch_and_combine(self, dtype, device):
         # seq len 16, hidden size 4
         # [0, 1, 2, 3]

--- a/tests/module/dispatcher/test_torch_all2all.py
+++ b/tests/module/dispatcher/test_torch_all2all.py
@@ -3,7 +3,7 @@ import torch
 from torch.testing._internal.common_distributed import DistributedTestBase
 from xtuner.v1.module.dispatcher.base import NaiveDispatcher, DispacherInterface
 from xtuner.v1.module.dispatcher.torch_all2all import TorchAll2AllDispatcher
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 
 import os
@@ -16,8 +16,9 @@ def mock_experts(hidden_states: torch.Tensor, tokens_per_exprts: torch.Tensor):
     return hidden_states
 
 
+@instantiate_parametrized_tests
 class TestNoETorchAll2AllDispatcher(DistributedTestBase):
-    @parametrize.parametrize("dtype,device", [(torch.bfloat16, "cuda")])
+    @parametrize("dtype,device", [(torch.bfloat16, "cuda")])
     @unittest.skipIf(True, "none")
     def test_dispatch_and_combine(self, dtype, device):
         self.create_pg(device)

--- a/tests/ops/test_foreach_allgather.py
+++ b/tests/ops/test_foreach_allgather.py
@@ -4,13 +4,14 @@ import torch
 import torch.distributed as dist
 import os
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from xtuner.v1.ops.comm.foreach_allgather import foreach_all_gather
 import time
 
 
+@instantiate_parametrized_tests
 class TestMoETorchAll2AllDispatcher(DistributedTestBase):
-    @parametrize.parametrize("device", [("cuda",)])
+    @parametrize("device", ["cuda"])
     def test_foreach_all_gather_acc(self, device):
         self.create_pg(device)
 
@@ -35,7 +36,7 @@ class TestMoETorchAll2AllDispatcher(DistributedTestBase):
             for x, y in zip(a, b):
                 self.assertTrue(torch.equal(x, y))
 
-    @parametrize.parametrize(
+    @parametrize(
         "device,shape",
         [
             ("cuda", (1,)),

--- a/tests/optim/test_muon.py
+++ b/tests/optim/test_muon.py
@@ -14,7 +14,7 @@ import copy
 import math
 from typing import Callable, overload
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -366,12 +366,13 @@ class TestMuonSingleGPU(DeterministicDDPTestCase):
 # ─── Test: end-to-end FSDP ───────────────────────────────────────────────────
 
 
+@instantiate_parametrized_tests
 class TestMuonFSDP(DeterministicDDPTestCase):
     @property
     def world_size(self) -> int:
         return 4
 
-    @parametrize.parametrize("enable_all2all", [True, False])
+    @parametrize("enable_all2all", [True, False])
     def test_muon_fsdp_matches_reference(self, enable_all2all: bool):
         """One Muon step on a fully-sharded model must match the single-process
         reference for every parameter, across all param categories.

--- a/tests/rl/test_utils.py
+++ b/tests/rl/test_utils.py
@@ -6,7 +6,7 @@ import ray
 
 
 from xtuner.v1.rl.utils.ray_utils import find_master_addr_and_port, get_accelerator_ids, get_ray_accelerator
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 
 class TestFindMasterAddrAndPort(unittest.TestCase):
@@ -64,6 +64,7 @@ class TestFindMasterAddrAndPort(unittest.TestCase):
             test_socket.close()
 
 
+@instantiate_parametrized_tests
 class TestGetAcceleratorIds(unittest.TestCase):
     """测试 get_accelerator_ids 函数"""
 
@@ -81,7 +82,7 @@ class TestGetAcceleratorIds(unittest.TestCase):
         if ray.is_initialized():
             ray.shutdown()
 
-    @parametrize.parametrize("num_accelerators", [1, 2, 4])
+    @parametrize("num_accelerators", [1, 2, 4])
     def test_get_accelerator_ids(self, num_accelerators: int):
         """测试获取 GPU ID 列表"""
 

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -7,7 +7,7 @@ from concurrent.futures import Future
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -466,6 +466,7 @@ class TestTrainerSaveHF(DistributedTestBase):
         return int(os.getenv("XTUNER_TEST_WORLD_SIZE", "2"))
 
 
+@instantiate_parametrized_tests
 class TestTrainerConfig(DeterministicDDPTestCase):
     def prepare(self):
         self.create_pg(DEVICE)
@@ -533,7 +534,7 @@ class TestTrainerConfig(DeterministicDDPTestCase):
         trainer_cfg.model_dump()
         pickle.dumps(trainer_cfg)
 
-    @parametrize.parametrize(
+    @parametrize(
         "pack_to_max_length,compile_cfg,torch_compile,success",
         [
             # compile_cfg could be Any if pack_to_max_length is True
@@ -566,7 +567,7 @@ class TestTrainerConfig(DeterministicDDPTestCase):
             trainer = Trainer.from_config(trainer_cfg)
             self.cleanup_trainer(trainer)
 
-    @parametrize.parametrize(
+    @parametrize(
         "model_ep_size,fsdp_ep_size,target_ep_size",
         [
             (1, 8, 8),

--- a/xtuner/v1/data_proto/messages/qwen35_chat.py
+++ b/xtuner/v1/data_proto/messages/qwen35_chat.py
@@ -65,6 +65,9 @@ def render_content(content, do_vision_count, image_count, video_count, add_visio
             video_content = item.get("video", item.get("video_url", {}))
             assert isinstance(video_content, dict), f"video_content must be a dict, but got {type(video_content)}"
             timestamps = video_content.get("timestamps", [])
+            # Match Transformers' processor replacement: per-frame placeholders stay
+            # nested inside the video boundary emitted by the chat template.
+            result += "<|vision_start|>"
             if len(timestamps) > 0:
                 video_placeholder = ""
                 for timestamp in timestamps:
@@ -76,6 +79,7 @@ def render_content(content, do_vision_count, image_count, video_count, add_visio
                 num_frames = video_content["num_frames"]
                 for _ in range(len(num_frames)):
                     result += "<|vision_start|><|video_pad|><|vision_end|>"
+            result += "<|vision_end|>"
             conversation_timestamp = video_content.get("conversation_timestamps", [])
             if len(conversation_timestamp) > 0:
                 start_time = conversation_timestamp[0]

--- a/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_tokenize_fn.py
+++ b/xtuner/v1/datasets/mllm_tokenize_fn/qwen3_vl_tokenize_fn.py
@@ -198,6 +198,11 @@ def replace_video_token(
                                         video_placeholder += f"<{curr_time:.1f} seconds>{image_tokens}"
                                 else:
                                     video_placeholder += f"{image_tokens}"
+                            # Current Transformers processors replace only the inner video token and
+                            # preserve the chat template's outer vision boundaries around the video.
+                            video_placeholder = (
+                                f"{chat_template.image_start_token}{video_placeholder}{chat_template.image_end_token}"
+                            )
                             text = text.replace(IMAGE_TOKEN_ALIAS, video_placeholder, 1)
                             current_image_idx += len(num_image_token_list[i])
                         c.text = text


### PR DESCRIPTION
## Summary

- replace the third-party `parametrize` decorator in 28 test files
- use PyTorch `parametrize` plus `instantiate_parametrized_tests` for unittest-based classes
- use native `pytest.mark.parametrize` for the one plain pytest class
- remove the third-party dependency and document why scanning module globals is unsafe with Transformers lazy modules
- align Qwen3/Qwen3.5 behavior and regression expectations with Transformers 5.14.1

## Root cause

The third-party decorator recursively scans decoration-frame globals to count stacked decorators. Transformers lazy modules can materialize attributes while that dictionary is being iterated, which raises `RuntimeError: dictionary changed size during iteration`. The upgrade exposed the latent incompatibility by changing the lazy-module surface imported during test collection.

PyTorch unittest parameterization records metadata on the test method and materializes cases from the decorated class. It does not recursively inspect imported module dictionaries.

## Why parameterization is split

`pytest.mark.parametrize` cannot be used directly on `unittest.TestCase` subclasses. Pytest delegates those methods to the unittest runner, which invokes them without injected arguments. A minimal reproduction under `pt29_glm2` fails with `TypeError: test_value() missing 1 required positional argument`.

Therefore:

- unittest-based classes use PyTorch `parametrize` plus `instantiate_parametrized_tests`
- plain pytest classes use `pytest.mark.parametrize`

This keeps each test on the parameterization mechanism supported by its runner without changing existing test base classes.

## Transformers 5.14.1 compatibility

The first Action run proved that 547 tests still passed and isolated 12 remaining regressions. This PR also addresses them:

- call the current Qwen3.5 dense decoder with keyword-only `position_embeddings` and `seq_ctx`
- preserve the outer vision boundary required by current processors when a video token expands into per-frame placeholders, for both Qwen3-VL and Qwen3.5-VL
- use `get_vision_bilinear_indices_and_weights`, the shared Transformers 5.14 vision interpolation API, while retaining FP32 accumulation and returning the model dtype before LayerNorm
- update Qwen3.5 MTP loss references for the 5.14.1 token sequence and fused kernels
- use an image-only tolerance for the bounded numerical drift introduced by the current fused GatedDeltaNet/MoE language path; instrumentation verified that the vision output and language-model input remain bitwise equal before the drift accumulates across 40 language layers
- raise the affected Qwen3.5 test version guards to Transformers 5.14

## Validation

Using `pt29_glm2`, variables from `zdev/env.sh`, and `gpu_lock.sh` for GPU runs:

- minimal reproduction: third-party decorator fails during collection; PyTorch replacement collects successfully
- minimal reproduction: `pytest.mark.parametrize` on `unittest.TestCase` fails because unittest does not inject parameters
- all 28 changed test files: `212 tests collected`
- static audit: every PyTorch-parameterized method has `instantiate_parametrized_tests`
- MoE fixture regression plus both dense decoder cases: `3 passed`
- Qwen3.5 standard VL, SP=1/4: `2 passed`
- Qwen3.5 MTP, SP=1/4: `2 passed`
- Qwen3.5 dense vision tower bitwise parity: `1 passed`
- production-file Ruff checks and `git diff --check`: passed
- PR lint Action: passed

The follow-up Action completed with 558 passed, 18 skipped, and one stale Qwen3.5 chat-template expectation. The four original HF video-reference failures passed. Commit `cde72f58` updates both remaining video-template expectations for the Transformers 5.14 outer boundary; the exact failed node now passes locally.