### PR TITLE
[Fix] Bound HF save reconstruction memory by save plan

### DIFF
--- a/tests/engine/test_moe_train_engine.py
+++ b/tests/engine/test_moe_train_engine.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import tempfile
 import shutil
 import time
+from unittest.mock import patch
+
 from torch.distributed.device_mesh import init_device_mesh
 import parametrize
 import torch
@@ -13,7 +15,7 @@ from transformers import AutoTokenizer
 from collections import defaultdict
 
 from xtuner.v1.model.moe.moe import SequenceContext
-from xtuner.v1.model.base import ModelItem
+from xtuner.v1.model.base import HFSaveCfg, ModelItem
 from xtuner.v1.loss.ce_loss import CELossConfig
 from xtuner.v1.model.moe.qwen3 import Qwen3MoE30BA3Config, Qwen3MoEConfig
 from xtuner.v1.config import FSDPConfig, LRConfig, AdamWConfig
@@ -49,6 +51,10 @@ class TestMoEEngine(DeterministicDDPTestCase):
             balancing_loss_cfg=BalancingLossConfig(),
             z_loss_cfg=ZLossConfig(),
             compile_cfg=False,
+            # The 8-rank test uses an 8 GiB bucket to reproduce the 16-rank
+            # default-4-GiB failure: local-shard accounting batches the whole
+            # model, while global accounting still bounds reconstruction.
+            hf_save_cfg=HFSaveCfg(bucket_size=8 * 1024**3),
         )
         optim_cfg: AdamWConfig = AdamWConfig()
         lr_cfg: LRConfig = LRConfig()
@@ -108,6 +114,18 @@ class TestMoEEngine(DeterministicDDPTestCase):
         losses_ref = torch.tensor([2.44, 2.44, 2.42, 2.41, 2.34, 2.33, 2.16, 2.13, 1.71, 1.55])
         losses = torch.tensor(losses)
         self._check_loss_curve(losses, losses_ref)
+
+        # HF reconstruction is independent of EP/SP here, so exercise it once
+        # instead of adding about 100 seconds to both parameterizations.
+        if ep_size == 1:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                save_dir = [tmpdir]
+                dist.broadcast_object_list(save_dir, src=0)
+                # Safetensors writing is external to the CUDA reconstruction
+                # under test and would otherwise write roughly 60 GB.
+                with patch("xtuner.v1.model.base.save_file"):
+                    engine.save_hf(save_dir[0])
+                dist.barrier()
 
         torch.cuda.empty_cache()
         try:

--- a/tests/engine/test_moe_train_engine.py
+++ b/tests/engine/test_moe_train_engine.py
@@ -36,25 +36,29 @@ DEVICE = get_device()
 
 
 class TestMoEEngine(DeterministicDDPTestCase):
-    @parametrize.parametrize(
-        "device,ep_size,sp_size",
-        [
-            ("cuda", 1, 1),
-            ("cuda", 2, 2),
-        ],
-    )
-    def test_moe_engine_train(self, device, ep_size, sp_size):
+    def test_moe_engine_train(self) -> None:
+        self._run_moe_engine_train_case("cuda", ep_size=2, sp_size=2, save_hf=False)
+
+    def test_moe_engine_train_and_save_hf(self) -> None:
+        self._run_moe_engine_train_case("cuda", ep_size=1, sp_size=1, save_hf=True)
+
+    def _run_moe_engine_train_case(
+        self,
+        device: str,
+        ep_size: int,
+        sp_size: int,
+        *,
+        save_hf: bool,
+    ) -> None:
         pg = self.create_pg(device)
 
+        hf_save_cfg = HFSaveCfg(bucket_size=8 * 1024**3) if save_hf else HFSaveCfg()
         moe_cfg = Qwen3MoE30BA3Config(
             ep_size=ep_size,
             balancing_loss_cfg=BalancingLossConfig(),
             z_loss_cfg=ZLossConfig(),
             compile_cfg=False,
-            # The 8-rank test uses an 8 GiB bucket to reproduce the 16-rank
-            # default-4-GiB failure: local-shard accounting batches the whole
-            # model, while global accounting still bounds reconstruction.
-            hf_save_cfg=HFSaveCfg(bucket_size=8 * 1024**3),
+            hf_save_cfg=hf_save_cfg,
         )
         optim_cfg: AdamWConfig = AdamWConfig()
         lr_cfg: LRConfig = LRConfig()
