### PR TITLE
[Fix] Preserve concurrent trace sessions in disaggregated RL

### DIFF
--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -404,7 +404,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                 item.routed_experts = MagicMock()
 
                 with patch(
-                    "xtuner.v1.rl.agent_loop_manager.produce_utils.release_existing_sessions",
+                    "xtuner.v1.rl.rollout.trace_store.release_existing_sessions",
                     new=AsyncMock(return_value={str(session_id)}),
                 ) as release_sessions:
                     self.assertFalse(await ctx.put_generated_group([item]))

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -383,7 +383,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.failed_samples, 1)
         self.assertEqual(result.filtered_samples, 1)
 
-    async def test_put_generated_group_releases_terminal_trace_sessions(self):
+    async def test_put_generated_group_releases_non_retryable_trace_sessions(self):
         # FAILED / FILTERED 不进入 replay buffer，必须在丢弃 RolloutState 前释放对应 trace session。
         cases = (
             (Status.FAILED, True, 101),
@@ -394,7 +394,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                 strategy = SyncProduceStrategyConfig(is_valid_sample_fn=lambda _samples: is_valid).build()
                 ctx = self._build_context(
                     strategy,
-                    f"terminal_{status.name.lower()}",
+                    f"non_retryable_{status.name.lower()}",
                     self._build_agent_loop(),
                     self._build_sampler(),
                     batch_size=1,

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -20,7 +20,7 @@ Bad Tests:
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status, discard_rollout_state
 from xtuner.v1.rl.agent_loop_manager import (
@@ -382,6 +382,36 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result.failed_samples, 1)
         self.assertEqual(result.filtered_samples, 1)
+
+    async def test_put_generated_group_releases_terminal_trace_sessions(self):
+        # FAILED / FILTERED 不进入 replay buffer，必须在丢弃 RolloutState 前释放对应 trace session。
+        cases = (
+            (Status.FAILED, True, 101),
+            (Status.COMPLETED, False, 102),
+        )
+        for status, is_valid, session_id in cases:
+            with self.subTest(status=status):
+                strategy = SyncProduceStrategyConfig(is_valid_sample_fn=lambda _samples: is_valid).build()
+                ctx = self._build_context(
+                    strategy,
+                    f"terminal_{status.name.lower()}",
+                    self._build_agent_loop(),
+                    self._build_sampler(),
+                    batch_size=1,
+                )
+                item = make_rollout_state(session_id, status=status, reward_score=1.0)
+                item.session_id = session_id
+                item.routed_experts = MagicMock()
+
+                with patch(
+                    "xtuner.v1.rl.agent_loop_manager.produce_utils.release_existing_sessions",
+                    new=AsyncMock(return_value={str(session_id)}),
+                ) as release_sessions:
+                    self.assertFalse(await ctx.put_generated_group([item]))
+
+                release_sessions.assert_awaited_once_with([str(session_id)])
+                self.assertIsNone(item.session_id)
+                self.assertIsNone(item.routed_experts)
 
     async def test_put_generated_group_records_raw_rewards_before_filtering(self):
         # 验证 raw reward 在过滤前统计，filtered group 仍能贡献生成侧 reward 指标。

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -21,6 +21,7 @@
 # 11. save/resume 保留 Ray ObjectRef：直接 ObjectRef 和 dict(dict(ObjectRef)) 嵌套结构恢复后，
 #     解引用得到的内容都应与保存前一致。
 
+import asyncio
 import tempfile
 import unittest
 from pathlib import Path
@@ -474,6 +475,51 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 assert await replay_buffer.count("retryable_task", Status.EXPIRED) == 1
                 assert len(replay_buffer) == 1
                 assert await replay_buffer.get(1, "terminal_task", Status.EXPIRED) == []
+
+    async def test_refresh_staleness_batches_terminal_release_outside_lock(self):
+        replay_buffer = AsyncReplayBufferConfig().build()
+        first = make_rollout_state(1, session_id=301, response_model_steps=[1])
+        second = make_rollout_state(2, session_id=302, response_model_steps=[1])
+        await replay_buffer.put([first], "terminal_task")
+        await replay_buffer.put([second], "terminal_task")
+
+        release_started = asyncio.Event()
+        allow_release = asyncio.Event()
+
+        async def delayed_release(session_ids):
+            release_started.set()
+            await allow_release.wait()
+            return set(session_ids)
+
+        with patch(
+            "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+            new=AsyncMock(side_effect=delayed_release),
+        ) as release_sessions:
+            refresh_task = asyncio.create_task(
+                replay_buffer.refresh_staleness(
+                    task_stale_thresholds={"terminal_task": 2},
+                    expired_groups_retryable_by_task={"terminal_task": False},
+                    current_train_step=4,
+                )
+            )
+            await asyncio.wait_for(release_started.wait(), timeout=1.0)
+            try:
+                # The terminal records are already removed and the buffer lock is
+                # available while the trace-store RPC is still blocked.
+                count = await asyncio.wait_for(
+                    replay_buffer.count("terminal_task", Status.COMPLETED),
+                    timeout=1.0,
+                )
+                assert count == 0
+            finally:
+                allow_release.set()
+            expired_counts = await refresh_task
+
+        release_sessions.assert_awaited_once_with(["301", "302"])
+        assert expired_counts == {"terminal_task": 2}
+        assert first.status == Status.EXPIRED
+        assert second.status == Status.EXPIRED
+        assert len(replay_buffer) == 0
 
     async def test_common_refresh_staleness_contract(self):
         # refresh_staleness 同时覆盖默认刷新 completed/aborted，以及 status filter 只刷新指定状态。

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -211,7 +211,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 )
 
                 with patch(
-                    "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+                    "xtuner.v1.rl.rollout.trace_store.release_existing_sessions",
                     new=AsyncMock(return_value={"101"}),
                 ) as release_sessions:
                     await replay_buffer.put(
@@ -255,7 +255,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 )
 
                 with patch(
-                    "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+                    "xtuner.v1.rl.rollout.trace_store.release_existing_sessions",
                     new=AsyncMock(),
                 ) as release_sessions:
                     await replay_buffer.put(
@@ -450,7 +450,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 assert len(replay_buffer) == 2
 
                 with patch(
-                    "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+                    "xtuner.v1.rl.rollout.trace_store.release_existing_sessions",
                     new=AsyncMock(return_value={"201"}),
                 ) as release_sessions:
                     expired_counts = await replay_buffer.refresh_staleness(
@@ -492,7 +492,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
             return set(session_ids)
 
         with patch(
-            "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+            "xtuner.v1.rl.rollout.trace_store.release_existing_sessions",
             new=AsyncMock(side_effect=delayed_release),
         ) as release_sessions:
             refresh_task = asyncio.create_task(

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -428,12 +428,12 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(group[1].response_ids, [12])
                 self.assertEqual(group[1].reward, {"score": 0.9})
 
-    async def test_common_refresh_staleness_drops_only_terminal_expired_groups(self):
-        # 同一轮 refresh 仍统计两类过期；只删除 terminal EXPIRED，保留 tail batch 可重试项。
+    async def test_common_refresh_staleness_drops_only_non_retryable_expired_groups(self):
+        # 同一轮 refresh 仍统计两类过期；只删除 non-retryable EXPIRED，保留 tail batch 可重试项。
         for config_name, replay_buffer_config_cls in REPLAY_BUFFER_CONFIGS:
             with self.subTest(replay_buffer_config=config_name):
                 replay_buffer = replay_buffer_config_cls().build()
-                terminal_stale = make_rollout_state(
+                non_retryable_stale = make_rollout_state(
                     1,
                     session_id=201,
                     response_model_steps=[1],
@@ -445,7 +445,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                     response_model_steps=[1],
                     mm_info={"pixel_values": np.ones((2, 3), dtype=np.float32)},
                 )
-                await replay_buffer.put([terminal_stale], "terminal_task")
+                await replay_buffer.put([non_retryable_stale], "non_retryable_task")
                 await replay_buffer.put([retryable_stale], "retryable_task")
                 assert len(replay_buffer) == 2
 
@@ -454,34 +454,34 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                     new=AsyncMock(return_value={"201"}),
                 ) as release_sessions:
                     expired_counts = await replay_buffer.refresh_staleness(
-                        task_stale_thresholds={"terminal_task": 2, "retryable_task": 2},
+                        task_stale_thresholds={"non_retryable_task": 2, "retryable_task": 2},
                         expired_groups_retryable_by_task={
-                            "terminal_task": False,
+                            "non_retryable_task": False,
                             "retryable_task": True,
                         },
                         current_train_step=4,
                     )
 
                 release_sessions.assert_awaited_once_with(["201"])
-                assert expired_counts == {"terminal_task": 1, "retryable_task": 1}
-                assert terminal_stale.status == Status.EXPIRED
-                assert terminal_stale.prompt_ids is None
-                assert terminal_stale.mm_info is None
+                assert expired_counts == {"non_retryable_task": 1, "retryable_task": 1}
+                assert non_retryable_stale.status == Status.EXPIRED
+                assert non_retryable_stale.prompt_ids is None
+                assert non_retryable_stale.mm_info is None
                 assert retryable_stale.status == Status.EXPIRED
                 assert retryable_stale.prompt_ids == [2, 1002]
                 assert retryable_stale.mm_info is not None
-                assert await replay_buffer.count("terminal_task", Status.COMPLETED) == 0
-                assert await replay_buffer.count("terminal_task", Status.EXPIRED) == 0
+                assert await replay_buffer.count("non_retryable_task", Status.COMPLETED) == 0
+                assert await replay_buffer.count("non_retryable_task", Status.EXPIRED) == 0
                 assert await replay_buffer.count("retryable_task", Status.EXPIRED) == 1
                 assert len(replay_buffer) == 1
-                assert await replay_buffer.get(1, "terminal_task", Status.EXPIRED) == []
+                assert await replay_buffer.get(1, "non_retryable_task", Status.EXPIRED) == []
 
-    async def test_refresh_staleness_batches_terminal_release_outside_lock(self):
+    async def test_refresh_staleness_batches_non_retryable_release_outside_lock(self):
         replay_buffer = AsyncReplayBufferConfig().build()
         first = make_rollout_state(1, session_id=301, response_model_steps=[1])
         second = make_rollout_state(2, session_id=302, response_model_steps=[1])
-        await replay_buffer.put([first], "terminal_task")
-        await replay_buffer.put([second], "terminal_task")
+        await replay_buffer.put([first], "non_retryable_task")
+        await replay_buffer.put([second], "non_retryable_task")
 
         release_started = asyncio.Event()
         allow_release = asyncio.Event()
@@ -497,17 +497,17 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
         ) as release_sessions:
             refresh_task = asyncio.create_task(
                 replay_buffer.refresh_staleness(
-                    task_stale_thresholds={"terminal_task": 2},
-                    expired_groups_retryable_by_task={"terminal_task": False},
+                    task_stale_thresholds={"non_retryable_task": 2},
+                    expired_groups_retryable_by_task={"non_retryable_task": False},
                     current_train_step=4,
                 )
             )
             await asyncio.wait_for(release_started.wait(), timeout=1.0)
             try:
-                # The terminal records are already removed and the buffer lock is
+                # The non-retryable records are already removed and the buffer lock is
                 # available while the trace-store RPC is still blocked.
                 count = await asyncio.wait_for(
-                    replay_buffer.count("terminal_task", Status.COMPLETED),
+                    replay_buffer.count("non_retryable_task", Status.COMPLETED),
                     timeout=1.0,
                 )
                 assert count == 0
@@ -516,7 +516,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
             expired_counts = await refresh_task
 
         release_sessions.assert_awaited_once_with(["301", "302"])
-        assert expired_counts == {"terminal_task": 2}
+        assert expired_counts == {"non_retryable_task": 2}
         assert first.status == Status.EXPIRED
         assert second.status == Status.EXPIRED
         assert len(replay_buffer) == 0

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -24,6 +24,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import ray
@@ -41,6 +42,7 @@ REPLAY_BUFFER_CONFIGS = [
 def make_rollout_state(
     uid: int,
     *,
+    session_id: int | None = None,
     status: Status = Status.COMPLETED,
     seq_staleness: int = 0,
     prompt_ids: list[int] | None = None,
@@ -66,6 +68,7 @@ def make_rollout_state(
         group_id=uid,
         message=[{"role": "user", "content": f"prompt {uid}"}],
         prompt_ids=prompt_ids,
+        session_id=session_id,
         tokens=list(tokens) if tokens is not None else list(prompt_ids),
         response=response if response is not None else f"response {uid}",
         response_ids=response_ids,
@@ -193,6 +196,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 replay_buffer = replay_buffer_config_cls().build()
                 stale = make_rollout_state(
                     1,
+                    session_id=101,
                     prompt_ids=[101, 102],
                     tokens=[999],
                     response="stale response",
@@ -205,14 +209,19 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                     extra_fields={"train_prompt_ids": [101, 102]},
                 )
 
-                await replay_buffer.put(
-                    [stale],
-                    "task",
-                    current_train_step=5,
-                    stale_threshold=3,
-                    expired_groups_retryable=False,
-                )
+                with patch(
+                    "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+                    new=AsyncMock(return_value={"101"}),
+                ) as release_sessions:
+                    await replay_buffer.put(
+                        [stale],
+                        "task",
+                        current_train_step=5,
+                        stale_threshold=3,
+                        expired_groups_retryable=False,
+                    )
 
+                release_sessions.assert_awaited_once_with(["101"])
                 assert stale.status == Status.EXPIRED
                 assert stale.prompt_ids is None
                 assert stale.tokens is None
@@ -230,6 +239,7 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 pixel_values = np.ones((2, 3), dtype=np.float32)
                 stale = make_rollout_state(
                     1,
+                    session_id=102,
                     prompt_ids=[101, 102],
                     tokens=[999],
                     response="stale response",
@@ -243,13 +253,18 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                     extra_fields={"train_prompt_ids": [101, 102]},
                 )
 
-                await replay_buffer.put(
-                    [stale],
-                    "task",
-                    current_train_step=5,
-                    stale_threshold=3,
-                )
+                with patch(
+                    "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+                    new=AsyncMock(),
+                ) as release_sessions:
+                    await replay_buffer.put(
+                        [stale],
+                        "task",
+                        current_train_step=5,
+                        stale_threshold=3,
+                    )
 
+                release_sessions.assert_not_awaited()
                 expired = await replay_buffer.get(1, "task", Status.EXPIRED)
                 reusable = expired[0][0]
                 assert reusable.status == Status.EXPIRED
@@ -419,11 +434,13 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 replay_buffer = replay_buffer_config_cls().build()
                 terminal_stale = make_rollout_state(
                     1,
+                    session_id=201,
                     response_model_steps=[1],
                     mm_info={"pixel_values": np.ones((2, 3), dtype=np.float32)},
                 )
                 retryable_stale = make_rollout_state(
                     2,
+                    session_id=202,
                     response_model_steps=[1],
                     mm_info={"pixel_values": np.ones((2, 3), dtype=np.float32)},
                 )
@@ -431,15 +448,20 @@ class TestReplayBuffer(unittest.IsolatedAsyncioTestCase):
                 await replay_buffer.put([retryable_stale], "retryable_task")
                 assert len(replay_buffer) == 2
 
-                expired_counts = await replay_buffer.refresh_staleness(
-                    task_stale_thresholds={"terminal_task": 2, "retryable_task": 2},
-                    expired_groups_retryable_by_task={
-                        "terminal_task": False,
-                        "retryable_task": True,
-                    },
-                    current_train_step=4,
-                )
+                with patch(
+                    "xtuner.v1.rl.replay_buffer.release_existing_sessions",
+                    new=AsyncMock(return_value={"201"}),
+                ) as release_sessions:
+                    expired_counts = await replay_buffer.refresh_staleness(
+                        task_stale_thresholds={"terminal_task": 2, "retryable_task": 2},
+                        expired_groups_retryable_by_task={
+                            "terminal_task": False,
+                            "retryable_task": True,
+                        },
+                        current_train_step=4,
+                    )
 
+                release_sessions.assert_awaited_once_with(["201"])
                 assert expired_counts == {"terminal_task": 1, "retryable_task": 1}
                 assert terminal_stale.status == Status.EXPIRED
                 assert terminal_stale.prompt_ids is None

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -142,7 +142,8 @@ class TestRLColocateTrainer(unittest.TestCase):
         trainer._benchmark_training_samples = 0
         trainer._benchmark_training_tokens = 0
         trainer._save_trajectories = MagicMock()
-        trainer._release_trace_store = MagicMock()
+        trainer._release_trace_sessions = MagicMock(return_value=set())
+        trainer._release_all_trace_sessions = MagicMock()
         trainer._sync_weights_and_save = MagicMock(
             side_effect=lambda train_step, step_timer_dict: train_step % trainer._sync_weights_interval == 0
         )
@@ -208,6 +209,8 @@ class TestRLColocateTrainer(unittest.TestCase):
         trainer.rollout_controller.offload.remote.assert_called_once_with()
         trainer.train_controller.onload.assert_called_once_with(target="all")
         trainer.train_controller.fit.assert_called_once()
+        trainer._release_all_trace_sessions.assert_called_once_with()
+        trainer._release_trace_sessions.assert_not_called()
         self.assertEqual(trainer._cur_step, 1)
 
     def test_fit_requires_non_empty_batch_from_manager(self):

--- a/tests/rl/test_rl_disaggregated_trainer.py
+++ b/tests/rl/test_rl_disaggregated_trainer.py
@@ -135,7 +135,8 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
         )
         trainer._save_trajectories = MagicMock()
         trainer._save_eval_trajectories = MagicMock()
-        trainer._release_trace_store = MagicMock()
+        trainer._release_trace_sessions = MagicMock(return_value=set())
+        trainer._release_all_trace_sessions = MagicMock()
         trainer._log_step = MagicMock()
         trainer._maybe_save_checkpoint = AsyncMock()
         trainer._maybe_save_hf = MagicMock()
@@ -185,7 +186,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
 
     def test_fit_persists_checkpoint_for_completed_model_step(self):
         # 验证 checkpoint 以 fit 完成的 model_step 为准，并通过 async manager.save 落盘。
-        train_sample = SimpleNamespace(group_id=1, rollout_id=1)
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=None)
         manager = _FakeManager([ProduceBatchResult(rollout_states=[[train_sample]])])
         manager.save = AsyncMock()
         trainer = self._make_trainer(manager)
@@ -217,7 +218,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
 
     def test_fit_retries_same_step_after_empty_expired_skip(self):
         # 验证空 expired batch 只同步上一版模型，不推进 train_step，并重试同一步。
-        train_sample = SimpleNamespace(group_id=1, rollout_id=1)
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=None)
         manager = _FakeManager(
             [
                 ProduceBatchResult(rollout_states=[], status=ProduceBatchStatus.EXPIRED_BATCH),
@@ -243,7 +244,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
 
     def test_fit_trains_non_empty_expired_batch_then_syncs_current_step(self):
         # 验证非空 expired batch 仍会训练，并用当前完成的 model_step 恢复 producer。
-        train_sample = SimpleNamespace(group_id=1, rollout_id=1)
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=None)
         manager = _FakeManager(
             [ProduceBatchResult(rollout_states=[[train_sample]], status=ProduceBatchStatus.EXPIRED_BATCH)]
         )
@@ -258,7 +259,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
 
     def test_fit_rebinds_weight_update_with_rollout_update_address(self):
         # 验证非共卡后续同步权重时继续沿用 rollout config 中的 NCCL update 地址。
-        train_sample = SimpleNamespace(group_id=1, rollout_id=1)
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=None)
         manager = _FakeManager([ProduceBatchResult(rollout_states=[[train_sample]])])
         trainer = self._make_trainer(manager)
         trainer._rollout_config = SimpleNamespace(weight_update_host="10.0.0.1", weight_update_port=23456)
@@ -280,7 +281,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
 
     def test_fit_keeps_background_producer_running_while_training_blocks(self):
         # 验证非共卡训练阻塞在同步训练 batch 时，后台 producer 仍能继续调度。
-        train_sample = SimpleNamespace(group_id=1, rollout_id=1)
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=None)
         training_started = threading.Event()
         producer_ticked = threading.Event()
         manager = _TickingManager(
@@ -309,7 +310,7 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
         # 后台 producer 在 learner 训练期间仍会创建 trace；训练结束只能释放当前消费 batch 的 session。
         train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=101)
         trainer = self._make_trainer(_FakeManager([]))
-        trainer._release_trace_store = RLDisaggregatedTrainer._release_trace_store.__get__(
+        trainer._release_trace_sessions = RLDisaggregatedTrainer._release_trace_sessions.__get__(
             trainer, RLDisaggregatedTrainer
         )
         live_session_ids = {"101", "202"}
@@ -331,15 +332,68 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
                 [[train_sample]],
                 train_step=1,
                 step_timer_dict={},
-                release_only_consumed_trace_sessions=True,
             )
 
         store.release_sessions.remote.assert_called_once_with(["101"])
         self.assertEqual(live_session_ids, {"202"})
 
+    def test_evaluation_releases_only_eval_sessions_and_preserves_leftovers(self):
+        eval_sample = SimpleNamespace(group_id=2, rollout_id=2, session_id="eval")
+        trainer = self._make_trainer(_FakeManager([]))
+        trainer._release_trace_sessions = RLDisaggregatedTrainer._release_trace_sessions.__get__(
+            trainer, RLDisaggregatedTrainer
+        )
+        trainer.eval_agent_loop_manager.produce_batch = AsyncMock(
+            return_value=ProduceBatchResult(rollout_states=[[eval_sample]])
+        )
+        live_session_ids = {"leftover", "eval"}
+
+        def release_sessions(session_ids):
+            released = [session_id for session_id in session_ids if session_id in live_session_ids]
+            live_session_ids.difference_update(released)
+            return released
+
+        store = SimpleNamespace(
+            release_sessions=SimpleNamespace(remote=MagicMock(side_effect=release_sessions)),
+        )
+        with (
+            patch("xtuner.v1.rl.rollout.trace_store.get_existing_store", return_value=store),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda value: value),
+        ):
+            metrics = asyncio.run(trainer._run_evaluation(train_step=1))
+
+        self.assertEqual(metrics, {"acc": 1.0})
+        store.release_sessions.remote.assert_called_once_with(["eval"])
+        self.assertEqual(live_session_ids, {"leftover"})
+
+    def test_evaluation_releases_eval_sessions_when_evaluator_fails(self):
+        eval_sample = SimpleNamespace(group_id=2, rollout_id=2, session_id="eval")
+        trainer = self._make_trainer(_FakeManager([]))
+        trainer.eval_agent_loop_manager.produce_batch = AsyncMock(
+            return_value=ProduceBatchResult(rollout_states=[[eval_sample]])
+        )
+        trainer.evaluator.run = MagicMock(side_effect=RuntimeError("evaluation failed"))
+
+        with self.assertRaisesRegex(RuntimeError, "evaluation failed"):
+            asyncio.run(trainer._run_evaluation(train_step=1))
+
+        trainer._release_trace_sessions.assert_called_once_with(["eval"])
+
+    def test_initial_evaluation_releases_only_its_sessions(self):
+        eval_sample = SimpleNamespace(group_id=2, rollout_id=2, session_id="initial-eval")
+        trainer = self._make_trainer(_FakeManager([]))
+        trainer.eval_agent_loop_manager.produce_batch = AsyncMock(
+            return_value=ProduceBatchResult(rollout_states=[[eval_sample]])
+        )
+
+        asyncio.run(trainer._run_initial_evaluate())
+
+        trainer._release_trace_sessions.assert_called_once_with(["initial-eval"])
+        trainer._release_all_trace_sessions.assert_not_called()
+
     def test_fit_observes_background_producer_failure_before_training_waited_batch(self):
         # 后台 producer 异常是终止性失败；前台 get_batch 还在等待时必须立刻暴露，不能先训练随后才失败。
-        train_sample = SimpleNamespace(group_id=1, rollout_id=1)
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=None)
         manager = _FailingProducerManager([ProduceBatchResult(rollout_states=[[train_sample]])])
         trainer = self._make_trainer(manager)
 
