### PR TITLE
[Fix] Align FP8 RL train and rollout weight quantization

### DIFF
--- a/tests/rl/test_weight_iterator.py
+++ b/tests/rl/test_weight_iterator.py
@@ -6,6 +6,9 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
+from xtuner.v1.float8 import Float8Config, ScalingGranularity
+from xtuner.v1.float8.fsdp_utils import WeightWithDynamicTilewiseFloat8CastTensor
+from xtuner.v1.float8.triton_kernels.per_block_quant_gemm import per_block_quant_torch
 from xtuner.v1.model.base import BaseModel, HFSaveCfg, XTunerBaseModelConfig
 from xtuner.v1.rl.weight_update.data import RolloutWeightUpdateInfo, RolloutWeightUpdateTarget
 from xtuner.v1.rl.weight_update.weight_iterator import WeightIterator
@@ -51,6 +54,29 @@ class ExpertShardModel(BaseModel):
         return [f"expert_{index}" for index in range(8)]
 
 
+class DirectFloat8WeightModel(BaseModel):
+    def __init__(self, master: torch.Tensor) -> None:
+        super().__init__(
+            XTunerBaseModelConfig(
+                float8_cfg=Float8Config(scaling_granularity_gemm=ScalingGranularity.TILEWISE),
+            )
+        )
+        layer = nn.Module()
+        layer.weight = nn.Parameter(
+            WeightWithDynamicTilewiseFloat8CastTensor(
+                master,
+                torch.float8_e4m3fn,
+                tuple(master.shape),
+            )
+        )
+        self.layers = nn.ModuleDict({"0": layer})
+        self.fsdp_config = SimpleNamespace(ep_size=1)
+        self._init_load_spec()
+
+    def to_hf_key_list(self, key: str) -> list[str]:
+        return [key]
+
+
 def test_hf_weight_update_batches_have_one_dtype() -> None:
     model = MixedDtypeModel()
     rollout_info = RolloutWeightUpdateInfo(
@@ -74,6 +100,59 @@ def test_hf_weight_update_batches_have_one_dtype() -> None:
     assert set(state_dict) == {"bf16_weight", "fp32_weight"}
     assert state_dict["bf16_weight"].dtype == torch.bfloat16
     assert state_dict["fp32_weight"].dtype == torch.float32
+
+
+def test_fp8_hf_weight_update_uses_bfloat16() -> None:
+    model = MixedDtypeModel()
+    model.config.float8_cfg = Float8Config(scaling_granularity_gemm=ScalingGranularity.TILEWISE)
+    model.fsdp_config = SimpleNamespace(ep_size=1)
+    rollout_info = RolloutWeightUpdateInfo(
+        rollout_config=cast(Any, SimpleNamespace()),
+        weight_update_targets=(),
+        train_rank=0,
+        transport_type="ipc",
+        backend="pytorch",
+    )
+    iterator = WeightIterator(
+        config=SimpleNamespace(update_weight_bucket_size_in_gb=1, model_cfg=None),
+        engine=SimpleNamespace(model=model),
+        rollout_info=rollout_info,
+        global_hf_keys_mapping_cache={},
+    )
+
+    state_dict = {name: tensor for batch in iterator.iter_hf_batches() for name, tensor in batch.state_dict.items()}
+
+    assert state_dict["bf16_weight"].dtype == torch.bfloat16
+    assert state_dict["fp32_weight"].dtype == torch.float32
+
+
+def test_direct_fp8_weight_update_quantizes_bfloat16() -> None:
+    generator = torch.Generator().manual_seed(11)
+    checkpoint = torch.randn(128, 128, generator=generator).to(torch.bfloat16)
+    master = checkpoint.to(torch.float32) + torch.randn(128, 128, generator=generator) * 1e-3
+    expected_data, expected_scale = per_block_quant_torch(master.to(torch.bfloat16))
+    fp16_data, fp16_scale = per_block_quant_torch(master.to(torch.float16))
+    assert not (torch.equal(fp16_data, expected_data) and torch.equal(fp16_scale, expected_scale))
+
+    model = DirectFloat8WeightModel(master)
+    rollout_info = RolloutWeightUpdateInfo(
+        rollout_config=cast(Any, SimpleNamespace()),
+        weight_update_targets=(),
+        train_rank=0,
+        transport_type="ipc",
+        backend="turbomind",
+    )
+    iterator = WeightIterator(
+        config=SimpleNamespace(model_cfg=model.config),
+        engine=SimpleNamespace(model=model),
+        rollout_info=rollout_info,
+        global_hf_keys_mapping_cache={},
+    )
+
+    (batch,) = list(iterator.iter_layer_batches())
+
+    assert torch.equal(batch.state_dict["model.layers.0.weight"], expected_data)
+    assert torch.equal(batch.state_dict["model.layers.0.weight_scale_inv"], expected_scale)
 
 
 @pytest.mark.parametrize(

--- a/xtuner/v1/float8/fsdp_utils.py
+++ b/xtuner/v1/float8/fsdp_utils.py
@@ -1,4 +1,5 @@
 import math
+import os
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 import torch
@@ -20,6 +21,8 @@ from xtuner.v1.utils import get_device, get_logger, get_torch_device_module, may
 logger = get_logger()
 DEVICE = get_device()
 DEVICE_MODULE = get_torch_device_module()
+
+_RL_FP8_QUANTIZE_WEIGHT_IN_BF16_ENV = "XTUNER_RL_FP8_QUANTIZE_WEIGHT_IN_BF16"
 
 
 def tensor_to_per_block_fp8_devided_64_scales(
@@ -160,6 +163,9 @@ def precompute_tilewise_float8_scale_for_fsdp(
                 f"Currently only reduce_mesh.ndim should equal to 1, got reduce_mesh.ndim = {reduce_mesh.ndim} for local_shape {local_shape}"
             )
         weights_same_shape_stack = torch.stack(weights_same_shape, dim=0)  # type: ignore
+        # 因为当前RL用bf16参数传输到推理引擎，这里为了训推一致性做类似处理
+        if os.environ.get(_RL_FP8_QUANTIZE_WEIGHT_IN_BF16_ENV, "0") == "1":
+            weights_same_shape_stack = weights_same_shape_stack.bfloat16().float()
         if dim >= 128 and dim % 128 == 64:
             assert reduce_mesh_devided_64 is not None, (
                 f"reduce_mesh_devided_64 should not be None for local_shape {local_shape}."
@@ -385,9 +391,13 @@ class WeightWithDynamicTilewiseFloat8CastTensor(torch.Tensor):
                 return (self._precomputed_w,), (self._precomputed_scale,)
             return (self._precomputed_w, self._precomputed_scale), None
         assert self._precomputed_scale is not None
+        quant_source = self._tensor
+        # 因为当前RL用bf16参数传输到推理引擎，这里为了训推一致性做类似处理
+        if os.environ.get(_RL_FP8_QUANTIZE_WEIGHT_IN_BF16_ENV, "0") == "1":
+            quant_source = quant_source.bfloat16().float()
         if self._tensor.shape[0] >= 128 and self._tensor.shape[0] % 128 == 64:
             w_fp8_data = cast_to_per_block_fp8_devided_64_with_scales(
-                tensor=self._tensor,
+                tensor=quant_source,
                 scales=self._precomputed_scale,
                 fsdp_mesh=mesh,
                 block_size=128,
@@ -395,7 +405,7 @@ class WeightWithDynamicTilewiseFloat8CastTensor(torch.Tensor):
             )
         else:
             w_fp8_data = cast_to_per_block_fp8_with_scales(
-                tensor=self._tensor,
+                tensor=quant_source,
                 scales=self._precomputed_scale,
                 block_size=128,
                 float8_dtype=self._dtype,

--- a/xtuner/v1/float8/fsdp_utils.py
+++ b/xtuner/v1/float8/fsdp_utils.py
@@ -22,7 +22,7 @@ logger = get_logger()
 DEVICE = get_device()
 DEVICE_MODULE = get_torch_device_module()
 
-_RL_FP8_QUANTIZE_WEIGHT_IN_BF16_ENV = "XTUNER_RL_FP8_QUANTIZE_WEIGHT_IN_BF16"
+_RL_FP8_QUANTIZE_IN_BF16_ENV = "XTUNER_RL_FP8_QUANTIZE_IN_BF16"
 
 
 def tensor_to_per_block_fp8_devided_64_scales(
@@ -164,7 +164,7 @@ def precompute_tilewise_float8_scale_for_fsdp(
             )
         weights_same_shape_stack = torch.stack(weights_same_shape, dim=0)  # type: ignore
         # 因为当前RL用bf16参数传输到推理引擎，这里为了训推一致性做类似处理
-        if os.environ.get(_RL_FP8_QUANTIZE_WEIGHT_IN_BF16_ENV, "0") == "1":
+        if os.environ.get(_RL_FP8_QUANTIZE_IN_BF16_ENV, "0") == "1":
             weights_same_shape_stack = weights_same_shape_stack.bfloat16().float()
         if dim >= 128 and dim % 128 == 64:
             assert reduce_mesh_devided_64 is not None, (
@@ -393,7 +393,7 @@ class WeightWithDynamicTilewiseFloat8CastTensor(torch.Tensor):
         assert self._precomputed_scale is not None
         quant_source = self._tensor
         # 因为当前RL用bf16参数传输到推理引擎，这里为了训推一致性做类似处理
-        if os.environ.get(_RL_FP8_QUANTIZE_WEIGHT_IN_BF16_ENV, "0") == "1":
+        if os.environ.get(_RL_FP8_QUANTIZE_IN_BF16_ENV, "0") == "1":
             quant_source = quant_source.bfloat16().float()
         if self._tensor.shape[0] >= 128 and self._tensor.shape[0] % 128 == 64:
             w_fp8_data = cast_to_per_block_fp8_devided_64_with_scales(

--- a/xtuner/v1/rl/weight_update/weight_iterator.py
+++ b/xtuner/v1/rl/weight_update/weight_iterator.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 import tqdm
 from torch.distributed.tensor import DTensor
 
+from xtuner.v1.model.base import is_float8_weight
 from xtuner.v1.model.compose.base import BaseComposeConfig
 from xtuner.v1.model.compose.qwen3_vl import Qwen3VLForConditionalGeneration
 from xtuner.v1.utils import get_device, get_torch_device_module
@@ -140,8 +141,12 @@ class WeightIterator:
             _tensor_list, _spec_list = list(zip(*tensor_list))
             fsdp_unshard_tensor_list = model._fsdp_foreach_allgather(_tensor_list, _spec_list)
             if save_dtype == torch.float8_e4m3fn:
+                runtime_is_float8_list = [is_float8_weight(tensor) for tensor in _tensor_list]
                 fsdp_unshard_tensor_list, name_list = model._to_float8(
-                    fsdp_unshard_tensor_list, name_list, _tensor_list, save_dtype
+                    fsdp_unshard_tensor_list,
+                    name_list,
+                    runtime_is_float8_list,
+                    save_dtype,
                 )
             return fsdp_unshard_tensor_list, name_list
 

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -655,6 +655,15 @@ class BaseRLTrainer:
 
         env_path = log_dir / "env.json"
         environment_variables = dict(os.environ)
+        xtuner_environment = {
+            key: value for key, value in sorted(environment_variables.items()) if key.startswith("XTUNER")
+        }
+        log_str = "\n============XTuner RL Training Environment============\n"
+        for key, value in xtuner_environment.items():
+            log_str += f"{key}: {value}\n"
+        log_str += "======================================================"
+        self.logger.info(log_str)
+
         infer_engine_version = get_rollout_engine_version()
         environment_variables.update(infer_engine_version)
         with env_path.open("w") as f:

--- a/xtuner/v1/train/trainer.py
+++ b/xtuner/v1/train/trainer.py
@@ -2145,7 +2145,7 @@ class Trainer:
             "GROUPED_GEMM_USE_CUTLASS": os.getenv("GROUPED_GEMM_USE_CUTLASS"),
             "XTUNER_USE_NATIVE_RMSNORM": os.getenv("XTUNER_USE_NATIVE_RMSNORM"),
             "XTUNER_SM_MARGIN": os.getenv("XTUNER_SM_MARGIN"),
-            "XTUNER_RL_FP8_QUANTIZE_WEIGHT_IN_BF16": os.getenv("XTUNER_RL_FP8_QUANTIZE_WEIGHT_IN_BF16"),
+            "XTUNER_RL_FP8_QUANTIZE_IN_BF16": os.getenv("XTUNER_RL_FP8_QUANTIZE_IN_BF16"),
         }
 
         for k, v in env.items():

--- a/xtuner/v1/train/trainer.py
+++ b/xtuner/v1/train/trainer.py
@@ -2145,6 +2145,7 @@ class Trainer:
             "GROUPED_GEMM_USE_CUTLASS": os.getenv("GROUPED_GEMM_USE_CUTLASS"),
             "XTUNER_USE_NATIVE_RMSNORM": os.getenv("XTUNER_USE_NATIVE_RMSNORM"),
             "XTUNER_SM_MARGIN": os.getenv("XTUNER_SM_MARGIN"),
+            "XTUNER_RL_FP8_QUANTIZE_WEIGHT_IN_BF16": os.getenv("XTUNER_RL_FP8_QUANTIZE_WEIGHT_IN_BF16"),
         }
 
         for k, v in env.items():


### PR DESCRIPTION
## Summary

- Add the default-off `XTUNER_RL_FP8_QUANTIZE_IN_BF16` switch. When enabled, tilewise FSDP scale precomputation and FP8 casting quantize the same BF16-rounded weight values exported to rollout, while keeping the FP32 optimizer master unchanged.
- Pass runtime FP8 metadata to direct rollout weight conversion and cover BF16 HF/direct-FP8 export behavior in the existing WeightIterator tests.
- Include the switch in the standard trainer environment report and print all `XTUNER*` variables in the RL trainer runtime environment report.

The legacy FP32-master quantization path remains the default, and the existing FP8 engine loss references are unchanged.

## Validation

- Pre-commit hooks: ruff, ruff-format, mypy, codespell, docformatter, and pydantic checks passed.
- `tests/engine/test_moe_train_engine_float8.py`: 7 passed with the original loss references.
- CUDA float8/WeightIterator/HF-save suite: 22 passed.

### Train/rollout mismatch before and after the fix

Both columns use the two-step Qwen3.5-35B-A3B GSM8K FP8 setup with real optimizer updates.

| Metric | Before fix: FP32 train quantization / BF16 rollout export | With fix: BF16-aligned quantization |
|---|---:|---:|
| Step 1 `k3_kl` | `3.414027e-4` | `3.324241e-4` |
| Step 2 `k3_kl` | `8.691058e-3` | `3.729346e-4` |
| Step 2 / Step 1 | `25.457x` | `1.121864x` |
| Absolute growth after the first update | `8.349655e-3` | `4.051050e-5` |
| Step 2 mismatch reduction | baseline | `95.71%` |

The fix keeps the mismatch at the initial `1e-4` scale instead of jumping to `1e-2`; both fixed steps had non-zero gradient norms.
