### PR TITLE
[Fix] Support sparse optimizer DCP resume

### DIFF
--- a/tests/engine/test_train_engine_checkpoint.py
+++ b/tests/engine/test_train_engine_checkpoint.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+import torch
+import torch.distributed.checkpoint as dcp
+from packaging.version import Version
+from torch.distributed.checkpoint.state_dict import (
+    StateDictOptions,
+    get_model_state_dict,
+    get_optimizer_state_dict,
+    set_model_state_dict,
+    set_optimizer_state_dict,
+)
+
+from xtuner.v1.engine.train_engine import _prune_uncheckpointed_optimizer_state
+
+
+@pytest.mark.skipif(
+    Version(torch.__version__) < Version("2.10"), reason="requires sparse optimizer loading in PyTorch 2.10+"
+)
+def test_sparse_adamw_dcp_state_can_resume_and_materialize_later() -> None:
+    model = torch.nn.Linear(4, 2)
+    optimizer = torch.optim.AdamW(model.parameters())
+    model.weight.mean().backward()
+    optimizer.step()
+
+    saved_state = {
+        "model": get_model_state_dict(model),
+        "optimizer": get_optimizer_state_dict(model, optimizer),
+    }
+
+    with tempfile.TemporaryDirectory() as checkpoint_dir:
+        dcp.save(saved_state, checkpoint_id=checkpoint_dir)
+
+        restored_model = torch.nn.Linear(4, 2)
+        restored_optimizer = torch.optim.AdamW(restored_model.parameters())
+        load_target = {
+            "model": get_model_state_dict(restored_model),
+            "optimizer": get_optimizer_state_dict(restored_model, restored_optimizer),
+        }
+        metadata = dcp.FileSystemReader(checkpoint_dir).read_metadata()
+        saved_keys = {str(key) for key in metadata.state_dict_metadata}
+
+        removed = _prune_uncheckpointed_optimizer_state(load_target["optimizer"], saved_keys)
+        assert set(removed) == {
+            "optimizer.state.bias.step",
+            "optimizer.state.bias.exp_avg",
+            "optimizer.state.bias.exp_avg_sq",
+        }
+
+        dcp.load(load_target, checkpoint_id=checkpoint_dir)
+        set_model_state_dict(restored_model, load_target["model"])
+        set_optimizer_state_dict(
+            restored_model,
+            restored_optimizer,
+            optim_state_dict=load_target["optimizer"],
+            options=StateDictOptions(strict=False),
+        )
+
+    assert restored_model.weight in restored_optimizer.state
+    assert restored_model.bias not in restored_optimizer.state
+    torch.testing.assert_close(
+        restored_optimizer.state[restored_model.weight]["exp_avg"],
+        optimizer.state[model.weight]["exp_avg"],
+    )
+
+    restored_optimizer.zero_grad(set_to_none=True)
+    restored_model.bias.mean().backward()
+    restored_optimizer.step()
+    assert restored_model.bias in restored_optimizer.state
+
+
+def test_partially_saved_optimizer_state_is_rejected() -> None:
+    optimizer_state = {
+        "state": {
+            "weight": {
+                "step": torch.tensor(1.0),
+                "exp_avg": torch.zeros(1),
+                "exp_avg_sq": torch.zeros(1),
+            }
+        }
+    }
+    saved_keys = {
+        "optimizer.state.weight.step",
+        "optimizer.state.weight.exp_avg",
+    }
+
+    with pytest.raises(RuntimeError, match="Incomplete optimizer state"):
+        _prune_uncheckpointed_optimizer_state(optimizer_state, saved_keys)

--- a/xtuner/v1/engine/train_engine.py
+++ b/xtuner/v1/engine/train_engine.py
@@ -58,6 +58,47 @@ logger = get_logger()
 DEVICE = get_device()
 DEVICE_MODULE = get_torch_device_module()
 