@@ -352,11 +406,9 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
     def test_fit_runs_eval_before_reset_and_stops_producer(self):
         # 验证 eval 在 producer 恢复前执行，避免生产侧提前抢占 rollout 资源。
         # 确定性排序依赖 RolloutState 的 group_id 和 rollout_id，测试用轻量对象模拟即可。
-        train_sample = SimpleNamespace(group_id=1, rollout_id=1)
-        eval_sample = SimpleNamespace(group_id=2, rollout_id=2)
-        manager = _FakeManager(
-            [ProduceBatchResult(rollout_states=[[train_sample]], status=ProduceBatchStatus.NORMAL)]
-        )
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=None)
+        eval_sample = SimpleNamespace(group_id=2, rollout_id=2, session_id=None)
+        manager = _FakeManager([ProduceBatchResult(rollout_states=[[train_sample]], status=ProduceBatchStatus.NORMAL)])
         trainer = self._make_trainer(manager)
         trainer._enable_evaluate = True
         events: list[str] = []

--- a/tests/rl/test_rl_disaggregated_trainer.py
+++ b/tests/rl/test_rl_disaggregated_trainer.py
@@ -305,6 +305,38 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
         self.assertIn("produce_loop_tick_during_training", manager.calls)
         self.assertEqual(trainer._cur_step, 1)
 
