### PR TITLE
[Fix] Avoid scanning Transformers lazy module during test collection

### DIFF
--- a/tests/model/test_qwen3_5.py
+++ b/tests/model/test_qwen3_5.py
@@ -34,7 +34,15 @@ class TestQwen3_5_VL(DeterministicDDPTestCase):
     def _patch_xtuner_fast_pos_embed_interpolate(self) -> None:
         from xtuner.v1.model.compose.qwen3_vl.modeling_vision import Qwen3VLVisionModel
         from transformers.models.qwen3_5_moe import Qwen3_5MoeVisionModel
-        Qwen3VLVisionModel.fast_pos_embed_interpolate = Qwen3_5MoeVisionModel.fast_pos_embed_interpolate
+
+        hf_fast_pos_embed_interpolate = Qwen3_5MoeVisionModel.fast_pos_embed_interpolate
+
+        def _fast_pos_embed_interpolate(self, grid_thw):
+            # Transformers 5.14 accumulates interpolation in fp32 and casts in its
+            # forward; XTuner's older forward expects this helper to keep the model dtype.
+            return hf_fast_pos_embed_interpolate(self, grid_thw).to(self.pos_embed.weight.dtype)
+
+        Qwen3VLVisionModel.fast_pos_embed_interpolate = _fast_pos_embed_interpolate
 
     def _forward(self, model, type, device, sp_size):
         QWEN3_VL_MOE_PATH = os.environ["QWEN3_5_MOE_PATH"]

--- a/tests/model/test_qwen3_5_dense.py
+++ b/tests/model/test_qwen3_5_dense.py
@@ -99,7 +99,7 @@ class TestQwen3_5_VLDense(DeterministicDDPTestCase):
             loss_hf.backward()
 
             x_xt = base.clone().requires_grad_(True)
-            o_xt = xt_layer(x_xt, (cos, sin), seq_ctx)
+            o_xt = xt_layer(x_xt, position_embeddings=(cos, sin), seq_ctx=seq_ctx)
             loss_xt = F.cross_entropy(F.linear(model.norm(o_xt), model.lm_head.weight).reshape(-1, cfg.vocab_size), labels)
             loss_xt.backward()
 

--- a/tests/model/test_qwen3_tile_embedding.py
+++ b/tests/model/test_qwen3_tile_embedding.py
@@ -5,12 +5,13 @@ import parametrize
 import torch
 from torch.testing._internal.common_distributed import DistributedTestBase
 import torch.distributed as dist
-from transformers import  AutoTokenizer
+# Import concrete symbols only. Third-party parametrize scans global module
+# dictionaries, which can mutate while Transformers resolves lazy imports.
+from transformers import AutoTokenizer
 import tempfile
 from pathlib import Path
 from safetensors import safe_open
 from unittest import skipIf
-import transformers
 from packaging import version
 
 from xtuner.v1.data_proto import SequenceContext


### PR DESCRIPTION
## Summary

- remove the unused module-level `import transformers` from `test_qwen3_tile_embedding.py`
- keep importing the concrete `AutoTokenizer` symbol needed by the tests
- document why the lazy module must not be bound in this decorator frame
- call the Qwen3.5 dense decoder keyword-only `position_embeddings` and `seq_ctx` parameters explicitly
- preserve the Qwen3.5 vision interpolation output dtype across Transformers versions
- retain the existing third-party `parametrize` dependency and all existing parameterized tests

## Root causes

### Test collection

Third-party `parametrize==0.1.1` recursively scans module objects in the decoration-frame globals to find stacked decorators. The top-level `transformers` object is a lazy module; attribute resolution can populate its dictionary while `parametrize` is iterating that dictionary, causing:

```text
RuntimeError: dictionary changed size during iteration
```

The direct module import was unused. Importing the concrete `AutoTokenizer` symbol does not expose the lazy module object to the global-module scan.

### Qwen3.5 dense decoder parity

`DenseDecoderLayer.forward` accepts hidden states positionally but declares `position_embeddings` and `seq_ctx` as keyword-only. The parity test still passed all three arguments positionally, so layer 0 and layer 3 failed before entering the decoder:

```text
TypeError: DenseDecoderLayer.forward() missing 2 required keyword-only arguments
```

The test now follows the public signature explicitly.

### Qwen3.5 vision interpolation dtype

Transformers 5.14 accumulates the deprecated interpolation helper in FP32 and casts inside its own forward. XTuner's older forward lacks that cast, so the test wrapper now returns the interpolation result in `pos_embed.weight.dtype`, avoiding an FP32 input against BF16 LayerNorm parameters. No tolerance or numerical baseline is changed.

## Validation

Using `pt29_glm2` with variables from `zdev/env.sh` and `gpu_lock.sh` for GPU tests:

- `pytest --collect-only -q tests/model/test_qwen3_tile_embedding.py`: `3 tests collected`
- Qwen3.5 dense decoder parity for layer 0 and layer 3: `2 passed`
- Qwen3.5 VL cases no longer raise the Float/BFloat16 dtype mismatch
- static audit: no test file now combines third-party `parametrize` with a module-level `import transformers`
- `git diff --check`: passed

This remains a narrowly scoped workaround and does not migrate the wider test suite to another parameterization framework.