+
+def _prune_uncheckpointed_optimizer_state(optimizer_state_dict: dict[str, Any], saved_keys: set[str]) -> list[str]:
+    """Remove wholly absent lazy optimizer states from a DCP load target.
+
+    ``get_optimizer_state_dict`` materializes optimizer states for every
+    trainable parameter. A checkpoint may legitimately omit all state slots
+    for a parameter that had not received a gradient when it was saved. DCP
+    treats the materialized load target as authoritative and otherwise reports
+    those absent slots as missing checkpoint keys.
+
+    A partially saved parameter state is not lazy initialization and is kept as
+    an error: optimizers such as AdamW cannot step with only a subset of
+    ``step``, ``exp_avg``, and ``exp_avg_sq`` restored.
+    """
+
+    state = optimizer_state_dict.get("state")
+    if not isinstance(state, dict):
+        return []
+
+    removed: list[str] = []
+    for parameter_name, parameter_state in list(state.items()):
+        if not isinstance(parameter_state, dict) or not parameter_state:
+            continue
+
+        checkpoint_keys = {
+            state_name: f"optimizer.state.{parameter_name}.{state_name}" for state_name in parameter_state
+        }
+        present_state_names = {name for name, key in checkpoint_keys.items() if key in saved_keys}
+
+        if not present_state_names:
+            state.pop(parameter_name)
+            removed.extend(checkpoint_keys.values())
+            continue
+
+        if len(present_state_names) != len(checkpoint_keys):
+            missing = [key for name, key in checkpoint_keys.items() if name not in present_state_names]
+            raise RuntimeError(f"Incomplete optimizer state for parameter '{parameter_name}': missing {missing}")
+
+    return removed
+
+
 threading_lock = threading.Lock()
 
 
@@ -497,15 +538,22 @@ class TrainEngine:
         load_optimizer = load_states or load_args
         state_dict = self._get_dcp_state_dict(cpu_offload=True, save_optimizer=load_optimizer)
 
-        if self.has_freeze_params:
-            set_options = StateDictOptions(cpu_offload=True, strict=False)
-        else:
-            set_options = StateDictOptions(cpu_offload=True, strict=True)
+        model_options = StateDictOptions(cpu_offload=True, strict=not self.has_freeze_params)
 
         with profile_time_and_memory(f"[Load DCP from {weights_dir}]"):
+            if load_optimizer:
+                metadata = dcp.FileSystemReader(weights_dir).read_metadata()
+                saved_keys = {str(key) for key in metadata.state_dict_metadata}
+                removed = _prune_uncheckpointed_optimizer_state(state_dict["optimizer"], saved_keys)
+                if removed:
+                    logger.warning(
+                        f"Ignoring {len(removed)} lazy optimizer-state leaves absent from the checkpoint; "
+                        f"examples={removed[:5]}"
+                    )
+
             dcp.load(state_dict=state_dict, checkpoint_id=weights_dir)
 
-            set_model_state_dict(self.model, state_dict["model"], options=set_options)
+            set_model_state_dict(self.model, state_dict["model"], options=model_options)
 
             if not load_optimizer:
                 return
@@ -532,7 +580,9 @@ class TrainEngine:
                 self.model,
                 self.optimizer,
                 optim_state_dict=optimizer_state_dict,
-                options=set_options,
+                # PyTorch 2.10+ treats wholly absent per-parameter optimizer
+                # states as valid lazy state when strict loading is disabled.
+                options=StateDictOptions(cpu_offload=True, strict=False),
             )
 
     def put_model_to_device(self, device: torch.device | str) -> bool:


### PR DESCRIPTION
## Motivation

PyTorch optimizers initialize per-parameter state lazily. A valid DCP checkpoint can therefore omit all optimizer-state leaves for a trainable parameter that did not receive a gradient before save. During resume, XTuner materializes a full optimizer load target, and DCP reports those absent lazy leaves as missing checkpoint keys.

## Changes

- Inspect DCP metadata before loading optimizer state and remove only parameter states whose leaves are wholly absent from the checkpoint.
- Keep partially missing optimizer states fatal so corrupted AdamW state is not silently accepted.
- Preserve model strictness while loading sparse optimizer state with the PyTorch 2.10+ `strict=False` behavior.
- Add a regression test covering AdamW DCP resume, later lazy-state materialization, and rejection of partially saved state.

## Impact

Model checkpoint validation remains unchanged. Existing optimizer states are restored normally; only wholly absent lazy per-parameter state is deferred until that parameter next receives a gradient.

## Tests

- XTuner pre-commit hooks passed for the changed files, except mypy (the hook environment exhausted local temporary storage while installing its pinned PyTorch 2.6 CUDA dependencies).
- `ruff check xtuner/v1/engine/train_engine.py tests/engine/test_train_engine_checkpoint.py`
- `python3.12 -m py_compile xtuner/v1/engine/train_engine.py tests/engine/test_train_engine_checkpoint.py`
- PyTorch 2.10 DCP save/load/optimizer-step reproduction passed.