+    def test_train_batch_releases_only_consumed_trace_sessions_for_disaggregated_rollout(self):
+        # 后台 producer 在 learner 训练期间仍会创建 trace；训练结束只能释放当前消费 batch 的 session。
+        train_sample = SimpleNamespace(group_id=1, rollout_id=1, session_id=101)
+        trainer = self._make_trainer(_FakeManager([]))
+        trainer._release_trace_store = RLDisaggregatedTrainer._release_trace_store.__get__(
+            trainer, RLDisaggregatedTrainer
+        )
+        live_session_ids = {"101", "202"}
+
+        def release_sessions(session_ids):
+            released = [session_id for session_id in session_ids if session_id in live_session_ids]
+            live_session_ids.difference_update(released)
+            return released
+
+        store = SimpleNamespace(
+            release_sessions=SimpleNamespace(remote=MagicMock(side_effect=release_sessions)),
+        )
+
+        with (
+            patch("xtuner.v1.rl.rollout.trace_store.get_existing_store", return_value=store),
+            patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda value: value),
+        ):
+            trainer._train_one_batch(
+                [[train_sample]],
+                train_step=1,
+                step_timer_dict={},
+                release_only_consumed_trace_sessions=True,
+            )
+
+        store.release_sessions.remote.assert_called_once_with(["101"])
+        self.assertEqual(live_session_ids, {"202"})
+
     def test_fit_observes_background_producer_failure_before_training_waited_batch(self):
         # 后台 producer 异常是终止性失败；前台 get_batch 还在等待时必须立刻暴露，不能先训练随后才失败。
         train_sample = SimpleNamespace(group_id=1, rollout_id=1)

