### PR TITLE
[Fix] Fix Ray generate concurrency group metadata

### DIFF
--- a/.claude/rules/rl_review.md
+++ b/.claude/rules/rl_review.md
@@ -18,10 +18,17 @@ handling, `RolloutState.extra_fields`, object references, or memory ownership ar
 RoutedExperts impact: <specific impact or "not affected">
 ```
 
+Also include Ray concurrency impact when the PR touches Ray actor methods, actor construction,
+method decorators or wrappers, concurrency-group definitions, or rollout control paths:
+
+```text
+Ray concurrency impact: <effective groups and possible starvation impact, or "not affected">
+```
+
 Do not leave these impacts implicit in the finding text. If a finding is about rollout status,
-pause/abort/timeout behavior, response handling, producer aggregation, or routed-experts ownership,
-repeat the relevant impact line inside that finding so the downstream effect is visible at the point
-of review.
+pause/abort/timeout behavior, response handling, producer aggregation, routed-experts ownership, or
+Ray actor concurrency, repeat the relevant impact line inside that finding so the downstream effect
+is visible at the point of review.
 
 ## ProduceBatchResult Checklist
 
@@ -57,6 +64,54 @@ Common impacts to call out explicitly:
   especially `group_gen_pause_time_s`.
 - Reward or filter-path changes can change `raw_rewards_sum`, `raw_rewards_count`,
   `produced_samples`, and `produced_tokens`.
+
+## Ray Actor Concurrency Checklist
+
+Review whether high-volume rollout calls can starve pause, abort, health-check, restart, or shutdown
+RPCs.
+
+Check this area when the PR changes any of these paths:
+
+- Ray actor methods decorated with `@ray.method(...)` or `@ray_method(...)`.
+- Decorators or wrappers stacked on Ray actor methods, especially wrappers using `functools.wraps`
+  or exposing `__wrapped__`.
+- Actor construction through `ray.remote(...)`, including `concurrency_groups` and
+  `max_concurrency`.
+- Generate, pause, continue, abort, health-check, restart, or shutdown methods.
+
+When a Ray method is combined with another decorator, keep the Ray method decorator closest to the
+function definition:
+
+```python
+@trace_rollout_endpoint("rollout.worker.generate")
+@ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
+async def generate(...):
+    ...
+```
+
+Do not use the reverse order:
+
+```python
+@ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
+@trace_rollout_endpoint("rollout.worker.generate")
+async def generate(...):
+    ...
+```
+
+The current Ray actor-class processing unwraps decorated methods before reading Ray method metadata.
+If `@ray.method(...)` is outside a wrapper, metadata such as `__ray_concurrency_group__` can remain
+on the discarded wrapper, causing the method to fall back to the default concurrency group.
+
+Review the effective dispatch behavior, not only the visible decorator order:
+
+- After following `__wrapped__`, the callable inspected by Ray must retain the expected Ray method
+  metadata.
+- Every named method concurrency group must be declared by the corresponding `ray.remote(...)`
+  actor construction.
+- High-volume `generate` methods must not accidentally fall back to the default group.
+- Pause, abort, and other control RPCs must remain schedulable while generation is saturated.
+- Slow health or lifecycle methods must not occupy every slot needed by critical control RPCs.
+- Blocking work inside async actor methods must not block the actor event loop or concurrency lane.
 
 ## RoutedExperts Checklist
 

--- a/docs/sphinx_patch/mock_obj.py
+++ b/docs/sphinx_patch/mock_obj.py
@@ -106,9 +106,18 @@ _orig_mockmod_getattr = mock._MockModule.__getattr__
 _orig_mockobj_getattr = mock._MockObject.__getattr__
 
 
+def _mock_ray_method(*args: Any, **kwargs: Any) -> Any:
+    """Keep ``ray.method`` as a pass-through decorator during autodoc imports."""
+    if len(args) == 1 and callable(args[0]) and not kwargs:
+        return args[0]
+    return lambda func: func
+
+
 def _patched_mockmod_getattr(self, name: str) -> Any:
     if name == "__version__":
         return _MOCK_VERSION
+    if self.__name__ == "ray" and name == "method":
+        return _mock_ray_method
     return _orig_mockmod_getattr(self, name)
 
 

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -83,8 +83,8 @@ class RolloutController:
             return
         self.proxy_manager.validate_registered_session_urls()
 
-    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     @trace_rollout_endpoint("rollout.controller.generate")
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     async def generate(self, rollout_state: RolloutState) -> RolloutState:
         if XTUNER_DETERMINISTIC:
             sample_params = rollout_state.sample_params.model_copy(deep=True)

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -784,8 +784,8 @@ class RolloutWorker(SingleAcceleratorWorker):
     async def _decode_routed_experts(self, routed_experts: Any) -> Any:
         return routed_experts
 
-    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     @trace_rollout_endpoint("rollout.worker.generate")
+    @ray.method(concurrency_group=ROLLOUT_CONCURRENCY_GROUP_GENERATE)
     async def generate(self, rollout_state: RolloutState) -> RolloutState:
         request_max_tokens = rollout_state.sample_params.max_tokens
         try:


### PR DESCRIPTION
## Summary
- Place `@ray.method` **closest to** the original `generate` method in both `RolloutController` and `RolloutWorker`.
- Keep `@trace_rollout_endpoint` as the outer wrapper.

## Problem
`trace_rollout_endpoint` wraps the decorated method with `functools.wraps`, which sets `wrapper.__wrapped__` to the original function.

With the previous decorator order:

```python
@ray.method(concurrency_group="generate")
@trace_rollout_endpoint(...)
async def generate(...):
    ...
```

@ray.method attached __ray_concurrency_group__ to the outer trace wrapper.When Ray builds actor method metadata, it calls inspect.unwrap(method) before reading __ray_concurrency_group__. Ray therefore inspected the original function, where the concurrency group attribute was absent.

As a result, both RolloutController.generate and RolloutWorker.generate were missing from Ray's concurrency group method mapping and executed in the default concurrency group.