### PR TITLE
[Feature] Instrument sandbox agents and SessionServer tracing

### DIFF
--- a/tests/rl/test_trace.py
+++ b/tests/rl/test_trace.py
@@ -3,12 +3,12 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import types
 import unittest
+import unittest.mock
 from contextlib import contextmanager
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from unittest import mock
 
 
 def _run_trace_utils(repo_root: Path, command: str) -> dict:
@@ -70,8 +70,8 @@ class TestTrace(unittest.TestCase):
                 return "object-ref"
 
         with (
-            mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
-            mock.patch.object(
+            unittest.mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
+            unittest.mock.patch.object(
                 rollout_api.trace_api,
                 "inject_trace_context",
                 return_value={"traceparent": "00-trace-span-01"},
@@ -108,8 +108,8 @@ class TestTrace(unittest.TestCase):
                 return "object-ref"
 
         with (
-            mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
-            mock.patch.object(
+            unittest.mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
+            unittest.mock.patch.object(
                 rollout_api.trace_api,
                 "inject_trace_context",
                 return_value={"traceparent": "current"},
@@ -137,8 +137,12 @@ class TestTrace(unittest.TestCase):
                 remote_method = RemoteMethod()
                 states = []
                 with (
-                    mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=trace_enabled),
-                    mock.patch.object(rollout_api.trace_api, "inject_trace_context", return_value={}),
+                    unittest.mock.patch.object(
+                        rollout_api, "is_rollout_trace_enabled", return_value=trace_enabled
+                    ),
+                    unittest.mock.patch.object(
+                        rollout_api.trace_api, "inject_trace_context", return_value={}
+                    ),
                 ):
                     result = rollout_api.trace_rollout_remote(remote_method, states, target=states)
 
@@ -267,9 +271,13 @@ class TestRolloutEndpointTrace(unittest.IsolatedAsyncioTestCase):
 
                 state = RolloutState(message=[], rollout_id=1)
                 with (
-                    mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
-                    mock.patch.object(rollout_api.trace_api, "trace_span", side_effect=passthrough_span),
-                    mock.patch.object(rollout_api.trace_api, "set_trace_attributes"),
+                    unittest.mock.patch.object(
+                        rollout_api, "is_rollout_trace_enabled", return_value=True
+                    ),
+                    unittest.mock.patch.object(
+                        rollout_api.trace_api, "trace_span", side_effect=passthrough_span
+                    ),
+                    unittest.mock.patch.object(rollout_api.trace_api, "set_trace_attributes"),
                 ):
                     result = await endpoint(state)
 
@@ -300,9 +308,9 @@ class TestRolloutEndpointTrace(unittest.IsolatedAsyncioTestCase):
             yield
 
         with (
-            mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
-            mock.patch.object(rollout_api.trace_api, "trace_span", side_effect=capture_span),
-            mock.patch.object(rollout_api.trace_api, "set_trace_attributes"),
+            unittest.mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
+            unittest.mock.patch.object(rollout_api.trace_api, "trace_span", side_effect=capture_span),
+            unittest.mock.patch.object(rollout_api.trace_api, "set_trace_attributes"),
         ):
             result = await endpoint(state)
 
@@ -338,12 +346,12 @@ class TestSessionServerTrace(unittest.IsolatedAsyncioTestCase):
             yield
 
         with (
-            mock.patch.object(session_server, "trace_span", side_effect=capture_span),
-            mock.patch.object(session_server, "set_trace_attributes") as set_attributes,
-            mock.patch.object(
+            unittest.mock.patch.object(session_server, "trace_span", side_effect=capture_span),
+            unittest.mock.patch.object(session_server, "set_trace_attributes") as set_attributes,
+            unittest.mock.patch.object(
                 session_server.SessionServer,
                 "_handle_request_impl",
-                new=mock.AsyncMock(return_value=response),
+                new=unittest.mock.AsyncMock(return_value=response),
             ),
         ):
             result = await server._handle_request(request)
@@ -385,9 +393,9 @@ class TestSessionServerTrace(unittest.IsolatedAsyncioTestCase):
 
         headers = {}
         with (
-            mock.patch.object(session_server, "trace_span", side_effect=capture_span),
-            mock.patch.object(session_server, "inject_trace_context", side_effect=inject),
-            mock.patch.object(session_server, "set_trace_attributes") as set_attributes,
+            unittest.mock.patch.object(session_server, "trace_span", side_effect=capture_span),
+            unittest.mock.patch.object(session_server, "inject_trace_context", side_effect=inject),
+            unittest.mock.patch.object(session_server, "set_trace_attributes") as set_attributes,
         ):
             async with server._backend_request(
                 Client(),
@@ -432,12 +440,14 @@ class TestSandboxTraceBridge(unittest.TestCase):
             observed_spans.append((name, dict(attributes or {})))
             yield
 
-        with TemporaryDirectory() as temp_dir, mock.patch.dict(os.environ, {"WORK_DIR": temp_dir}):
+        with tempfile.TemporaryDirectory() as temp_dir, unittest.mock.patch.dict(
+            os.environ, {"WORK_DIR": temp_dir}
+        ):
             sandbox_trace._reset_for_testing()
             sandbox_trace.init_writer(actor_id="test")
             with (
-                mock.patch.object(sandbox_trace, "trace_span", side_effect=capture_span),
-                mock.patch.object(
+                unittest.mock.patch.object(sandbox_trace, "trace_span", side_effect=capture_span),
+                unittest.mock.patch.object(
                     sandbox_trace,
                     "set_trace_attributes",
                     side_effect=lambda attrs: observed_final_attributes.append(dict(attrs)),

--- a/tests/rl/test_trace.py
+++ b/tests/rl/test_trace.py
@@ -1,9 +1,14 @@
+import importlib.util
 import json
 import os
 import subprocess
 import sys
+import types
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
 
 
 def _run_trace_utils(repo_root: Path, command: str) -> dict:
@@ -34,12 +39,13 @@ class TestTrace(unittest.TestCase):
         self.assertEqual(output["failure_attributes"]["error.type"], "RuntimeError")
         self.assertEqual(output["failure_attributes"]["error.message"], "boom")
 
-    def test_injected_parent_carrier_links_child_span_in_another_process(self):
+    def test_mixed_case_parent_carrier_links_child_span_in_another_process(self):
         repo_root = Path(__file__).resolve().parents[2]
         output = _run_trace_utils(repo_root, "parent-child")
 
         self.assertEqual(output["child"]["trace_id"], output["parent_trace_id"])
         self.assertEqual(output["child"]["parent_span_id"], output["parent_span_id"])
+        self.assertIn("Traceparent", output["child"]["carrier_keys"])
 
     def test_nested_trace_span_preserves_parent_to_child_order(self):
         repo_root = Path(__file__).resolve().parents[2]
@@ -48,6 +54,96 @@ class TestTrace(unittest.TestCase):
         self.assertEqual(output["child_parent_span_id"], output["parent_span_id"])
         self.assertEqual(output["span_name_paths"]["order.parent"], ["order.parent"])
         self.assertEqual(output["span_name_paths"]["order.child"], ["order.parent", "order.child"])
+
+    def test_rollout_remote_propagates_and_cleans_batch_carriers(self):
+        from xtuner.v1.data_proto.rl_data import RolloutState
+        from xtuner.v1.rl.trace import rollout_api
+
+        states = [RolloutState(message=[], rollout_id=index) for index in (1, 2)]
+        observed_carriers = []
+
+        class RemoteMethod:
+            def remote(self, rollout_states):
+                observed_carriers.extend(
+                    dict(state.extra_fields[rollout_api.TRACE_CARRIER_EXTRA_FIELD]) for state in rollout_states
+                )
+                return "object-ref"
+
+        with (
+            mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
+            mock.patch.object(
+                rollout_api.trace_api,
+                "inject_trace_context",
+                return_value={"traceparent": "00-trace-span-01"},
+            ),
+        ):
+            result = rollout_api.trace_rollout_remote(
+                RemoteMethod(),
+                states,
+                target=states,
+            )
+
+        self.assertEqual(result, "object-ref")
+        self.assertEqual(
+            observed_carriers,
+            [{"traceparent": "00-trace-span-01"}, {"traceparent": "00-trace-span-01"}],
+        )
+        self.assertTrue(all(rollout_api.TRACE_CARRIER_EXTRA_FIELD not in state.extra_fields for state in states))
+
+    def test_rollout_remote_restores_existing_single_carrier(self):
+        from xtuner.v1.data_proto.rl_data import RolloutState
+        from xtuner.v1.rl.trace import rollout_api
+
+        previous_carrier = {"traceparent": "previous"}
+        state = RolloutState(
+            message=[],
+            rollout_id=1,
+            extra_fields={rollout_api.TRACE_CARRIER_EXTRA_FIELD: previous_carrier},
+        )
+        observed = {}
+
+        class RemoteMethod:
+            def remote(self, rollout_state):
+                observed.update(rollout_state.extra_fields[rollout_api.TRACE_CARRIER_EXTRA_FIELD])
+                return "object-ref"
+
+        with (
+            mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
+            mock.patch.object(
+                rollout_api.trace_api,
+                "inject_trace_context",
+                return_value={"traceparent": "current"},
+            ),
+        ):
+            result = rollout_api.trace_rollout_remote(RemoteMethod(), state, target=state)
+
+        self.assertEqual(result, "object-ref")
+        self.assertEqual(observed, {"traceparent": "current"})
+        self.assertIs(state.extra_fields[rollout_api.TRACE_CARRIER_EXTRA_FIELD], previous_carrier)
+
+    def test_rollout_remote_accepts_empty_group_without_changing_call(self):
+        from xtuner.v1.rl.trace import rollout_api
+
+        class RemoteMethod:
+            def __init__(self):
+                self.calls = []
+
+            def remote(self, rollout_states):
+                self.calls.append(rollout_states)
+                return "object-ref"
+
+        for trace_enabled in (False, True):
+            with self.subTest(trace_enabled=trace_enabled):
+                remote_method = RemoteMethod()
+                states = []
+                with (
+                    mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=trace_enabled),
+                    mock.patch.object(rollout_api.trace_api, "inject_trace_context", return_value={}),
+                ):
+                    result = rollout_api.trace_rollout_remote(remote_method, states, target=states)
+
+                self.assertEqual(result, "object-ref")
+                self.assertEqual(remote_method.calls, [states])
 
     def test_viewer_uses_span_name_path_for_display_chain(self):
         from recipe.trace.viewer.payload import build_rollout_view_payload_from_jaeger_traces
@@ -149,6 +245,231 @@ class TestTrace(unittest.TestCase):
         self.assertEqual(payload["samples"][0]["stage"], "stage_two")
         self.assertIn("XTuner Rollout Trace Viewer", html)
         self.assertIn("stage_two", html)
+
+
+class TestRolloutEndpointTrace(unittest.IsolatedAsyncioTestCase):
+    async def test_deep_copied_batch_results_do_not_leak_call_chain(self):
+        from xtuner.v1.data_proto.rl_data import RolloutState
+        from xtuner.v1.rl.trace import rollout_api
+
+        @contextmanager
+        def passthrough_span(*args, **kwargs):
+            yield
+
+        for container_type in (list, tuple):
+            with self.subTest(container_type=container_type.__name__):
+
+                @rollout_api.trace_rollout_endpoint("test.endpoint")
+                async def endpoint(rollout_state):
+                    return container_type(
+                        (rollout_state.model_copy(deep=True), rollout_state.model_copy(deep=True))
+                    )
+
+                state = RolloutState(message=[], rollout_id=1)
+                with (
+                    mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
+                    mock.patch.object(rollout_api.trace_api, "trace_span", side_effect=passthrough_span),
+                    mock.patch.object(rollout_api.trace_api, "set_trace_attributes"),
+                ):
+                    result = await endpoint(state)
+
+                self.assertNotIn(rollout_api.TRACE_CALL_CHAIN_EXTRA_FIELD, state.extra_fields)
+                self.assertTrue(
+                    all(rollout_api.TRACE_CALL_CHAIN_EXTRA_FIELD not in item.extra_fields for item in result)
+                )
+
+    async def test_nested_endpoint_restores_existing_call_chain(self):
+        from xtuner.v1.data_proto.rl_data import RolloutState
+        from xtuner.v1.rl.trace import rollout_api
+
+        @rollout_api.trace_rollout_endpoint("test.inner")
+        async def endpoint(rollout_state):
+            return rollout_state.model_copy(deep=True)
+
+        previous_call_chain = ["test.outer"]
+        state = RolloutState(
+            message=[],
+            rollout_id=1,
+            extra_fields={rollout_api.TRACE_CALL_CHAIN_EXTRA_FIELD: previous_call_chain},
+        )
+        observed_paths = []
+
+        @contextmanager
+        def capture_span(name, attributes=None, *, parent_carrier=None):
+            observed_paths.append(attributes["xtuner.span_name_path"])
+            yield
+
+        with (
+            mock.patch.object(rollout_api, "is_rollout_trace_enabled", return_value=True),
+            mock.patch.object(rollout_api.trace_api, "trace_span", side_effect=capture_span),
+            mock.patch.object(rollout_api.trace_api, "set_trace_attributes"),
+        ):
+            result = await endpoint(state)
+
+        self.assertEqual(observed_paths, [("test.outer", "test.inner")])
+        self.assertIs(state.extra_fields[rollout_api.TRACE_CALL_CHAIN_EXTRA_FIELD], previous_call_chain)
+        self.assertIs(result.extra_fields[rollout_api.TRACE_CALL_CHAIN_EXTRA_FIELD], previous_call_chain)
+
+
+class TestSessionServerTrace(unittest.IsolatedAsyncioTestCase):
+    async def test_request_span_extracts_parent_and_records_status(self):
+        from multidict import CIMultiDict
+
+        from xtuner.v1.rl.rollout import session_server
+
+        server = object.__new__(session_server.SessionServer)
+        request = types.SimpleNamespace(
+            match_info={"path": "v1/chat/completions"},
+            headers=CIMultiDict(
+                {"Traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"}
+            ),
+            method="POST",
+        )
+        response = types.SimpleNamespace(status=201)
+        observed = {}
+
+        @contextmanager
+        def capture_span(name, attributes=None, *, parent_carrier=None):
+            observed.update(
+                name=name,
+                attributes=dict(attributes or {}),
+                parent_carrier=parent_carrier,
+            )
+            yield
+
+        with (
+            mock.patch.object(session_server, "trace_span", side_effect=capture_span),
+            mock.patch.object(session_server, "set_trace_attributes") as set_attributes,
+            mock.patch.object(
+                session_server.SessionServer,
+                "_handle_request_impl",
+                new=mock.AsyncMock(return_value=response),
+            ),
+        ):
+            result = await server._handle_request(request)
+
+        self.assertIs(result, response)
+        self.assertEqual(observed["name"], "session_server.request")
+        self.assertIs(observed["parent_carrier"], request.headers)
+        self.assertEqual(observed["parent_carrier"]["traceparent"], request.headers["Traceparent"])
+        set_attributes.assert_called_once_with({"http.response.status_code": 201, "error": False})
+
+    async def test_backend_roundtrip_injects_current_context(self):
+        from xtuner.v1.rl.rollout import session_server
+
+        server = object.__new__(session_server.SessionServer)
+        response = types.SimpleNamespace(status=503)
+        forwarded = {}
+        observed_spans = []
+
+        class RequestContext:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return False
+
+        class Client:
+            def request(self, **kwargs):
+                forwarded.update(kwargs)
+                return RequestContext()
+
+        @contextmanager
+        def capture_span(name, attributes=None, **kwargs):
+            observed_spans.append((name, dict(attributes or {})))
+            yield
+
+        def inject(headers):
+            headers["traceparent"] = "injected"
+            return headers
+
+        headers = {}
+        with (
+            mock.patch.object(session_server, "trace_span", side_effect=capture_span),
+            mock.patch.object(session_server, "inject_trace_context", side_effect=inject),
+            mock.patch.object(session_server, "set_trace_attributes") as set_attributes,
+        ):
+            async with server._backend_request(
+                Client(),
+                method="POST",
+                url="http://worker",
+                headers=headers,
+                trace_session_id="session-1",
+            ):
+                pass
+
+        self.assertEqual(headers["traceparent"], "injected")
+        self.assertIs(forwarded["headers"], headers)
+        set_attributes.assert_called_once_with({"http.upstream.status_code": 503, "error": True})
+        self.assertEqual(
+            observed_spans,
+            [
+                (
+                    "session_server.backend_roundtrip",
+                    {
+                        "xtuner.stage": "llm_backend_roundtrip",
+                        "xtuner.session_id": "session-1",
+                    },
+                )
+            ],
+        )
+
+
+class TestSandboxTraceBridge(unittest.TestCase):
+    def test_legacy_span_is_preserved_and_otel_schema_stays_minimal(self):
+        trace_path = Path(__file__).resolve().parents[2] / "xtuner/v1/rl/agent_loop/sandbox_agent_loop/trace.py"
+        spec = importlib.util.spec_from_file_location("sandbox_trace_test", trace_path)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        sandbox_trace = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(sandbox_trace)
+
+        observed_spans = []
+        observed_final_attributes = []
+
+        @contextmanager
+        def capture_span(name, attributes=None):
+            observed_spans.append((name, dict(attributes or {})))
+            yield
+
+        with TemporaryDirectory() as temp_dir, mock.patch.dict(os.environ, {"WORK_DIR": temp_dir}):
+            sandbox_trace._reset_for_testing()
+            sandbox_trace.init_writer(actor_id="test")
+            with (
+                mock.patch.object(sandbox_trace, "trace_span", side_effect=capture_span),
+                mock.patch.object(
+                    sandbox_trace,
+                    "set_trace_attributes",
+                    side_effect=lambda attrs: observed_final_attributes.append(dict(attrs)),
+                ),
+            ):
+                with sandbox_trace.span("session-1", "acquire", task_id="task-1") as handle:
+                    handle.annotate(
+                        sandbox_name="default",
+                        sandbox_image="sandbox:latest",
+                        sandbox_url="http://sandbox.internal/id",
+                    )
+                    handle.mark_error("acquire failed")
+                with sandbox_trace.span("session-1", "run_total"):
+                    pass
+            sandbox_trace._reset_for_testing()
+
+            legacy_files = list((Path(temp_dir) / "trace").glob("spans.*.jsonl"))
+            self.assertEqual(len(legacy_files), 1)
+            legacy_records = [json.loads(line) for line in legacy_files[0].read_text().splitlines()]
+
+        self.assertEqual(observed_spans[0][0], "sandbox.acquire")
+        self.assertEqual(observed_spans[0][1]["xtuner.session_id"], "session-1")
+        self.assertEqual(observed_spans[1][0], "sandbox_agent.execute")
+        self.assertEqual(observed_final_attributes[0]["sandbox.sandbox_name"], "default")
+        self.assertTrue(observed_final_attributes[0]["error"])
+        self.assertNotIn("sandbox.sandbox_url", observed_final_attributes[0])
+        self.assertNotIn("sandbox.duration_ms", observed_final_attributes[0])
+        self.assertNotIn("sandbox.ok", observed_final_attributes[0])
+        self.assertEqual([record["event"] for record in legacy_records], ["enter", "exit", "enter", "exit"])
+        self.assertEqual(legacy_records[1]["sandbox_url"], "http://sandbox.internal/id")
+        self.assertEqual(legacy_records[1]["ok"], False)
+        self.assertEqual(legacy_records[1]["err"], "acquire failed")
 
 
 if __name__ == "__main__":

--- a/tests/rl/trace_utils.py
+++ b/tests/rl/trace_utils.py
@@ -9,6 +9,7 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
+
 try:
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 except ImportError:
@@ -72,7 +73,10 @@ def record_span() -> None:
 
 
 def child_span() -> None:
-    carrier = json.loads(os.environ["XTUNER_TEST_TRACE_CARRIER"])
+    from multidict import CIMultiDict
+
+    serialized_carrier = json.loads(os.environ["XTUNER_TEST_TRACE_CARRIER"])
+    carrier = CIMultiDict({key.title(): value for key, value in serialized_carrier.items()})
     exporter = _install_in_memory_exporter()
 
     with (
@@ -89,6 +93,7 @@ def child_span() -> None:
             "span_id": f"{span.context.span_id:016x}",
             "parent_span_id": f"{span.parent.span_id:016x}" if span.parent else None,
             "span_name_path": list(span.attributes.get("xtuner.span_name_path") or []),
+            "carrier_keys": list(carrier),
         }
     )
 

--- a/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
+++ b/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
@@ -13,6 +13,7 @@ from lagent.utils import create_object
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
+from xtuner.v1.rl.trace.rollout_api import trace_rollout_endpoint
 from xtuner.v1.rl.utils import create_task
 
 from ...rollout.chat_template import canonicalize_messages_for_chat_template
@@ -250,6 +251,7 @@ class AgentInSandboxLoop(AgentLoop):
     # NOTE: A single sandbox session may yield multiple trainable segments, so this returns a list
     # rather than the base class's single RolloutState. The base contract is never exercised for
     # this loop (generate_group is the only entry point), so we override the return type here.
+    @trace_rollout_endpoint("agent_in_sandbox_loop.generate_sample")
     async def generate_sample(  # type: ignore[override]
         self, rollout_state: RolloutState, **kwargs
     ) -> list[RolloutState]:

--- a/xtuner/v1/rl/agent_loop/sandbox_agent_loop/runner.py
+++ b/xtuner/v1/rl/agent_loop/sandbox_agent_loop/runner.py
@@ -83,10 +83,10 @@ class Runner:
         t_infer: float | None = None
         t_validate: float | None = None
         try:
-            with span(uid_obs, "run_total", task_id=tid) as total_span:
+            with span(uid_obs, "run_total", task_id=tid, group_id=item.group_id) as total_span:
                 # ─── acquire infer sandbox ───────────────────────────────
                 t0 = time.monotonic()
-                with span(uid_obs, "acquire", task_id=tid) as acquire_span:
+                with span(uid_obs, "acquire", task_id=tid, group_id=item.group_id) as acquire_span:
                     infer_client = await pool.get(infer_sandbox, record=item.infer)
                     item.infer.sandbox_env_id = pool.env_id(infer_sandbox)
                     sandbox_url = pool.url(infer_sandbox)
@@ -97,12 +97,13 @@ class Runner:
                         sandbox_env_id=item.infer.sandbox_env_id,
                         sandbox_url=sandbox_url,
                         sandbox_image=infer_spec.image,
+                        sandbox_create_attempts=item.infer.metadata.get("sandbox_create_attempts"),
                     )
                 t_acquire = time.monotonic() - t0
 
                 # ─── infer ──────────────────────────────────────────────
                 t1 = time.monotonic()
-                with span(uid_obs, "infer", task_id=tid) as infer_span:
+                with span(uid_obs, "infer", task_id=tid, group_id=item.group_id) as infer_span:
                     infer_result = await self.infer.run(infer_client, item, item.infer)
                     if not infer_result.ok:
                         infer_span.mark_error(_format_error(item.infer.error))
@@ -113,17 +114,23 @@ class Runner:
 
                 # ─── validate ───────────────────────────────────────────
                 t2 = time.monotonic()
-                with span(uid_obs, "validate", task_id=tid):
+                with span(uid_obs, "validate", task_id=tid, group_id=item.group_id) as validate_span:
                     validate_name = self.validate.name
                     validate_record = item.judgers.setdefault(
                         validate_name,
                         StageRecord(judger_name=validate_name),
                     )
                     score = float(await self.validate.run(item, pool, validate_record))
+                    validate_span.annotate(reward=score)
                 t_validate = time.monotonic() - t2
                 item.reward = score
 
                 item.status = RolloutStatus.COMPLETED
+                total_span.annotate(
+                    status=item.status.value,
+                    reward=score,
+                    agent_name=item.infer.agent.name if item.infer.agent is not None else None,
+                )
                 return item
         except Exception as exc:
             promoted = (
@@ -140,7 +147,8 @@ class Runner:
             return self._fail(item, promoted)
         finally:
             self._log_final(tid, item, t_acquire, t_infer, t_validate)
-            await pool.release_all()
+            with span(uid_obs, "release", task_id=tid, group_id=item.group_id):
+                await pool.release_all()
 
     def _log_final(
         self,

--- a/xtuner/v1/rl/agent_loop/sandbox_agent_loop/trace.py
+++ b/xtuner/v1/rl/agent_loop/sandbox_agent_loop/trace.py
@@ -21,8 +21,8 @@ Each Ray actor writes its own two files so concurrent writes never contend
 a single file descriptor across processes. Line-buffered + per-line flush
 keeps ``tail -f`` and crash-recovery both simple.
 
-If the ``WORK_DIR`` environment variable is unset the module degrades to a
-zero-cost no-op — tests and local one-shot scripts never have to care.
+If the ``WORK_DIR`` environment variable is unset, legacy JSONL emission is
+disabled. The OTel bridge remains governed by XTuner's tracing configuration.
 """
 
 from __future__ import annotations
@@ -35,10 +35,30 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator, TextIO
 
+from xtuner.v1.rl.trace import set_trace_attributes, trace_span
 from xtuner.v1.utils import get_logger
 
 
 _writer: _TraceWriter | None = None
+
+_OTEL_STAGE_NAMES = {
+    "run_total": "sandbox_agent.execute",
+    "acquire": "sandbox.acquire",
+    "infer": "sandbox.infer",
+    "validate": "sandbox.validate",
+    "release": "sandbox.release",
+}
+
+# Keep the OTel schema stable and low-cardinality. The legacy JSONL records
+# continue to receive every annotation.
+_OTEL_ANNOTATION_KEYS = {
+    "agent_name",
+    "reward",
+    "sandbox_create_attempts",
+    "sandbox_image",
+    "sandbox_name",
+    "status",
+}
 
 
 def init_writer(actor_id: str | None = None) -> None:
@@ -169,29 +189,51 @@ def span(uid: str, stage: str, **extra: Any) -> Iterator[SpanHandle]:
         if extra:
             enter.update(extra)
         _writer.write_span(enter)
-    try:
-        yield handle
-    except BaseException as exc:
-        handle.ok = False
-        handle.err = f"{type(exc).__name__}: {exc}"
-        raise
-    finally:
-        duration_ms = int((time.monotonic() - t_start) * 1000)
-        if _writer is not None:
-            record: dict[str, Any] = {
-                "ts": time.time(),
-                "event": "exit",
-                "uid": uid,
-                "stage": stage,
-                "duration_ms": duration_ms,
-                "ok": handle.ok,
-                "err": handle.err,
-            }
-            if extra:
-                record.update(extra)
-            if handle.annotations:
-                record.update(handle.annotations)
-            _writer.write_span(record)
+    otel_name = _OTEL_STAGE_NAMES.get(stage, f"sandbox.{stage}")
+    otel_attributes = {
+        "xtuner.stage": otel_name,
+        "xtuner.session_id": uid,
+    }
+    if extra.get("task_id") is not None:
+        otel_attributes["sandbox.task_id"] = extra["task_id"]
+    if extra.get("group_id") is not None:
+        otel_attributes["xtuner.group_id"] = extra["group_id"]
+    with trace_span(otel_name, attributes=otel_attributes):
+        try:
+            yield handle
+        except BaseException as exc:
+            handle.ok = False
+            handle.err = f"{type(exc).__name__}: {exc}"
+            raise
+        finally:
+            duration_ms = int((time.monotonic() - t_start) * 1000)
+            final_attributes = {}
+            if not handle.ok:
+                final_attributes["error"] = True
+            final_attributes.update(
+                {
+                    f"sandbox.{key}": value
+                    for key, value in handle.annotations.items()
+                    if key in _OTEL_ANNOTATION_KEYS and value is not None
+                }
+            )
+            if final_attributes:
+                set_trace_attributes(final_attributes)
+            if _writer is not None:
+                record: dict[str, Any] = {
+                    "ts": time.time(),
+                    "event": "exit",
+                    "uid": uid,
+                    "stage": stage,
+                    "duration_ms": duration_ms,
+                    "ok": handle.ok,
+                    "err": handle.err,
+                }
+                if extra:
+                    record.update(extra)
+                if handle.annotations:
+                    record.update(handle.annotations)
+                _writer.write_span(record)
 
 
 def _reset_for_testing() -> None:

--- a/xtuner/v1/rl/agent_loop_manager/produce_utils.py
+++ b/xtuner/v1/rl/agent_loop_manager/produce_utils.py
@@ -21,6 +21,8 @@ from xtuner.v1.data_proto.rl_data import (
 from xtuner.v1.rl.agent_loop import AgentLoopSpec
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
 from xtuner.v1.rl.rollout.trace_store import release_and_discard_rollout_groups
+from xtuner.v1.rl.trace import trace_span
+from xtuner.v1.rl.trace.rollout_api import trace_rollout_remote
 from xtuner.v1.rl.utils import (
     AGENT_LOOP_PAUSE_REQUEST_TIMEOUT_S,
     PRODUCER_PAUSE_PENDING_TASK_TIMEOUT_S,
@@ -140,16 +142,27 @@ class BaseProduceContext:
             item.extra_fields["producer_future_step"] = self.train_step
 
         start = time.perf_counter()
-        if isinstance(self.agent_loop, ray.actor.ActorHandle):
-            result = await self.agent_loop.generate_group.remote(
-                rollout_state,
-                enable_partial_rollout=enable_partial_rollout,
-            )
-        else:
-            result = await self.agent_loop.generate_group(
-                rollout_state,
-                enable_partial_rollout=enable_partial_rollout,
-            )
+        with trace_span(
+            "agent_loop_manager.generate_group",
+            attributes={
+                "xtuner.stage": "agent_loop.generate_group",
+                "xtuner.task_name": self.task_name,
+                "xtuner.producer_future_step": self.train_step,
+                "rollout.group_size": len(rollout_state),
+            },
+        ):
+            if isinstance(self.agent_loop, ray.actor.ActorHandle):
+                result = await trace_rollout_remote(
+                    self.agent_loop.generate_group,
+                    rollout_state,
+                    enable_partial_rollout=enable_partial_rollout,
+                    target=rollout_state,
+                )
+            else:
+                result = await self.agent_loop.generate_group(
+                    rollout_state,
+                    enable_partial_rollout=enable_partial_rollout,
+                )
         elapsed = time.perf_counter() - start
         for item in result:
             extra_fields = getattr(item, "extra_fields", None)

--- a/xtuner/v1/rl/rollout/session_server.py
+++ b/xtuner/v1/rl/rollout/session_server.py
@@ -1,5 +1,6 @@
 import copy
 import json
+from contextlib import asynccontextmanager
 from functools import reduce
 from http import HTTPStatus
 from operator import add
@@ -10,6 +11,12 @@ import ray
 from aiohttp import ClientConnectionResetError, ClientSession, ClientTimeout, web
 
 from transformers import AutoTokenizer
+from xtuner.v1.rl.trace import (
+    inject_trace_context,
+    set_trace_attributes,
+    trace_function,
+    trace_span,
+)
 from xtuner.v1.utils import get_logger
 
 from .chat_template import canonicalize_messages_for_chat_template
@@ -73,6 +80,26 @@ def _request_uses_trace_store(req_body: dict) -> bool:
     if req_body.get("session_id") is None or "messages" not in req_body:
         return False
     return _bool_request_value(req_body.get("return_token_ids"), True)
+
+
+def _response_usage_attributes(payload: dict) -> dict[str, int]:
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        return {}
+    attributes = {}
+    prompt_tokens = usage.get("prompt_tokens", usage.get("input_tokens"))
+    completion_tokens = usage.get("completion_tokens", usage.get("output_tokens"))
+    if isinstance(prompt_tokens, int) and not isinstance(prompt_tokens, bool):
+        attributes["prompt.tokens"] = prompt_tokens
+    if isinstance(completion_tokens, int) and not isinstance(completion_tokens, bool):
+        attributes["completion.tokens"] = completion_tokens
+    return attributes
+
+
+def _session_trace_attributes(session_id: Any) -> dict[str, Any]:
+    if session_id is None:
+        return {}
+    return {"xtuner.session_id": session_id}
 
 
 def _extract_output_logprobs(output_token_logprobs: Optional[list], output_token_ids: list[int]) -> list[float]:
@@ -276,6 +303,7 @@ class SessionServer:
         self._site: Optional[web.TCPSite] = None
         self._lmdeploy_actor: Optional[ray.actor.ActorHandle] = None
 
+    @trace_function("session_server.prepare_request", attributes={"xtuner.stage": "llm_prepare"})
     async def on_request(self, req_body: dict, fmt: str, *, trace_enabled: bool = True) -> dict:
         """Normalize the request to drive the prefix cache + inject extension
         fields.
@@ -297,6 +325,9 @@ class SessionServer:
             matches ``fmt``; in trace mode it carries ``input_ids`` plus the
             ``return_*`` extension flags.
         """
+        session_id = req_body.get("session_id")
+        set_trace_attributes(_session_trace_attributes(session_id))
+
         # Evaluate path: forward unchanged except for the legacy ``logprobs``
         # → ``return_logprob`` rename and stripping the SessionServer-only
         # ``session_id`` field.
@@ -377,6 +408,7 @@ class SessionServer:
 
         return worker_req
 
+    @trace_function("session_server.record_response", attributes={"xtuner.stage": "llm_record"})
     async def on_response(self, worker_resp: dict, fmt: str, orig_req_body: dict) -> dict:
         """Trace the assistant turn into ``trace_store`` (always in OpenAI
         shape).
@@ -396,6 +428,7 @@ class SessionServer:
             caller but kept for symmetry.
         """
         session_id = orig_req_body["session_id"]
+        set_trace_attributes(_session_trace_attributes(session_id))
 
         if fmt == FMT_ANTHROPIC:
             output_token_ids = worker_resp.get("output_ids")
@@ -530,6 +563,27 @@ class SessionServer:
         get_logger().info("SessionServer stopped.")
 
     async def _handle_request(self, request: web.Request) -> web.Response:
+        req_path = request.match_info["path"]
+        with trace_span(
+            "session_server.request",
+            attributes={
+                "xtuner.stage": "llm_generate",
+                "http.request.method": request.method,
+                "http.route": f"/{req_path.lstrip('/')}",
+                "session.format": _detect_format(req_path),
+            },
+            parent_carrier=request.headers,
+        ):
+            response = await self._handle_request_impl(request)
+            set_trace_attributes(
+                {
+                    "http.response.status_code": response.status,
+                    "error": response.status >= HTTPStatus.BAD_REQUEST,
+                }
+            )
+            return response
+
+    async def _handle_request_impl(self, request: web.Request) -> web.Response:
         """Proxy handler: detect format, run hooks, forward, stream back."""
 
         req_path = request.match_info["path"]
@@ -551,6 +605,7 @@ class SessionServer:
         request_body = await request.read()
         request_data = None
         orig_req_body: Optional[dict] = None
+        session_id = None
         trace_enabled = False
         orig_return_logprob = orig_return_token_ids = False
         orig_return_routed_experts = True
@@ -568,6 +623,9 @@ class SessionServer:
                     else:
                         request_data.pop("tools", None)
                 orig_req_body = copy.deepcopy(request_data)
+
+                session_id = request_data.get("session_id")
+                set_trace_attributes(_session_trace_attributes(session_id))
 
                 trace_enabled = _request_uses_trace_store(request_data)
                 # Accept either ``return_logprob`` (canonical) or the legacy
@@ -603,6 +661,12 @@ class SessionServer:
             target_url += f"?{request.query_string}"
 
         is_stream = request_data.get("stream", False) if request_data else False
+        set_trace_attributes(
+            {
+                "session.stream": bool(is_stream),
+                "session.trace_store_enabled": trace_enabled,
+            }
+        )
 
         # Build the per-format stream cleaner (strips lmdeploy-injected
         # extension fields that the client didn't ask for, and removes the
@@ -616,8 +680,13 @@ class SessionServer:
 
         timeout = ClientTimeout(total=self.request_timeout, sock_connect=30)
         async with ClientSession(read_bufsize=self.read_bufsize, timeout=timeout) as client:
-            async with client.request(
-                method=request.method, url=target_url, headers=forward_headers, data=request_body
+            async with self._backend_request(
+                client,
+                method=request.method,
+                url=target_url,
+                headers=forward_headers,
+                data=request_body,
+                trace_session_id=session_id,
             ) as resp:
                 if is_stream:
                     response_chunks: list[bytes] = []
@@ -707,12 +776,14 @@ class SessionServer:
                     response_data = None
 
             if response_data is not None:
+                set_trace_attributes(_response_usage_attributes(response_data))
                 try:
                     await self.on_response(response_data, fmt, orig_req_body)
                 except Exception as exc:
                     session_error_msg = f"SessionServer response hook failed: {type(exc).__name__}: {exc}"
 
         if session_error_msg:
+            set_trace_attributes({"error": True, "error.type": "session_server_trace_hook"})
             get_logger().error(session_error_msg)
 
         if is_stream:
@@ -735,6 +806,28 @@ class SessionServer:
             return web.json_response(_error_payload(fmt, session_error_msg), status=500)
 
         return response
+
+    @asynccontextmanager
+    async def _backend_request(self, client: ClientSession, *, trace_session_id=None, **kwargs):
+        """Trace the complete upstream request and response-body lifecycle."""
+        with trace_span(
+            "session_server.backend_roundtrip",
+            attributes={
+                "xtuner.stage": "llm_backend_roundtrip",
+                **_session_trace_attributes(trace_session_id),
+            },
+        ):
+            headers = kwargs.get("headers")
+            if isinstance(headers, dict):
+                inject_trace_context(headers)
+            async with client.request(**kwargs) as response:
+                set_trace_attributes(
+                    {
+                        "http.upstream.status_code": response.status,
+                        "error": response.status >= HTTPStatus.BAD_REQUEST,
+                    }
+                )
+                yield response
 
     async def _decode_routed_experts(self, routed_experts: Any) -> np.ndarray:
         if isinstance(routed_experts, str):

--- a/xtuner/v1/rl/trace/rollout_api.py
+++ b/xtuner/v1/rl/trace/rollout_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import os
 from collections.abc import Callable, Mapping
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from functools import wraps
 from typing import Any, Protocol, TypeVar
 
@@ -71,15 +71,23 @@ def trace_rollout_endpoint(
 
             with _attach_rollout_call_chain(rollout_state, span_name, parent_carrier) as (
                 call_chain,
-                cleanup_call_chain_on_exit,
+                had_previous_call_chain,
+                previous_call_chain,
             ):
                 attributes["xtuner.span_name_path"] = call_chain
                 with trace_api.trace_span(span_name, attributes=attributes, parent_carrier=parent_carrier):
                     result = await func(*args, **kwargs)
                     result_rollout_state = result if isinstance(result, RolloutState) else rollout_state
                     trace_api.set_trace_attributes(rollout_state_final_attributes(result_rollout_state))
-                    if cleanup_call_chain_on_exit and isinstance(result, RolloutState):
-                        result.extra_fields.pop(TRACE_CALL_CHAIN_EXTRA_FIELD, None)
+                    result_states = (result,) if isinstance(result, RolloutState) else result
+                    if isinstance(result_states, (list, tuple)):
+                        for item in result_states:
+                            if not isinstance(item, RolloutState):
+                                continue
+                            if had_previous_call_chain:
+                                item.extra_fields[TRACE_CALL_CHAIN_EXTRA_FIELD] = previous_call_chain
+                            else:
+                                item.extra_fields.pop(TRACE_CALL_CHAIN_EXTRA_FIELD, None)
                     return result
 
         return wrapper  # type: ignore[return-value]
@@ -90,15 +98,17 @@ def trace_rollout_endpoint(
 def trace_rollout_remote(
     remote_method: _RayRemoteMethod,
     *args: Any,
-    target: RolloutState | None = None,
+    target: RolloutState | list[RolloutState] | tuple[RolloutState, ...] | None = None,
     **kwargs: Any,
 ) -> Any:
     if not is_rollout_trace_enabled():
         return remote_method.remote(*args, **kwargs)
 
-    rollout_state = _resolve_rollout_state_target(args, kwargs, target=target, owner="trace_rollout_remote")
+    rollout_states = _resolve_rollout_state_targets(args, kwargs, target=target, owner="trace_rollout_remote")
     carrier = trace_api.inject_trace_context({})
-    with attach_rollout_trace_carrier(rollout_state, carrier):
+    with ExitStack() as stack:
+        for rollout_state in rollout_states:
+            stack.enter_context(attach_rollout_trace_carrier(rollout_state, carrier))
         return remote_method.remote(*args, **kwargs)
 
 
@@ -172,13 +182,16 @@ def _attach_rollout_call_chain(
     parent_carrier: Mapping[str, str] | None,
 ):
     extra_fields = rollout_state.extra_fields
-    cleanup_call_chain_on_exit = TRACE_CALL_CHAIN_EXTRA_FIELD not in extra_fields
+    had_previous_call_chain = TRACE_CALL_CHAIN_EXTRA_FIELD in extra_fields
+    previous_call_chain = extra_fields.get(TRACE_CALL_CHAIN_EXTRA_FIELD)
     call_chain = (*_rollout_call_chain(rollout_state, parent_carrier), span_name)
     extra_fields[TRACE_CALL_CHAIN_EXTRA_FIELD] = list(call_chain)
     try:
-        yield call_chain, cleanup_call_chain_on_exit
+        yield call_chain, had_previous_call_chain, previous_call_chain
     finally:
-        if cleanup_call_chain_on_exit:
+        if had_previous_call_chain:
+            rollout_state.extra_fields[TRACE_CALL_CHAIN_EXTRA_FIELD] = previous_call_chain
+        else:
             rollout_state.extra_fields.pop(TRACE_CALL_CHAIN_EXTRA_FIELD, None)
 
 
@@ -197,17 +210,19 @@ def _rollout_call_chain(
     return ()
 
 
-def _resolve_rollout_state_target(
+def _resolve_rollout_state_targets(
     args: tuple[Any, ...],
     kwargs: Mapping[str, Any],
     *,
-    target: RolloutState | None = None,
+    target: RolloutState | list[RolloutState] | tuple[RolloutState, ...] | None = None,
     owner: str,
-) -> RolloutState:
+) -> tuple[RolloutState, ...]:
     if target is not None:
-        if not isinstance(target, RolloutState):
-            raise TypeError(f"{owner} target must be a RolloutState")
-        return target
+        if isinstance(target, RolloutState):
+            return (target,)
+        if isinstance(target, (list, tuple)) and all(isinstance(item, RolloutState) for item in target):
+            return tuple(target)
+        raise TypeError(f"{owner} target must be a RolloutState or a RolloutState collection")
 
     rollout_states: list[RolloutState] = []
     for value in (*args, *kwargs.values()):
@@ -220,7 +235,7 @@ def _resolve_rollout_state_target(
 
     if len(rollout_states) != 1:
         raise ValueError(f"{owner} requires exactly one RolloutState argument")
-    return rollout_states[0]
+    return (rollout_states[0],)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Add OpenTelemetry instrumentation to the rollout, sandbox, and SessionServer paths so a request trace remains connected across Ray actors, sandbox stages, and the proxy lifecycle.

## Motivation

The existing rollout and SessionServer paths already expose the live boundaries needed for tracing, but their OTel context was not consistently propagated across Ray calls or represented in sandbox and proxy spans. This made cross-process request traces incomplete even though the underlying training behavior was correct.

## Implementation

- Propagate the active OTel context through Ray `generate_group` calls for a single `RolloutState` or a concrete `list`/`tuple` group, while restoring internal carrier and call-chain fields after the call.
- Bridge the existing sandbox stage timer to live OTel spans with stable names and a bounded attribute schema. Legacy JSONL enter/exit records and timing semantics remain unchanged.
- Trace the SessionServer proxy lifecycle as `prepare_request`, `backend_roundtrip`, and `record_response` under one request span. Incoming aiohttp headers are used as the parent carrier, and the backend carrier is injected inside the roundtrip span.

## Compatibility

- No training behavior or request/response payload format changes.
- No prompt, response body, or raw header attributes are exported.
- No duplicate duration/ok telemetry is added; OTel owns duration and logical failures use `error=true`.
- This PR instruments existing live call sites only. It does not add synthetic trace reconstruction, trajectory polling, timeline storage, or a flush API.

## Tests

- Focused rollout propagation, nested cleanup, sandbox bridge, SessionServer, and mixed-case W3C carrier tests.
- Existing `SingleTurnAgentLoop` and producer compatibility tests: 29 passed.
- `ruff check` on all changed Python files.
- `compileall` on changed modules and tests.
- `git diff --check` and final diff review against `upstream/main`.