--- a/tests/rl/test_rl_trainer_checkpoint.py
+++ b/tests/rl/test_rl_trainer_checkpoint.py
@@ -45,6 +45,7 @@ from xtuner.v1.rl.trainer import WorkerConfig
 from xtuner.v1.rl.utils import AcceleratorResourcesConfig
 from xtuner.v1.train.rl_trainer import RLColocateTrainerConfig, RLDisaggregatedTrainerConfig
 
+
 QWEN3_4B_PATH = os.environ.get("QWEN3_4B_PATH")
 CHECKPOINT_DIR = "checkpoints"
 TRAIN_STATE_PATH = "train_state.json"
@@ -237,7 +238,8 @@ class TestRLTrainerCheckpoint(unittest.TestCase):
             patch("xtuner.v1.train.rl_trainer.set_cpu_resource_manager", lambda manager: None),
             patch("xtuner.v1.train.rl_trainer.get_rollout_engine_version", return_value={}),
             patch("xtuner.v1.train.rl_trainer.ray.get", side_effect=lambda obj, timeout=None: obj),
-            patch("xtuner.v1.train.rl_trainer.BaseRLTrainer._release_trace_store", return_value=None),
+            patch("xtuner.v1.train.rl_trainer.BaseRLTrainer._release_trace_sessions", return_value=set()),
+            patch("xtuner.v1.train.rl_trainer.BaseRLTrainer._release_all_trace_sessions", return_value=None),
             patch.object(WorkerConfig, "build", autospec=True, side_effect=build_train_controller),
             patch.object(RolloutConfig, "build", autospec=True, side_effect=build_rollout_controller),
         ):

--- a/tests/rl/test_trace_store.py
+++ b/tests/rl/test_trace_store.py
@@ -9,8 +9,38 @@ from xtuner.v1.rl.rollout.trace_store import (
     RolloutTraceStore,
     _free_ray_refs,
     get_existing_store,
+    release_and_discard_rollout_groups,
     release_existing_sessions,
 )
+
+
+class TestRolloutTraceCleanup(unittest.TestCase):
+    def test_release_and_discard_detaches_only_trace_owned_refs(self):
+        trace_owned_ref = object()
+        rollout_owned_ref = object()
+        trace_owned = SimpleNamespace(session_id="trace-owned", routed_experts=trace_owned_ref)
+        rollout_owned = SimpleNamespace(session_id="rollout-owned", routed_experts=rollout_owned_ref)
+        routed_experts_seen_by_discard = {}
+
+        def record_discard(item):
+            routed_experts_seen_by_discard[item.session_id] = item.routed_experts
+
+        with (
+            patch(
+                "xtuner.v1.rl.rollout.trace_store.release_existing_sessions",
+                new=AsyncMock(return_value={"trace-owned"}),
+            ) as release_sessions,
+            patch(
+                "xtuner.v1.rl.rollout.trace_store.discard_rollout_state",
+                side_effect=record_discard,
+            ) as discard,
+        ):
+            asyncio.run(release_and_discard_rollout_groups([[trace_owned, rollout_owned]]))
+
+        release_sessions.assert_awaited_once_with(["trace-owned", "rollout-owned"])
+        self.assertIsNone(routed_experts_seen_by_discard["trace-owned"])
+        self.assertIs(routed_experts_seen_by_discard["rollout-owned"], rollout_owned_ref)
+        self.assertEqual(discard.call_count, 2)
 
 
 class TestRolloutTraceStore(unittest.TestCase):

--- a/tests/rl/test_trace_store.py
+++ b/tests/rl/test_trace_store.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import ray
 
+from xtuner.v1.rl.rollout import trace_store as trace_store_module
 from xtuner.v1.rl.rollout.trace_store import (
     RolloutTraceStore,
     _free_ray_refs,
@@ -41,6 +42,15 @@ class TestRolloutTraceCleanup(unittest.TestCase):
         self.assertIsNone(routed_experts_seen_by_discard["trace-owned"])
         self.assertIs(routed_experts_seen_by_discard["rollout-owned"], rollout_owned_ref)
         self.assertEqual(discard.call_count, 2)
+
+    def test_get_existing_store_returns_none_when_ray_is_uninitialized(self):
+        cached_store = object()
+        with (
+            patch.object(trace_store_module, "_handle_cache", cached_store),
+            patch.object(trace_store_module.ray, "is_initialized", return_value=False),
+        ):
+            self.assertIsNone(get_existing_store())
+            self.assertIsNone(trace_store_module._handle_cache)
 
 
 class TestRolloutTraceStore(unittest.TestCase):
@@ -94,10 +104,6 @@ class TestRolloutTraceStore(unittest.TestCase):
             return_value=None,
         ):
             self.assertEqual(asyncio.run(release_existing_sessions(["missing"])), set())
-
-    def test_get_existing_store_returns_none_when_ray_is_uninitialized(self):
-        with patch("xtuner.v1.rl.rollout.trace_store.ray.is_initialized", return_value=False):
-            self.assertIsNone(get_existing_store())
 
     def test_free_ray_refs_recurses_into_nested_containers(self):
         object_ref = ray.put({"payload": [1, 2, 3]})

