### PR TITLE
[Feature] Configure prefix caching for rollout engines

### DIFF
--- a/xtuner/v1/rl/rollout/lmdeploy.py
+++ b/xtuner/v1/rl/rollout/lmdeploy.py
@@ -398,6 +398,8 @@ class LMDeployWorker(RolloutWorker):
             hf_overrides.update(fp32_lm_head=self.config.fp32_lm_head)
         if backend == "pytorch" and self.config.max_prefill_token_num:
             extra_engine_config["max_prefill_token_num"] = self.config.max_prefill_token_num
+        if backend == "pytorch" and self.config.enable_prefix_caching:
+            extra_engine_config["enable_prefix_caching"] = True
 
         assert self.server_launch_spec is not None
         dp_rank = 0

--- a/xtuner/v1/rl/rollout/vllm.py
+++ b/xtuner/v1/rl/rollout/vllm.py
@@ -318,7 +318,7 @@ class vLLMWorker(RolloutWorker):
         args["enable_sleep_mode"] = True
         args["worker_extension_cls"] = "xtuner.v1.rl.rollout.vllm.WorkerWrap"
         args["trust_remote_code"] = True
-        args["enable_prefix_caching"] = False
+        args["enable_prefix_caching"] = self.config.enable_prefix_caching
         args["allowed_local_media_path"] = "/"
         args["mm_processor_cache_gb"] = 0
         args["max_num_batched_tokens"] = 4096

--- a/xtuner/v1/rl/rollout/worker.py
+++ b/xtuner/v1/rl/rollout/worker.py
@@ -351,6 +351,13 @@ class RolloutConfig(BaseModel):
             help="Use float32 for language model head.",
         ),
     ] = False
+    enable_prefix_caching: Annotated[
+        bool,
+        Parameter(
+            group=infer_group,
+            help="Whether to enable prefix caching for the rollout worker.",
+        ),
+    ] = False
     worker_log_dir: Annotated[Path, Parameter(help="Directory to save worker logs.")] = Path.cwd() / "work_dir"
     health_check_interval_seconds: Annotated[
         float,


### PR DESCRIPTION
## Motivation

Rollout backends support prefix caching, but XTuner does not expose a common configuration for enabling it. LMDeploy currently requires an engine-specific extra config, while vLLM hard-codes prefix caching off.

## Changes

- Add an opt-in `RolloutConfig.enable_prefix_caching` option, disabled by default.
- Forward the option to the LMDeploy PyTorch engine configuration.
- Forward the same option to the vLLM server configuration.
- Add coverage for the default and opt-in configuration behavior.

## Tests

- `ruff check xtuner/v1/rl/rollout/worker.py xtuner/v1/rl/rollout/lmdeploy.py xtuner/v1/rl/rollout/vllm.py tests/rl/test_rollout_config_dist_port_base_patch.py`
- `pytest tests/rl/test_rollout_config_dist_port_base_patch.py tests/rl/test_rollout_logic.py -q`