### PR TITLE
feat(muon): split fused QKV projections

### DIFF
--- a/xtuner/v1/model/compose/qwen3_vl/modeling_vision.py
+++ b/xtuner/v1/model/compose/qwen3_vl/modeling_vision.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Callable
+from typing import List, Callable, cast
 from xtuner.v1.ops.act_fn import get_act_fn
 import torch.nn as nn
 import torch
@@ -131,6 +131,10 @@ class Qwen3VLVisionAttention(nn.Module):
         self.config = config
         self.attention_dropout = 0.0
         self.attn_impl_func: Callable[..., AttnOpOutputs] = get_attn_impl_fn(config.attn_impl)  # type: ignore[assignment]
+
+    def get_muon_split_sizes(self) -> dict[nn.Parameter, tuple[int, ...]]:
+        """Return the logical Q, K, and V row blocks for MuonSplit."""
+        return {cast(nn.Parameter, self.qkv.weight): (self.dim, self.dim, self.dim)}
 
     def forward(
         self,

--- a/xtuner/v1/module/attention/gated_deltanet.py
+++ b/xtuner/v1/module/attention/gated_deltanet.py
@@ -185,6 +185,16 @@ class GatedDeltaNet(nn.Module):
         self.in_proj_b = build_linear(self.hidden_size, self.num_v_heads, bias=False)
         self.in_proj_a = build_linear(self.hidden_size, self.num_v_heads, bias=False)
 
+    def get_muon_split_sizes(self) -> dict[nn.Parameter, tuple[int, ...]]:
+        """Return the logical Q, K, and V row blocks for MuonSplit."""
+        return {
+            cast(nn.Parameter, self.in_proj_qkv.weight): (
+                self.key_dim,
+                self.key_dim,
+                self.value_dim,
+            )
+        }
+
     def forward_for_sp(
         self,
         hidden_states: torch.Tensor,


### PR DESCRIPTION
## Motivation

Muon should orthogonalize the logical projections inside a fused QKV weight independently.

Treating a fused QKV weight as a single matrix couples unrelated Q, K, and V updates during Newton-Schulz orthogonalization and applies learning-rate scaling based on the combined matrix shape.

This PR uses the `get_muon_split_sizes()` interface introduced in #2001 to expose the logical row blocks of fused QKV parameters.

## Changes

- Add Muon split metadata for GatedDeltaNet `in_proj_qkv.weight`:
  - Q: `key_dim`
  - K: `key_dim`
  - V: `value_dim`
- Add Muon split metadata for Qwen3-VL Vision `qkv.weight`:
  - Q: `dim`
  - K: `dim`
  - V: `dim`
- Keep the forward computation and parameter layout unchanged.

The Muon optimizer configuration discovers these mappings through the module-level `get_muon_split_sizes()` interface and processes each logical projection independently.