@@ -115,12 +119,12 @@ class TestMoEEngine(DeterministicDDPTestCase):
         losses = torch.tensor(losses)
         self._check_loss_curve(losses, losses_ref)
 
-        # HF reconstruction is independent of EP/SP here, so exercise it once
-        # instead of adding about 100 seconds to both parameterizations.
-        if ep_size == 1:
+        if save_hf:
             with tempfile.TemporaryDirectory() as tmpdir:
                 save_dir = [tmpdir]
                 dist.broadcast_object_list(save_dir, src=0)
+                # On 8 ranks, an 8 GiB reconstruction bucket matches the faulty
+                # 16-rank/default-4-GiB batch size from the production OOM.
                 # Safetensors writing is external to the CUDA reconstruction
                 # under test and would otherwise write roughly 60 GB.
                 with patch("xtuner.v1.model.base.save_file"):

--- a/tests/model/test_fsdp_model.py
+++ b/tests/model/test_fsdp_model.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -131,10 +132,9 @@ class TestFSDPModel(DeterministicDDPTestCase):
         for name, ref_param in ref_model.state_dict().items():
             torch.testing.assert_close(_full_tensor(model.state_dict()[name]), ref_param)
 
-    def test_save_hf_respects_global_bucket_size(self):
+    def _save_hf_with_bucket(self, tmpdir: str, bucket_size: int) -> tuple[ToyModel, Path]:
         self.create_pg("cuda")
 
-        bucket_size = 1100
         config = ToyModelConfig(
             compile_cfg=False,
             hf_save_cfg=HFSaveCfg(bucket_size=bucket_size, worker_per_rank=1),
@@ -148,26 +148,43 @@ class TestFSDPModel(DeterministicDDPTestCase):
             )
         )
 
+        shared_tmpdir = [tmpdir]
+        dist.broadcast_object_list(shared_tmpdir, src=0)
+        source_dir = Path(shared_tmpdir[0]) / "source"
+        saved_dir = Path(shared_tmpdir[0]) / "saved"
+        if dist.get_rank() == 0:
+            source_dir.mkdir()
+            (source_dir / "config.json").write_text("{}")
+        dist.barrier()
+
+        model.set_hf(source_dir)
+        model.save_hf(saved_dir)
+        return model, saved_dir
+
+    def test_save_hf_respects_global_bucket_size(self):
+        bucket_size = 1100
         with tempfile.TemporaryDirectory() as tmpdir:
-            shared_tmpdir = [tmpdir]
-            dist.broadcast_object_list(shared_tmpdir, src=0)
-            source_dir = Path(shared_tmpdir[0]) / "source"
-            saved_dir = Path(shared_tmpdir[0]) / "saved"
+            model, saved_dir = self._save_hf_with_bucket(tmpdir, bucket_size)
             if dist.get_rank() == 0:
-                source_dir.mkdir()
-                (source_dir / "config.json").write_text("{}")
-            dist.barrier()
+                safetensor_paths = list(saved_dir.glob("*.safetensors"))
+                assert safetensor_paths
 
-            model.set_hf(source_dir)
-            model.save_hf(saved_dir)
-
-            if dist.get_rank() == 0:
-                # bucket_size bounds reconstructed checkpoint tensors, not each
-                # rank's local FSDP shards. A tensor larger than the bucket is
-                # valid, but it must occupy its shard alone.
-                for safetensor_path in saved_dir.glob("*.safetensors"):
+                # Check the reconstruction bucket bound.
+                for safetensor_path in safetensor_paths:
                     with safe_open(safetensor_path, framework="pt") as reader:
                         tensors = [reader.get_tensor(key) for key in reader.keys()]
                     shard_size = sum(tensor.numel() * tensor.element_size() for tensor in tensors)
                     assert shard_size <= bucket_size or len(tensors) == 1