--- a/tests/rl/test_trace_store.py
+++ b/tests/rl/test_trace_store.py
@@ -1,0 +1,77 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import ray
+
+from xtuner.v1.rl.rollout.trace_store import (
+    RolloutTraceStore,
+    _free_ray_refs,
+    get_existing_store,
+    release_existing_sessions,
+)
+
+
+class TestRolloutTraceStore(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.started_ray = False
+        try:
+            if not ray.is_initialized():
+                ray.init(address="local", num_cpus=1, include_dashboard=False, ignore_reinit_error=True)
+                cls.started_ray = True
+        except Exception as exc:
+            raise unittest.SkipTest(f"Ray init failed for trace-store tests: {exc}") from exc
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.started_ray and ray.is_initialized():
+            ray.shutdown()
+
+    def test_release_sessions_deduplicates_and_skips_missing_ids(self):
+        store = RolloutTraceStore.remote()
+        try:
+            ray.get(store.insert.remote("a", "prompt-a", {"value": 1}))
+            ray.get(store.insert.remote("b", "prompt-b", {"value": 2}))
+
+            released = ray.get(store.release_sessions.remote(["a", "missing", "a"]))
+
+            self.assertEqual(released, ["a"])
+            self.assertEqual(ray.get(store.list_sessions.remote()), ["b"])
+        finally:
+            ray.kill(store)
+
+    def test_release_existing_sessions_stably_deduplicates_before_rpc(self):
+        release_remote = AsyncMock(return_value=["one"])
+        store = SimpleNamespace(release_sessions=SimpleNamespace(remote=release_remote))
+        with patch(
+            "xtuner.v1.rl.rollout.trace_store.get_existing_store",
+            return_value=store,
+        ):
+            released = asyncio.run(release_existing_sessions(["one", "one", "missing"]))
+
+        self.assertEqual(released, {"one"})
+        release_remote.assert_awaited_once_with(["one", "missing"])
+
+    def test_release_existing_sessions_handles_empty_input_and_missing_store(self):
+        with patch("xtuner.v1.rl.rollout.trace_store.get_existing_store") as get_store:
+            self.assertEqual(asyncio.run(release_existing_sessions([])), set())
+            get_store.assert_not_called()
+
+        with patch(
+            "xtuner.v1.rl.rollout.trace_store.get_existing_store",
+            return_value=None,
+        ):
+            self.assertEqual(asyncio.run(release_existing_sessions(["missing"])), set())
+
+    def test_get_existing_store_returns_none_when_ray_is_uninitialized(self):
+        with patch("xtuner.v1.rl.rollout.trace_store.ray.is_initialized", return_value=False):
+            self.assertIsNone(get_existing_store())
+
+    def test_free_ray_refs_recurses_into_nested_containers(self):
+        object_ref = ray.put({"payload": [1, 2, 3]})
+        with patch.object(ray.internal, "free") as free:
+            _free_ray_refs({"outer": [({"inner": object_ref},)]})
+
+        free.assert_called_once_with([object_ref], local_only=False)

--- a/xtuner/v1/rl/agent_loop_manager/produce_utils.py
+++ b/xtuner/v1/rl/agent_loop_manager/produce_utils.py
@@ -21,6 +21,7 @@ from xtuner.v1.data_proto.rl_data import (
 )
 from xtuner.v1.rl.agent_loop import AgentLoopSpec
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
+from xtuner.v1.rl.rollout.trace_store import release_existing_sessions
 from xtuner.v1.rl.utils import (
     AGENT_LOOP_PAUSE_REQUEST_TIMEOUT_S,
     PRODUCER_PAUSE_PENDING_TASK_TIMEOUT_S,
@@ -197,7 +198,13 @@ class BaseProduceContext:
             # 失败样本和业务过滤样本都不进入 replay buffer。
             self.progress.add_produced(self.task_name, samples=len(group), tokens=produced_tokens)
             self.progress.add_discarded(self.task_name, discard_status, samples=len(group))
+            released_session_ids = await release_existing_sessions(
+                [str(item.session_id) for item in group if item.session_id is not None]
+            )
             for item in group:
+                if item.session_id is not None and str(item.session_id) in released_session_ids:
+                    # TraceStore.release_sessions() already freed these routed-expert refs.
+                    item.routed_experts = None
                 discard_rollout_state(item)
             return False
 

--- a/xtuner/v1/rl/agent_loop_manager/produce_utils.py
+++ b/xtuner/v1/rl/agent_loop_manager/produce_utils.py
@@ -16,12 +16,11 @@ from xtuner.v1.data_proto.rl_data import (
     RolloutState,
     Status,
     calculate_group_effective_response_masks,
-    discard_rollout_state,
     get_group_status,
 )
 from xtuner.v1.rl.agent_loop import AgentLoopSpec
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
-from xtuner.v1.rl.rollout.trace_store import release_existing_sessions
+from xtuner.v1.rl.rollout.trace_store import release_and_discard_rollout_groups
 from xtuner.v1.rl.utils import (
     AGENT_LOOP_PAUSE_REQUEST_TIMEOUT_S,
     PRODUCER_PAUSE_PENDING_TASK_TIMEOUT_S,
@@ -198,14 +197,7 @@ class BaseProduceContext:
             # 失败样本和业务过滤样本都不进入 replay buffer。
             self.progress.add_produced(self.task_name, samples=len(group), tokens=produced_tokens)
             self.progress.add_discarded(self.task_name, discard_status, samples=len(group))
-            released_session_ids = await release_existing_sessions(
-                [str(item.session_id) for item in group if item.session_id is not None]
-            )
-            for item in group:
-                if item.session_id is not None and str(item.session_id) in released_session_ids:
-                    # TraceStore.release_sessions() already freed these routed-expert refs.
-                    item.routed_experts = None
-                discard_rollout_state(item)
+            await release_and_discard_rollout_groups([group])
             return False
 
         # ABORTED 保持可重试；EXPIRED 由 task 的 retryability 决定保留或丢弃。

--- a/xtuner/v1/rl/replay_buffer.py
+++ b/xtuner/v1/rl/replay_buffer.py
@@ -493,8 +493,8 @@ class ReplayBuffer:
         return Status.EXPIRED
 
     @staticmethod
-    async def _discard_terminal_expired_groups(groups: list[list[RolloutState]]) -> None:
-        """Release terminal trace sessions in one RPC, then discard groups."""
+    async def _discard_non_retryable_expired_groups(groups: list[list[RolloutState]]) -> None:
+        """Release non-retryable trace sessions in one RPC, then discard groups."""
         if not groups:
             return
 
@@ -528,7 +528,7 @@ class ReplayBuffer:
         )
         staleness = max(item.seq_staleness for item in items)
         if status == Status.EXPIRED and not expired_groups_retryable:
-            await self._discard_terminal_expired_groups([items])
+            await self._discard_non_retryable_expired_groups([items])
             return
         storage_item = StorageItem(
             item=items,
@@ -569,7 +569,7 @@ class ReplayBuffer:
         expired_counts: dict[str, int] = {}
         retryable_by_task = expired_groups_retryable_by_task or {}
         token_stale_thresholds = task_token_stale_thresholds or {}
-        terminal_expired_groups: list[list[RolloutState]] = []
+        non_retryable_expired_groups: list[list[RolloutState]] = []
         async with self._lock:
             updated_records: list[StorageItem] = []
             deleted_uids: list[int] = []
@@ -595,14 +595,14 @@ class ReplayBuffer:
                     if status == Status.EXPIRED:
                         expired_count += 1
                         if not retryable:
-                            terminal_expired_groups.append(record.item)
+                            non_retryable_expired_groups.append(record.item)
                             deleted_uids.append(record.uid)
                             continue
                     updated_records.append(replace(record, status=status, staleness=staleness))
                 expired_counts[task_name] = expired_count
             await self._storage.delete(deleted_uids)
             await self._storage.update(updated_records)
-        await self._discard_terminal_expired_groups(terminal_expired_groups)
+        await self._discard_non_retryable_expired_groups(non_retryable_expired_groups)
         return expired_counts
 
     async def is_ready(

--- a/xtuner/v1/rl/replay_buffer.py
+++ b/xtuner/v1/rl/replay_buffer.py
@@ -494,7 +494,8 @@ class ReplayBuffer:
 
     @staticmethod
     async def _discard_non_retryable_expired_groups(groups: list[list[RolloutState]]) -> None:
-        """Release non-retryable trace sessions in one RPC, then discard groups."""
+        """Release non-retryable trace sessions in one RPC, then discard
+        groups."""
         if not groups:
             return
 

--- a/xtuner/v1/rl/replay_buffer.py
+++ b/xtuner/v1/rl/replay_buffer.py
@@ -14,13 +14,12 @@ from xtuner.v1.data_proto.rl_data import (
     RolloutState,
     Status,
     calculate_group_effective_response_masks,
-    discard_rollout_state,
     get_group_status,
     refresh_seq_staleness,
     reset_rollout_response,
     update_sample_version,
 )
-from xtuner.v1.rl.rollout.trace_store import release_existing_sessions
+from xtuner.v1.rl.rollout.trace_store import release_and_discard_rollout_groups
 from xtuner.v1.rl.utils import (
     BetweenNode,
     ConditionNode,
@@ -499,15 +498,9 @@ class ReplayBuffer:
         if not groups:
             return
 
-        released_session_ids = await release_existing_sessions(
-            [str(item.session_id) for group in groups for item in group if item.session_id is not None]
-        )
+        await release_and_discard_rollout_groups(groups)
         for group in groups:
             for item in group:
-                if item.session_id is not None and str(item.session_id) in released_session_ids:
-                    # TraceStore.release_sessions() already freed these routed-expert refs.
-                    item.routed_experts = None
-                discard_rollout_state(item)
                 item.status = Status.EXPIRED
 
     async def put(

--- a/xtuner/v1/rl/replay_buffer.py
+++ b/xtuner/v1/rl/replay_buffer.py
@@ -20,6 +20,7 @@ from xtuner.v1.data_proto.rl_data import (
     reset_rollout_response,
     update_sample_version,
 )
+from xtuner.v1.rl.rollout.trace_store import release_existing_sessions
 from xtuner.v1.rl.utils import (
     BetweenNode,
     ConditionNode,
@@ -488,10 +489,26 @@ class ReplayBuffer:
                     reset_rollout_response(item)
         else:
             for item in group:
-                discard_rollout_state(item)
                 item.status = Status.EXPIRED
 
         return Status.EXPIRED
+
+    @staticmethod
+    async def _discard_terminal_expired_groups(groups: list[list[RolloutState]]) -> None:
+        """Release terminal trace sessions in one RPC, then discard groups."""
+        if not groups:
+            return
+
+        released_session_ids = await release_existing_sessions(
+            [str(item.session_id) for group in groups for item in group if item.session_id is not None]
+        )
+        for group in groups:
+            for item in group:
+                if item.session_id is not None and str(item.session_id) in released_session_ids:
+                    # TraceStore.release_sessions() already freed these routed-expert refs.
+                    item.routed_experts = None
+                discard_rollout_state(item)
+                item.status = Status.EXPIRED
 
     async def put(
         self,
@@ -518,6 +535,7 @@ class ReplayBuffer:
         )
         staleness = max(item.seq_staleness for item in items)
         if status == Status.EXPIRED and not expired_groups_retryable:
+            await self._discard_terminal_expired_groups([items])
             return
         storage_item = StorageItem(
             item=items,
@@ -558,6 +576,7 @@ class ReplayBuffer:
         expired_counts: dict[str, int] = {}
         retryable_by_task = expired_groups_retryable_by_task or {}
         token_stale_thresholds = task_token_stale_thresholds or {}
+        terminal_expired_groups: list[list[RolloutState]] = []
         async with self._lock:
             updated_records: list[StorageItem] = []
             deleted_uids: list[int] = []
@@ -583,12 +602,14 @@ class ReplayBuffer:
                     if status == Status.EXPIRED:
                         expired_count += 1
                         if not retryable:
+                            terminal_expired_groups.append(record.item)
                             deleted_uids.append(record.uid)
                             continue
                     updated_records.append(replace(record, status=status, staleness=staleness))
                 expired_counts[task_name] = expired_count
             await self._storage.delete(deleted_uids)
             await self._storage.update(updated_records)
+        await self._discard_terminal_expired_groups(terminal_expired_groups)
         return expired_counts
 
     async def is_ready(

--- a/xtuner/v1/rl/rollout/trace_store.py
+++ b/xtuner/v1/rl/rollout/trace_store.py
@@ -498,6 +498,7 @@ async def release_existing_sessions(session_ids: list[str]) -> set[str]:
     Returns:
         set[str]: Session identifiers that existed and were released.
     """
+    session_ids = list(dict.fromkeys(str(session_id) for session_id in session_ids))
     if not session_ids:
         return set()
 

--- a/xtuner/v1/rl/rollout/trace_store.py
+++ b/xtuner/v1/rl/rollout/trace_store.py
@@ -511,11 +511,9 @@ async def release_existing_sessions(session_ids: list[str]) -> set[str]:
 async def release_and_discard_rollout_groups(groups: list[list[RolloutState]]) -> None:
     """Release trace-owned resources before discarding terminal rollouts.
 
-    Sessions released by the trace store have already freed their routed-expert
-    references. Detach those references before the generic rollout-state
-    cleanup so it does not explicitly free them a second time. Rollouts whose
-    sessions are absent from the store retain their references for the generic
-    cleanup path.
+    Sessions released by the trace store have already freed their routed-expert references. Detach those references
+    before the generic rollout-state cleanup so it does not explicitly free them a second time. Rollouts whose sessions
+    are absent from the store retain their references for the generic cleanup path.
     """
     released_session_ids = await release_existing_sessions(
         [str(item.session_id) for group in groups for item in group if item.session_id is not None]

--- a/xtuner/v1/rl/rollout/trace_store.py
+++ b/xtuner/v1/rl/rollout/trace_store.py
@@ -335,6 +335,23 @@ class RolloutTraceStore:
         trie = self.sessions.pop(session_id) if key is None else self.sessions[session_id]
         trie.release(key)
 
+    def release_sessions(self, session_ids: list[str]) -> list[str]:
+        """Release existing trace sessions in one actor call.
+
+        Args:
+            session_ids (list[str]): Session identifiers that no longer own live rollout state.
+
+        Returns:
+            list[str]: Session identifiers that existed and were released.
+        """
+        released_session_ids = []
+        for session_id in dict.fromkeys(session_ids):
+            if session_id not in self.sessions:
+                continue
+            self.release(session_id)
+            released_session_ids.append(session_id)
+        return released_session_ids
+
     def release_all(self):
         """Release all sessions and free associated resources."""
         for session_id in list(self.sessions):
@@ -462,12 +479,33 @@ def get_existing_store():
     global _handle_cache
     if _handle_cache is not None:
         return _handle_cache
+    if not ray.is_initialized():
+        return None
 
     try:
         _handle_cache = ray.get_actor(_STORE_NAME, namespace=_STORE_NAMESPACE)
     except ValueError:
         return None
     return _handle_cache
+
+
+async def release_existing_sessions(session_ids: list[str]) -> set[str]:
+    """Release trace sessions that exist without creating the singleton store.
+
+    Args:
+        session_ids (list[str]): Candidate trace session identifiers.
+
+    Returns:
+        set[str]: Session identifiers that existed and were released.
+    """
+    if not session_ids:
+        return set()
+
+    store = get_existing_store()
+    if store is None:
+        return set()
+
+    return set(await store.release_sessions.remote(session_ids))
 
 
 if __name__ == "__main__":

--- a/xtuner/v1/rl/rollout/trace_store.py
+++ b/xtuner/v1/rl/rollout/trace_store.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import ray
 from pydantic import BaseModel, ConfigDict, Field
 
+from xtuner.v1.data_proto.rl_data import RolloutState, discard_rollout_state
 from xtuner.v1.utils import get_logger
 
 
@@ -354,9 +355,7 @@ class RolloutTraceStore:
 
     def release_all(self):
         """Release all sessions and free associated resources."""
-        for session_id in list(self.sessions):
-            self.release(session_id)
-        self.sessions.clear()
+        self.release_sessions(list(self.sessions))
         self.objects.clear()
         self.updated_at.clear()
 
@@ -507,6 +506,25 @@ async def release_existing_sessions(session_ids: list[str]) -> set[str]:
         return set()
 
     return set(await store.release_sessions.remote(session_ids))
+
+
+async def release_and_discard_rollout_groups(groups: list[list[RolloutState]]) -> None:
+    """Release trace-owned resources before discarding terminal rollouts.
+
+    Sessions released by the trace store have already freed their routed-expert
+    references. Detach those references before the generic rollout-state
+    cleanup so it does not explicitly free them a second time. Rollouts whose
+    sessions are absent from the store retain their references for the generic
+    cleanup path.
+    """
+    released_session_ids = await release_existing_sessions(
+        [str(item.session_id) for group in groups for item in group if item.session_id is not None]
+    )
+    for group in groups:
+        for item in group:
+            if item.session_id is not None and str(item.session_id) in released_session_ids:
+                item.routed_experts = None
+            discard_rollout_state(item)
 
 
 if __name__ == "__main__":

--- a/xtuner/v1/rl/rollout/trace_store.py
+++ b/xtuner/v1/rl/rollout/trace_store.py
@@ -476,10 +476,11 @@ def get_store():
 def get_existing_store():
     """Return the existing singleton store actor without creating one."""
     global _handle_cache
+    if not ray.is_initialized():
+        _handle_cache = None
+        return None
     if _handle_cache is not None:
         return _handle_cache
-    if not ray.is_initialized():
-        return None
 
     try:
         _handle_cache = ray.get_actor(_STORE_NAME, namespace=_STORE_NAMESPACE)

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -95,7 +95,7 @@ def _trainer_config_requires_rollout_proxy(cfg: "BaseRLTrainerConfig") -> bool:
     ) or _agent_loop_manager_requires_rollout_proxy(cfg.eval_agent_loop_manager_cfg)
 
 
-# 在使用了 trace_store 情况下，我们不能提前释放 obj ref 而是由 _release_trace_store 统一释放
+# 在使用了 trace_store 情况下，我们不能提前释放 obj ref，而是由 trainer 在消费后统一释放
 # 这样可以确保一拆多情况下正确。判断逻辑和 rollout_proxy 一致。
 def _agent_loop_manager_uses_trace_store(
     cfg: AgentLoopManagerConfig | DisaggAgentLoopManagerConfig | None,
@@ -103,6 +103,18 @@ def _agent_loop_manager_uses_trace_store(
     # Agent loops that require the rollout proxy currently export train traces
     # through RolloutTraceStore. Those trace refs are shared across segments.
     return _agent_loop_manager_requires_rollout_proxy(cfg)
+
+
+def _trace_session_ids(rollout_batches: list[list[RolloutState]]) -> list[str]:
+    """Return stable, unique trace session ids owned by rollout batches."""
+    return list(
+        dict.fromkeys(
+            str(rollout_state.session_id)
+            for group in rollout_batches
+            for rollout_state in group
+            if rollout_state.session_id is not None
+        )
+    )
 
 
 def check_fa3():
@@ -859,6 +871,7 @@ class BaseRLTrainer:
             self.tokenizer.save_pretrained(str(save_hf_path))
 
     async def _run_initial_evaluate(self) -> None:
+        eval_batch: list[list[RolloutState]] = []
         try:
             eval_produce_result = await self.eval_agent_loop_manager.produce_batch(
                 self.evaluator.eval_batch_size,
@@ -880,39 +893,44 @@ class BaseRLTrainer:
             tb_scores = {f"eval/{k}": v for k, v in eval_metrics.items()}
             self._exp_tracker.add_scalars(tag_scalar_dict=tb_scores, global_step=0)
         finally:
-            self._release_trace_store()
+            self._release_trace_sessions(_trace_session_ids(eval_batch))
 
-    def _release_trace_store(self, train_batch: list[list[RolloutState]] | None = None) -> None:
+    def _release_trace_sessions(self, session_ids: list[str]) -> set[str]:
+        from xtuner.v1.rl.rollout.trace_store import get_existing_store
+
+        session_ids = list(dict.fromkeys(str(session_id) for session_id in session_ids))
+        if not session_ids:
+            return set()
+
+        store = get_existing_store()
+        if store is None:
+            return set()
+
+        released_session_ids = ray.get(store.release_sessions.remote(session_ids))
+        self.logger.info(
+            "Release owned trace sessions and preserve sessions held by other consumers: "
+            f"released={len(released_session_ids)}, requested={len(session_ids)}"
+        )
+        return set(released_session_ids)
+
+    def _release_all_trace_sessions(self) -> None:
         from xtuner.v1.rl.rollout.trace_store import get_existing_store
 
         store = get_existing_store()
         if store is None:
             return
 
-        if train_batch is None:
-            self.logger.info("Release all sessions and free associated resources")
-            ray.get(store.release_all.remote())
-            keys = ray.get(store.list_sessions.remote())
-            # A leftover session key should stay visible without crashing fit()
-            # during teardown.
-            if keys:
-                self.logger.warning(f"Trace store keys not released after release_all: {keys}")
-            return
+        self.logger.info("Release all sessions and free associated resources")
+        ray.get(store.release_all.remote())
+        keys = ray.get(store.list_sessions.remote())
+        # A leftover session key should stay visible without crashing fit()
+        # during teardown.
+        if keys:
+            self.logger.warning(f"Trace store keys not released after release_all: {keys}")
 
-        session_ids = {
-            str(rollout_state.session_id)
-            for group in train_batch
-            for rollout_state in group
-            if rollout_state.session_id is not None
-        }
-        if not session_ids:
-            return
-
-        released_session_ids = ray.get(store.release_sessions.remote(sorted(session_ids)))
-        self.logger.info(
-            "Release consumed trace sessions and preserve concurrent rollout sessions: "
-            f"released={len(released_session_ids)}, requested={len(session_ids)}"
-        )
+    def _release_trace_sessions_after_train_batch(self, train_batch: list[list[RolloutState]]) -> None:
+        """Release training traces when no concurrent rollout owner exists."""
+        self._release_all_trace_sessions()
 
     def _train_one_batch(
         self,
@@ -922,7 +940,6 @@ class BaseRLTrainer:
         *,
         offload_rollout_before_train: bool = False,
         onload_train_before_train: bool = False,
-        release_only_consumed_trace_sessions: bool = False,
         raw_rewards_sum: float = 0.0,
         raw_rewards_count: int = 0,
     ) -> TrainInfo:
@@ -967,13 +984,7 @@ class BaseRLTrainer:
                 rollout_idx=train_step,
             )
 
-        if release_only_consumed_trace_sessions:
-            # Disaggregated rollout keeps producing while learner.fit() runs. Release
-            # only the sessions consumed by this batch so concurrent rollout traces
-            # remain valid until their own batches are trained.
-            self._release_trace_store(train_batch)
-        else:
-            self._release_trace_store()
+        self._release_trace_sessions_after_train_batch(train_batch)
 
         return {
             "data_info": data_info,
@@ -981,6 +992,7 @@ class BaseRLTrainer:
         }
 
     async def _run_evaluation(self, train_step: int) -> dict[str, float]:
+        eval_batch: list[list[RolloutState]] = []
         try:
             eval_produce_result = await self.eval_agent_loop_manager.produce_batch(
                 self.evaluator.eval_batch_size,
@@ -1000,7 +1012,7 @@ class BaseRLTrainer:
             self.logger.info(f"Train step {train_step} eval trajectories saved to {eval_trajectory_path}")
             return eval_metrics
         finally:
-            self._release_trace_store()
+            self._release_trace_sessions(_trace_session_ids(eval_batch))
 
     def _save_debug_rollout_batch(self, train_batch: list[list[RolloutState]], train_step: int) -> None:
         assert self._debug_rollout_dir is not None
@@ -1874,6 +1886,10 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
 
         self._cpu_resource_manager.log_registered_summary()
 
+    def _release_trace_sessions_after_train_batch(self, train_batch: list[list[RolloutState]]) -> None:
+        """Release only consumed traces while the background producer runs."""
+        self._release_trace_sessions(_trace_session_ids(train_batch))
+
     def _build_disaggregated_placement_groups(
         self,
         train_resources: AcceleratorResourcesConfig,
@@ -2007,7 +2023,6 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
                             train_batch,
                             train_step,
                             step_timer_dict,
-                            release_only_consumed_trace_sessions=True,
                             raw_rewards_sum=produce_result.raw_rewards_sum,
                             raw_rewards_count=produce_result.raw_rewards_count,
                         )

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -882,20 +882,37 @@ class BaseRLTrainer:
         finally:
             self._release_trace_store()
 
-    def _release_trace_store(self) -> None:
+    def _release_trace_store(self, train_batch: list[list[RolloutState]] | None = None) -> None:
         from xtuner.v1.rl.rollout.trace_store import get_existing_store
 
         store = get_existing_store()
         if store is None:
             return
 
-        self.logger.info("Release all sessions and free associated resources")
-        ray.get(store.release_all.remote())
-        keys = ray.get(store.list_sessions.remote())
-        # NOTE: previously asserted ``len(keys) == 0`` here, but a leftover session key should not crash the whole
-        # fit() at teardown. Warn instead so the leak stays visible without aborting the run.
-        if keys:
-            self.logger.warning(f"Trace store keys not released after release_all: {keys}")
+        if train_batch is None:
+            self.logger.info("Release all sessions and free associated resources")
+            ray.get(store.release_all.remote())
+            keys = ray.get(store.list_sessions.remote())
+            # A leftover session key should stay visible without crashing fit()
+            # during teardown.
+            if keys:
+                self.logger.warning(f"Trace store keys not released after release_all: {keys}")
+            return
+
+        session_ids = {
+            str(rollout_state.session_id)
+            for group in train_batch
+            for rollout_state in group
+            if rollout_state.session_id is not None
+        }
+        if not session_ids:
+            return
+
+        released_session_ids = ray.get(store.release_sessions.remote(sorted(session_ids)))
+        self.logger.info(
+            "Release consumed trace sessions and preserve concurrent rollout sessions: "
+            f"released={len(released_session_ids)}, requested={len(session_ids)}"
+        )
 
     def _train_one_batch(
         self,
@@ -905,6 +922,7 @@ class BaseRLTrainer:
         *,
         offload_rollout_before_train: bool = False,
         onload_train_before_train: bool = False,
+        release_only_consumed_trace_sessions: bool = False,
         raw_rewards_sum: float = 0.0,
         raw_rewards_count: int = 0,
     ) -> TrainInfo:
@@ -949,7 +967,13 @@ class BaseRLTrainer:
                 rollout_idx=train_step,
             )
 
-        self._release_trace_store()
+        if release_only_consumed_trace_sessions:
+            # Disaggregated rollout keeps producing while learner.fit() runs. Release
+            # only the sessions consumed by this batch so concurrent rollout traces
+            # remain valid until their own batches are trained.
+            self._release_trace_store(train_batch)
+        else:
+            self._release_trace_store()
 
         return {
             "data_info": data_info,
@@ -1983,6 +2007,7 @@ class RLDisaggregatedTrainer(BaseRLTrainer):
                             train_batch,
                             train_step,
                             step_timer_dict,
+                            release_only_consumed_trace_sessions=True,
                             raw_rewards_sum=produce_result.raw_rewards_sum,
                             raw_rewards_count=produce_result.raw_rewards_count,
                         )


### PR DESCRIPTION
## Summary

This PR fixes the ownership and cleanup of agentic rollout trace sessions in disaggregated RL training.

- Release only the trace sessions consumed by the current learner batch.
- Preserve sessions created concurrently by the background producer and sessions that remain retryable in the replay buffer.
- Release terminal failed/filtered rollouts and non-retryable expired rollouts that will never reach the learner.
- Add regression tests for trainer, producer, and replay-buffer cleanup paths.

## Root Cause

`RLDisaggregatedTrainer` intentionally keeps its background producer running while the learner trains the current batch. During that overlap, the `RolloutTraceStore` contains sessions with different owners:

1. sessions belonging to the batch already consumed by the learner; and
2. sessions that the producer has concurrently created for future replay-buffer batches.

The inherited post-batch cleanup called `RolloutTraceStore.release_all()`. That operation assumed a batch-synchronous lifecycle in which every live session belonged to the completed learner batch. The assumption is not valid for disaggregated training, so cleanup could delete producer-owned sessions and force-free their Ray-backed `routed_experts` while future rollout states still referenced them.

Ray preserves ordering for calls from one caller, but it does not provide a global ordering across the learner and producer callers. Consequently, the same race could surface in more than one form:

- the learner clears the store, the producer inserts a new session, and the learner's subsequent empty-store assertion observes the new session; or
- a future rollout/replay entry keeps references to data cleared by the learner, later causing trace prompt mismatches or stale `ObjectRef` failures when the data is consumed or checkpointed.

A short one-step asynchronous smoke test can miss the problem when cleanup happens before the next producer insertion, or when the prefetched batch is immediately aborted at shutdown and never consumed. The failure becomes reproducible when producer progress overlaps the learner's post-batch cleanup.

This is therefore an XTuner lifecycle bug in the combination of disaggregated training, agentic trace storage, and concurrent prefetch; it is not caused by a sandbox configuration.

## Fix

### Selective trainer cleanup

Add an atomic, idempotent `RolloutTraceStore.release_sessions(session_ids)` actor method and use it after a disaggregated learner batch. The trainer extracts the sessions represented by the consumed batch and releases only those sessions. Colocated and evaluation cleanup retain their existing full-store behavior.

The actor method ignores already-absent IDs and returns the IDs it actually released. Keeping the lookup and release in one actor RPC avoids a client-side list/intersection/release time-of-check/time-of-use window.

### Terminal discard cleanup

Selective post-batch cleanup means a rollout that will never reach `train_batch()` needs an explicit terminal cleanup path. This PR therefore releases trace sessions before discarding:

- failed or filtered producer groups; and
- expired replay-buffer groups that are marked non-retryable.

Retryable expired groups retain their sessions because they may re-enter the training lifecycle. When trace cleanup has already freed the routed-expert objects, the corresponding local field is cleared before generic rollout-state disposal to avoid a second explicit free.

## Impact

- **`ProduceBatchResult`:** no status, reward, timing, rollout-state, or accounting semantics are changed.
- **`RoutedExperts`:** references for consumed or terminally discarded sessions are freed exactly once; references owned by concurrent or retryable rollouts remain valid until their owning lifecycle ends.
- **Ray concurrency:** no actor concurrency groups or scheduling policy are changed. Cleanup is one lightweight actor RPC over the session IDs represented by the batch/discarded group.
- **Performance:** no model forward, backward, or weight-sync hot path is changed. The added work is linear in the small number of session IDs being released, so a separate performance benchmark is not expected to be meaningful.

## Reproduction

The issue was observed in a three-node disaggregated run with 8 learner GPUs and 16 rollout GPUs:

1. the learner starts training a completed rollout batch;
2. the background producer continues opening trace sessions for the next batch;
3. the learner completes backward and performs post-batch trace cleanup;
4. global cleanup removes sessions that were not part of the learner batch, leading to a non-empty-store assertion, prompt mismatch, or a stale Ray object later in replay/checkpoint handling depending on cross-caller timing.

The trainer regression test models this deterministically with one consumed session and one concurrently produced session, then verifies that only the consumed session is released.

## Test Plan

- Targeted regression tests for:
  - consumed-only cleanup in `RLDisaggregatedTrainer`;
  - failed/filtered producer cleanup;
  - terminal expired replay cleanup; and
  - preservation of retryable expired sessions.
- Result: `5 passed`.
- Ruff checks on all changed files: passed.
- Python byte-compilation of the changed production modules: passed.
- `git diff --check`: passed.
- Three-node, 24-GPU disaggregated smoke:
  - verified that the consumed batch was released while five concurrent sessions remained live;
  - completed learner forward/backward, producer pause, DCP/HF checkpoint, 16-rank weight synchronization, Ray shutdown, and all three replicas successfully.

The full repository matrix is left to upstream CI.

## Out of Scope

This PR does not change replay-checkpoint serialization. The stale replay `ObjectRef` symptom can be caused by the same premature trace release, but serialization policy and timeout diagnostics are separate concerns.
