### PR TITLE
[CI] Use latest Claude Opus model

### DIFF
--- a/.github/workflows/claude-general.yml
+++ b/.github/workflows/claude-general.yml
@@ -192,7 +192,7 @@ jobs:
             ```
           claude_args: |
               --max-turns 30
-              --model claude-opus-4-6
+              --model opus
               --allowedTools "
                 Read,Write,Edit,MultiEdit,LS,Grep,Glob,
                 Bash(cat:*),Bash(test:*),Bash(printf:*),Bash(jq:*),Bash(head:*),Bash(git:*),Bash(gh:*),
@@ -315,7 +315,7 @@ jobs:
 
           claude_args: |
               --max-turns 30
-              --model claude-opus-4-6
+              --model opus
               --allowedTools "
                 Read,Write,Edit,MultiEdit,LS,Grep,Glob,
                 Bash(cat:*),Bash(test:*),Bash(printf:*),Bash(jq:*),Bash(head:*),Bash(git:*),Bash(gh:*),


### PR DESCRIPTION
## Summary

- Use the Claude Code opus alias in both general review jobs.
- Automatically follow the latest Opus model supported by Claude Code and the configured provider.

## Validation

- Parsed .github/workflows/claude-general.yml with PyYAML.
- Ran git diff --check.