+
+                # Independently check that save_hf produced a complete checkpoint.
+                expected_keys = set(model.state_dict())
+                index = json.loads((saved_dir / "model.safetensors.index.json").read_text())
+                assert set(index["weight_map"]) == expected_keys
+                assert {path.name for path in safetensor_paths} == set(index["weight_map"].values())
+
+                saved_keys = set()
+                for safetensor_path in safetensor_paths:
+                    with safe_open(safetensor_path, framework="pt") as reader:
+                        saved_keys.update(reader.keys())
+                assert saved_keys == expected_keys
             dist.barrier()

--- a/tests/model/test_fsdp_model.py
+++ b/tests/model/test_fsdp_model.py
@@ -1,5 +1,9 @@
+import tempfile
+from pathlib import Path
+
 import torch
 import torch.distributed as dist
+from safetensors import safe_open
 from torch import nn
 from torch.distributed.tensor import DTensor
 
@@ -7,7 +11,7 @@ from xtuner._testing.testcase import DeterministicDDPTestCase
 from xtuner.v1.config import FSDPConfig
 from xtuner.v1.data_proto import SequenceContext
 from xtuner.v1.loss.ce_loss import CELossConfig
-from xtuner.v1.model.base import BaseModel, ModelOutputs, XTunerBaseModelConfig
+from xtuner.v1.model.base import BaseModel, HFSaveCfg, ModelOutputs, XTunerBaseModelConfig
 from xtuner.v1.module import LMHead
 
 
@@ -126,3 +130,44 @@ class TestFSDPModel(DeterministicDDPTestCase):
 
         for name, ref_param in ref_model.state_dict().items():
             torch.testing.assert_close(_full_tensor(model.state_dict()[name]), ref_param)
+
+    def test_save_hf_respects_global_bucket_size(self):
+        self.create_pg("cuda")
+
+        bucket_size = 1100
+        config = ToyModelConfig(
+            compile_cfg=False,
+            hf_save_cfg=HFSaveCfg(bucket_size=bucket_size, worker_per_rank=1),
+        )
+        model = config.build().to("cuda")
+        model.fully_shard(
+            FSDPConfig(
+                param_dtype=torch.float32,
+                reduce_dtype=torch.float32,
+                torch_compile=False,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shared_tmpdir = [tmpdir]
+            dist.broadcast_object_list(shared_tmpdir, src=0)
+            source_dir = Path(shared_tmpdir[0]) / "source"
+            saved_dir = Path(shared_tmpdir[0]) / "saved"
+            if dist.get_rank() == 0:
+                source_dir.mkdir()
+                (source_dir / "config.json").write_text("{}")
+            dist.barrier()
+
+            model.set_hf(source_dir)
+            model.save_hf(saved_dir)
+
+            if dist.get_rank() == 0:
+                # bucket_size bounds reconstructed checkpoint tensors, not each
+                # rank's local FSDP shards. A tensor larger than the bucket is
+                # valid, but it must occupy its shard alone.
+                for safetensor_path in saved_dir.glob("*.safetensors"):
+                    with safe_open(safetensor_path, framework="pt") as reader:
+                        tensors = [reader.get_tensor(key) for key in reader.keys()]
+                    shard_size = sum(tensor.numel() * tensor.element_size() for tensor in tensors)
+                    assert shard_size <= bucket_size or len(tensors) == 1
+            dist.barrier()

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from functools import reduce
 from importlib import import_module
 from itertools import chain
+from math import prod
 from pathlib import Path
 from shutil import copy, copytree, rmtree
 from typing import Annotated, Any, Generator, Iterable, Literal, Mapping, NamedTuple, Sequence, cast
@@ -111,8 +112,16 @@ class HFSaveCfg(PydanticBaseModel):
     model_config = ConfigDict(extra="forbid")
     worker_per_rank: Annotated[int, Parameter(group="model")] = 16
     max_save_rank: Annotated[int, Parameter(group="model")] = 16
-    # Max bytes per generated safetensors shard.
-    bucket_size: Annotated[int, Parameter(group="model")] = 1024**3 * 4
+    bucket_size: Annotated[
+        int,
+        Parameter(
+            group="model",
+            help=(
+                "Approximate maximum reconstruction bytes per HF save bucket. "
+                "A single tensor item may exceed this limit."
+            ),
+        ),
+    ] = 1024**3 * 4
     # TODO: `XTunerBaseModel` should also be able to specify which parameters to be trained in fp32,
     # currently it could only be specified in HFSaveCfg
     # Each entry is a **regex** pattern (passed to `re.search`) matched against the HF parameter name.
@@ -534,7 +543,7 @@ class _HFSaveBucketItem(NamedTuple):
     tensor: torch.Tensor
     save_plan: HFSavePlan
     runtime_is_float8: bool
-    byte_size: int
+    reconstruction_bytes: int
 
 
 class BaseModel(nn.Module):
@@ -1295,7 +1304,8 @@ class BaseModel(nn.Module):
             params (list[tuple[torch.Tensor, LoadSpec]]): Runtime tensors and their new-schema LoadSpecs.
             dtype (torch.dtype): Target checkpoint dtype, currently bfloat16 or float8_e4m3fn.
             device (torch.device | str): Device to move yielded tensors to.
-            bucket_size (int | None): Approximate bucket size in bytes.
+            bucket_size (int | None): Approximate maximum reconstruction bytes per bucket. A single tensor item may
+                exceed this limit.
             distributed_save (bool): Whether to apply the HF save write policy. When enabled, non-fused tensors are
                 yielded only on rank0 and fused HF keys are divided across save ranks.
             preserved_fused_shard_group (dist.ProcessGroup | None): Communication group whose fused-dim shard should
@@ -1319,7 +1329,7 @@ class BaseModel(nn.Module):
         if bucket_size is None:
             bucket_size = self.config.hf_save_cfg.bucket_size
 
-        bucket_bytes = 0
+        bucket_reconstruction_bytes = 0
         bucket: list[_HFSaveBucketItem] = []
         buffer_names = {self._clean_param_name(name) for name, _ in self.named_buffers()}
 
@@ -1327,22 +1337,21 @@ class BaseModel(nn.Module):
             save_item = self._make_hf_save_item(
                 param,
                 load_spec,
-                checkpoint_dtype=dtype,
                 is_buffer=load_spec.name in buffer_names,
                 distributed_save=distributed_save,
                 preserved_fused_shard_group=preserved_fused_shard_group,
                 target_fused_key_partition=target_fused_key_partition,
             )
-            if bucket_bytes + save_item.byte_size > bucket_size and bucket:
+            if bucket_reconstruction_bytes + save_item.reconstruction_bytes > bucket_size and bucket:
                 yield self._build_hf_param_bucket(
                     bucket,
                     dtype=dtype,
                     device=device,
                 )
-                bucket_bytes = 0
+                bucket_reconstruction_bytes = 0
                 bucket = []
 
-            bucket_bytes += save_item.byte_size
+            bucket_reconstruction_bytes += save_item.reconstruction_bytes
             bucket.append(save_item)
 
         if bucket:
@@ -1357,7 +1366,6 @@ class BaseModel(nn.Module):
         param: torch.Tensor,
         load_spec: LoadSpec,
         *,
-        checkpoint_dtype: torch.dtype,
         is_buffer: bool,
         distributed_save: bool,
         preserved_fused_shard_group: dist.ProcessGroup | None,
@@ -1375,18 +1383,21 @@ class BaseModel(nn.Module):
             # Persistent buffers, e.g. FoPE rotary coefficients, keep their runtime dtype.
             checkpoint_tensor = runtime_tensor
 
+        save_plan = load_spec.plan_hf_save(
+            distributed_save=distributed_save,
+            preserve_process_group=preserved_fused_shard_group,
+            target_fused_key_partition=target_fused_key_partition,
+        )
+        # Account for the tensor materialized by unshard, before FP8 conversion
+        # or checkpoint-visible padding trim. The save plan owns policy-specific
+        # shape semantics, including preserved EP shards.
+        reconstruction_bytes = prod(save_plan.runtime_output_shape) * checkpoint_tensor.element_size()
+
         return _HFSaveBucketItem(
             tensor=checkpoint_tensor,
-            save_plan=load_spec.plan_hf_save(
-                distributed_save=distributed_save,
-                preserve_process_group=preserved_fused_shard_group,
-                target_fused_key_partition=target_fused_key_partition,
-            ),
+            save_plan=save_plan,
             runtime_is_float8=is_float8_weight(runtime_tensor),
-            # Buckets bound the tensors reconstructed by HF save. DTensor.numel()
-            # is the logical/global size; using the local shard here makes the
-            # effective bucket grow with the FSDP world size.
-            byte_size=self._get_tensor_size(param, checkpoint_dtype),
+            reconstruction_bytes=reconstruction_bytes,
         )
 
     def _load_spec_params(self) -> list[tuple[torch.Tensor, LoadSpec]]:
@@ -1512,11 +1523,6 @@ class BaseModel(nn.Module):
         if "_orig_mod." in name:
             name = name.replace("_orig_mod.", "")
         return name
-
-    def _get_tensor_size(self, tensor: torch.Tensor, dtype: torch.dtype) -> int:
-        """Get the size of the tensor in bytes."""
-        # return tensor.element_size() * tensor.numel()
-        return dtype.itemsize * tensor.numel()
 
     def _iter_hf_save_chunks(
         self,

--- a/xtuner/v1/model/base.py
+++ b/xtuner/v1/model/base.py
@@ -1383,7 +1383,10 @@ class BaseModel(nn.Module):
                 target_fused_key_partition=target_fused_key_partition,
             ),
             runtime_is_float8=is_float8_weight(runtime_tensor),
-            byte_size=self._get_tensor_size(runtime_tensor, checkpoint_dtype),
+            # Buckets bound the tensors reconstructed by HF save. DTensor.numel()
+            # is the logical/global size; using the local shard here makes the
+            # effective bucket grow with the FSDP world size.
+            byte_size=self._get_tensor_size(param, checkpoint_dtype),
         )
 
     def _load_spec_params(self) -> list[tuple[torch.Tensor, LoadSpec]]:


### PR DESCRIPTION
## Summary

- account each HF save bucket item from `HFSavePlan.runtime_output_shape` and the actual reconstruction tensor dtype
- clarify that `HFSaveCfg.bucket_size` bounds approximate reconstruction bytes, while allowing a single oversized item
- keep the real FSDP checkpoint shard-size check, add index/key completeness validation, and add an 8-GPU Qwen3-MoE train-to-save regression

## Root cause

HF save previously charged a bucket using each rank-local FSDP shard. The unified save path can reconstruct the global tensor, so the effective batch grew with the FSDP world size and allowed tens of GiB to enter one all-gather/`torch.cat` reconstruction.

Charging global `param.numel()` fixes the default BF16 full-save case but is still inaccurate for FP32 parameters and buffers, FP8 saves that reconstruct in BF16, and RL policies that preserve EP shards. The final accounting therefore uses the policy-specific runtime output shape from `HFSavePlan` multiplied by the actual pre-unshard tensor element size.

## Reproduction

On one 8x GPU node with the full 48-layer Qwen3-30B-A3B model:

| Revision | HF save peak | Save increment |
| --- | ---: | ---: |
| baseline `ff3452ad` | 14.28 GiB | 7.17 GiB |
| before fix | 71.02 GiB | 63.91 GiB |
| after fix | 14.89 GiB | 7.79 GiB |

The topology-equivalent 8-rank ETE configuration reproduced the production stack in `_merge_gathered_save_shard -> torch.cat`: the old implementation OOMed at 137.43 GiB allocated, while the fixed implementation completed at a 59.1 GiB peak.

## Validation

- `python -m pytest -q tests/utils/test_load_spec.py tests/rl/test_weight_iterator.py`: 37 passed
- `python -m pytest -q tests/model/test_fsdp_model.py`: 2 passed
- `test_moe_engine_train` and `test_moe_engine_train_and_save_hf`: 2 passed on 8 GPUs
- pre-commit hooks, Ruff, mypy, and `git diff --check`: passed