### PR TITLE
[Fix] Deduplicate agent artifacts across rollout segments

### DIFF
--- a/tests/rl/test_trajectory_logging.py
+++ b/tests/rl/test_trajectory_logging.py
@@ -1,0 +1,322 @@
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from xtuner.v1.data_proto.rl_data import RolloutState, Status
+from xtuner.v1.train.rl_trainer import BaseRLTrainer
+
+
+with patch.dict(
+    sys.modules,
+    {
+        "lagent": MagicMock(),
+        "lagent.utils": MagicMock(),
+        "lagent.utils.rate_limiter": MagicMock(),
+    },
+):
+    from xtuner.v1.rl.agent_loop.sandbox_agent_loop.agent_in_sandbox_loop import AgentInSandboxLoop
+    from xtuner.v1.rl.agent_loop.sandbox_agent_loop.schemas import AgentRolloutItem, RolloutStatus
+
+
+class TestSandboxArtifactOwnership(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _make_state() -> RolloutState:
+        return RolloutState(
+            group_id=3,
+            rollout_id=7,
+            session_id=12345678901234567890,
+            message=[{"role": "user", "content": "test"}],
+            num_tokens=1,
+            extra_fields={},
+        )
+
+    @staticmethod
+    def _make_item(status: RolloutStatus, segment_count: int = 2) -> AgentRolloutItem:
+        segments = [
+            {
+                "messages": [
+                    {"role": "user", "content": "test"},
+                    {"role": "assistant", "content": f"segment-{index}"},
+                ],
+                "tools": [{"type": "function", "function": {"name": f"tool-{index}"}}],
+            }
+            for index in range(segment_count)
+        ]
+        return AgentRolloutItem(
+            id="test-item",
+            data_source="test",
+            instruction="instruction.md",
+            status=status,
+            reward=1.0 if status == RolloutStatus.COMPLETED else None,
+            artifacts={
+                "messages": segments,
+                "response_message": {
+                    "role": "assistant",
+                    "content": "done",
+                    "finish_reason": "stop",
+                },
+                "large_blob": "x" * 1024,
+            },
+        )
+
+    @staticmethod
+    def _make_loop(mode: str = "train") -> AgentInSandboxLoop:
+        loop = AgentInSandboxLoop.__new__(AgentInSandboxLoop)
+        loop.mode = mode
+        loop.tokenizer = MagicMock()
+        loop.tokenizer.apply_chat_template.side_effect = lambda messages, **_: f"rendered-{messages[-1]['content']}\n"
+        loop.tokenizer.decode.side_effect = lambda token_ids: f"decoded-{token_ids[-1]}"
+        return loop
+
+    @staticmethod
+    def _trace_store(segment_count: int):
+        traces = [
+            {
+                "input_ids": [1, 10 + index, 20 + index],
+                "labels": [-100, 10 + index, 20 + index],
+                "logprobs": [0.0, -0.1, -0.2],
+                "routed_experts": None,
+            }
+            for index in range(segment_count)
+        ]
+        return SimpleNamespace(export_training_trace=SimpleNamespace(remote=AsyncMock(side_effect=traces)))
+
+    async def test_completed_session_assigns_artifacts_only_to_first_segment(self):
+        loop = self._make_loop()
+        state = self._make_state()
+        item = self._make_item(RolloutStatus.COMPLETED)
+        original_artifacts = copy.deepcopy(item.artifacts)
+        trace_store = self._trace_store(segment_count=2)
+
+        with patch(
+            "xtuner.v1.rl.agent_loop.sandbox_agent_loop.agent_in_sandbox_loop.get_store",
+            return_value=trace_store,
+        ):
+            segments = await loop._build_rollout_states(state, item)
+
+        self.assertEqual(len(segments), 2)
+        self.assertEqual([segment.session_id for segment in segments], [state.session_id, state.session_id])
+        self.assertEqual(
+            [segment.extra_fields["agent_trace_segment_index"] for segment in segments],
+            [0, 1],
+        )
+        self.assertTrue(all(segment.extra_fields["agent_trace_segment_count"] == 2 for segment in segments))
+        self.assertEqual(segments[0].extra_fields["agent_artifacts"], original_artifacts)
+        self.assertNotIn("agent_artifacts", segments[1].extra_fields)
+        self.assertEqual(
+            [segment.extra_fields["agent_messages"][-1]["content"] for segment in segments],
+            ["segment-0", "segment-1"],
+        )
+        self.assertEqual(
+            [segment.extra_fields["agent_tools"][0]["function"]["name"] for segment in segments],
+            ["tool-0", "tool-1"],
+        )
+        self.assertEqual([segment.response_ids for segment in segments], [[10, 20], [11, 21]])
+        self.assertEqual(item.artifacts, original_artifacts)
+
+    async def test_single_segment_keeps_artifacts(self):
+        loop = self._make_loop()
+        state = self._make_state()
+        item = self._make_item(RolloutStatus.COMPLETED, segment_count=1)
+
+        with patch(
+            "xtuner.v1.rl.agent_loop.sandbox_agent_loop.agent_in_sandbox_loop.get_store",
+            return_value=self._trace_store(segment_count=1),
+        ):
+            segments = await loop._build_rollout_states(state, item)
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0].extra_fields["agent_artifacts"], item.artifacts)
+
+    async def test_failed_train_session_keeps_artifacts(self):
+        loop = self._make_loop()
+        state = self._make_state()
+        item = self._make_item(RolloutStatus.FAILED)
+
+        segments = await loop._build_rollout_states(state, item)
+
+        self.assertEqual(segments, [state])
+        self.assertEqual(state.status, Status.FAILED)
+        self.assertEqual(state.extra_fields["agent_artifacts"], item.artifacts)
+
+    async def test_eval_session_keeps_artifacts(self):
+        loop = self._make_loop(mode="eval")
+        state = self._make_state()
+        item = self._make_item(RolloutStatus.COMPLETED)
+
+        segments = await loop._build_rollout_states(state, item)
+
+        self.assertEqual(segments, [state])
+        self.assertEqual(state.extra_fields["agent_artifacts"], item.artifacts)
+        self.assertEqual(state.extra_fields["agent_messages"][-1]["content"], "segment-1")
+
+
+class TestTrajectoryLogging(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.output_dir = Path(self.temp_dir.name)
+        self.trainer = BaseRLTrainer.__new__(BaseRLTrainer)
+        self.trainer.logger = MagicMock()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def _load_jsonl(path: Path) -> list[dict]:
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    @staticmethod
+    def _make_rollout(
+        *,
+        rollout_id: int,
+        session_id: int | None,
+        reward: float,
+        artifacts: dict | None,
+        segment_index: int | None = None,
+        segment_count: int | None = None,
+        status: Status = Status.COMPLETED,
+    ) -> RolloutState:
+        messages = [{"role": "assistant", "content": f"segment-{segment_index}"}]
+        tools = [{"type": "function", "function": {"name": "shell"}}]
+        extra_fields = {
+            "agent_name": "test-agent",
+            "agent_status": "completed",
+            "agent_tool_turns": 1,
+            "agent_messages": messages,
+            "agent_tools": tools,
+        }
+        if artifacts is not None:
+            extra_fields["agent_artifacts"] = artifacts
+        if segment_index is not None:
+            extra_fields["agent_trace_segment_index"] = segment_index
+        if segment_count is not None:
+            extra_fields["agent_trace_segment_count"] = segment_count
+        return RolloutState(
+            group_id=3,
+            rollout_id=rollout_id,
+            session_id=session_id,
+            message=[{"role": "user", "content": "test"}],
+            num_tokens=1,
+            response=f"response-{segment_index}",
+            response_ids=[10, 11],
+            reward={"score": reward},
+            status=status,
+            extra_fields=extra_fields,
+        )
+
+    def test_train_artifacts_are_written_once_per_session(self):
+        artifacts = {
+            "messages": [
+                {"messages": [{"role": "assistant", "content": "segment-0"}], "tools": []},
+                {"messages": [{"role": "assistant", "content": "segment-1"}], "tools": []},
+            ],
+            "response_message": {"role": "assistant", "content": "done"},
+            "large_blob": "x" * 1024,
+        }
+        data_groups = [
+            [
+                self._make_rollout(
+                    rollout_id=7,
+                    session_id=12345678901234567890,
+                    reward=1.0,
+                    artifacts=artifacts,
+                    segment_index=0,
+                    segment_count=2,
+                ),
+                self._make_rollout(
+                    rollout_id=7,
+                    session_id=12345678901234567890,
+                    reward=1.0,
+                    artifacts=None,
+                    segment_index=1,
+                    segment_count=2,
+                ),
+            ]
+        ]
+        trajectory_path = self.output_dir / "train_rollout_1.jsonl"
+
+        self.trainer._save_trajectories(data_groups, trajectory_path)
+
+        objects = self._load_jsonl(trajectory_path)
+        summary, rows = objects[0], objects[1:]
+        self.assertNotIn("trajectory_format_version", summary)
+        self.assertNotIn("session_artifacts_file", summary)
+        self.assertEqual(summary["total_len"], 2)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["agent"]["artifacts"], artifacts)
+        self.assertIsNone(rows[1]["agent"]["artifacts"])
+        self.assertEqual(trajectory_path.read_text(encoding="utf-8").count('"large_blob"'), 1)
+        self.assertEqual([row["agent"]["segment_index"] for row in rows], [0, 1])
+        self.assertTrue(all(row["agent"]["segment_count"] == 2 for row in rows))
+        self.assertTrue(all(row["agent"]["session_id"] == "12345678901234567890" for row in rows))
+        self.assertEqual(rows[0]["agent"]["messages"][0]["content"], "segment-0")
+        self.assertEqual(rows[1]["agent"]["messages"][0]["content"], "segment-1")
+        self.assertEqual([path.name for path in self.output_dir.glob("*.jsonl")], ["train_rollout_1.jsonl"])
+
+    def test_eval_keeps_artifacts_in_the_trajectory_file(self):
+        first_artifacts = {"large_blob": "first"}
+        second_artifacts = {"large_blob": "second"}
+        data_groups = [
+            [self._make_rollout(rollout_id=10, session_id=None, reward=0.0, artifacts=first_artifacts)],
+            [self._make_rollout(rollout_id=11, session_id=222, reward=1.0, artifacts=second_artifacts)],
+        ]
+        trajectory_path = self.output_dir / "eval_rollout_1.jsonl"
+
+        self.trainer._save_eval_trajectories(data_groups, trajectory_path)
+
+        summary, *rows = self._load_jsonl(trajectory_path)
+        self.assertEqual(summary["total_len"], 2)
+        self.assertEqual(summary["reward_mean"], 0.5)
+        self.assertEqual([row["agent"]["session_id"] for row in rows], [None, "222"])
+        self.assertEqual(
+            [row["agent"]["artifacts"] for row in rows],
+            [first_artifacts, second_artifacts],
+        )
+        self.assertEqual([path.name for path in self.output_dir.glob("*.jsonl")], ["eval_rollout_1.jsonl"])
+
+    def test_non_agent_rollout_keeps_null_agent_metadata(self):
+        data = RolloutState(
+            group_id=3,
+            rollout_id=20,
+            message=[{"role": "user", "content": "test"}],
+            num_tokens=1,
+            response="response",
+            response_ids=[10, 11],
+            reward={"score": 1.0},
+            status=Status.COMPLETED,
+            extra_fields={},
+        )
+        trajectory_path = self.output_dir / "train_rollout_1.jsonl"
+
+        self.trainer._save_trajectories([[data]], trajectory_path)
+
+        _, row = self._load_jsonl(trajectory_path)
+        self.assertIsNone(row["agent"]["session_id"])
+        self.assertIsNone(row["agent"]["segment_index"])
+        self.assertIsNone(row["agent"]["segment_count"])
+        self.assertIsNone(row["agent"]["artifacts"])
+
+    def test_invalid_train_group_is_not_written(self):
+        data = self._make_rollout(
+            rollout_id=20,
+            session_id=123,
+            reward=1.0,
+            artifacts={"large_blob": "discarded"},
+            status=Status.FAILED,
+        )
+        trajectory_path = self.output_dir / "train_rollout_1.jsonl"
+
+        self.trainer._save_trajectories([[data]], trajectory_path)
+
+        objects = self._load_jsonl(trajectory_path)
+        self.assertEqual(objects[0]["total_len"], 0)
+        self.assertEqual(len(objects), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
+++ b/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
@@ -292,7 +292,6 @@ class AgentInSandboxLoop(AgentLoop):
         if selected_agent is not None:
             rollout_state.extra_fields["agent_name"] = selected_agent.get("name")
             rollout_state.extra_fields["agent_selected"] = _to_json_safe(selected_agent)
-        rollout_state.extra_fields["agent_artifacts"] = _to_json_safe(item.artifacts)
         rollout_state.extra_fields["agent_judgers"] = {
             name: record.model_dump(mode="json") for name, record in item.judgers.items()
         }
@@ -302,6 +301,7 @@ class AgentInSandboxLoop(AgentLoop):
         if item.error is not None:
             rollout_state.error_msg = f"{item.error.stage}/{item.error.category}: {item.error.message}"
         if item.status != RolloutStatus.COMPLETED:
+            rollout_state.extra_fields["agent_artifacts"] = _to_json_safe(item.artifacts)
             return [rollout_state]
 
         segments = _load_train_trace_segments(item.artifacts)
@@ -350,6 +350,7 @@ class AgentInSandboxLoop(AgentLoop):
                 segment_state.response = _response_text(response_message)
             rollout_states.append(segment_state)
 
+        rollout_states[0].extra_fields["agent_artifacts"] = _to_json_safe(item.artifacts)
         return rollout_states
 
     def _fill_eval_rollout_state(self, rollout_state: RolloutState, item: AgentRolloutItem) -> None:

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1430,54 +1430,20 @@ class BaseRLTrainer:
 
     def _save_trajectories(self, data_groups: list[list[RolloutState]], save_path: Path) -> None:
         rewards = []
-        trajectory_items = []
+        response_len_list = []
+        valid_groups = []
 
         for group in data_groups:
             if not is_valid_for_training(group, self.logger):
                 continue
+            valid_groups.append(group)
             for data in group:
                 assert data.reward is not None
                 rewards.append(data.reward["score"])
                 response_ids = self._get_trajectory_response_ids(data)
-                response = data.response
-                if response is None and response_ids:
-                    response = self.tokenizer.decode(response_ids)
-                ground_truth = None
-                if data.reward_model is not None:
-                    ground_truth = data.reward_model.get("ground_truth")
-                response_len = len(response_ids)
-                trajectory_items.append(
-                    {
-                        "rollout_id": data.rollout_id,
-                        "group_id": data.group_id,
-                        "task_name": data.task_name,
-                        "data_source": data.data_source,
-                        "status": data.status.value if hasattr(data.status, "value") else str(data.status),
-                        "finish_reason": data.finish_reason,
-                        "error_msg": data.error_msg,
-                        "prompt": data.message,
-                        "label": ground_truth,
-                        "response": response,
-                        "reward": data.reward["score"],
-                        "prompt_len": data.num_tokens,
-                        "response_len": response_len,
-                        "reward_payload": data.reward,
-                        "agent": {
-                            "name": data.extra_fields.get("agent_name"),
-                            "selected": data.extra_fields.get("agent_selected"),
-                            "status": data.extra_fields.get("agent_status", None),
-                            "judgers": data.extra_fields.get("agent_judgers", None),
-                            "finish_info": data.extra_fields.get("agent_finish_info", None),
-                            "tool_turns": data.extra_fields.get("agent_tool_turns", None),
-                            "artifacts": data.extra_fields.get("agent_artifacts"),
-                            "messages": data.extra_fields.get("agent_messages"),
-                            "tools": data.extra_fields.get("agent_tools"),
-                        },
-                    }
-                )
+                response_len_list.append(len(response_ids))
 
         rewards_tensor = torch.tensor(rewards).float() if rewards else torch.tensor([0.0]).float()
-        response_len_list = [item["response_len"] for item in trajectory_items]
         response_lens = torch.tensor(response_len_list).float() if response_len_list else torch.tensor([0.0]).float()
 
         with open(save_path, "w", encoding="utf-8") as f:
@@ -1494,40 +1460,32 @@ class BaseRLTrainer:
             }
             json.dump(summary, f, ensure_ascii=False, separators=(",", ":"))
             f.write("\n")
-            for item in trajectory_items:
-                json.dump(item, f, ensure_ascii=False, separators=(",", ":"))
-                f.write("\n")
+            for group in valid_groups:
+                for data in group:
+                    assert data.reward is not None
+                    response_ids = self._get_trajectory_response_ids(data)
+                    response = data.response
+                    if response is None and response_ids:
+                        response = self.tokenizer.decode(response_ids)
+                    ground_truth = None
+                    if data.reward_model is not None:
+                        ground_truth = data.reward_model.get("ground_truth")
 
-    def _save_eval_trajectories(self, data_groups: list[list[RolloutState]], save_path: Path) -> None:
-        rewards = []
-        trajectory_items = []
-
-        for group in data_groups:
-            for data in group:
-                reward = data.reward["score"] if data.reward is not None and "score" in data.reward else 0.0
-                response = data.response or ""
-                response_ids = self._get_trajectory_response_ids(data)
-                response_len = len(response_ids)
-                rewards.append(reward)
-                ground_truth = None
-                if data.reward_model is not None:
-                    ground_truth = data.reward_model.get("ground_truth")
-                trajectory_items.append(
-                    {
+                    item = {
                         "rollout_id": data.rollout_id,
                         "group_id": data.group_id,
                         "task_name": data.task_name,
                         "data_source": data.data_source,
                         "status": data.status.value if hasattr(data.status, "value") else str(data.status),
-                        "prompt": data.message,
-                        "response": response,
-                        "prompt_len": data.num_tokens,
-                        "response_len": response_len,
-                        "label": ground_truth,
-                        "reward": reward,
-                        "reward_payload": data.reward or {"score": reward},
                         "finish_reason": data.finish_reason,
                         "error_msg": data.error_msg,
+                        "prompt": data.message,
+                        "label": ground_truth,
+                        "response": response,
+                        "reward": data.reward["score"],
+                        "prompt_len": data.num_tokens,
+                        "response_len": len(response_ids),
+                        "reward_payload": data.reward,
                         "agent": {
                             "name": data.extra_fields.get("agent_name"),
                             "selected": data.extra_fields.get("agent_selected"),
@@ -1535,15 +1493,29 @@ class BaseRLTrainer:
                             "judgers": data.extra_fields.get("agent_judgers", None),
                             "finish_info": data.extra_fields.get("agent_finish_info", None),
                             "tool_turns": data.extra_fields.get("agent_tool_turns", None),
+                            "session_id": str(data.session_id) if data.session_id is not None else None,
+                            "segment_index": data.extra_fields.get("agent_trace_segment_index"),
+                            "segment_count": data.extra_fields.get("agent_trace_segment_count"),
                             "artifacts": data.extra_fields.get("agent_artifacts"),
                             "messages": data.extra_fields.get("agent_messages"),
                             "tools": data.extra_fields.get("agent_tools"),
                         },
                     }
-                )
+                    json.dump(item, f, ensure_ascii=False, separators=(",", ":"))
+                    f.write("\n")
+
+    def _save_eval_trajectories(self, data_groups: list[list[RolloutState]], save_path: Path) -> None:
+        rewards = []
+        response_len_list = []
+
+        for group in data_groups:
+            for data in group:
+                reward = data.reward["score"] if data.reward is not None and "score" in data.reward else 0.0
+                response_ids = self._get_trajectory_response_ids(data)
+                rewards.append(reward)
+                response_len_list.append(len(response_ids))
 
         rewards_tensor = torch.tensor(rewards).float() if rewards else torch.tensor([0.0]).float()
-        response_len_list = [item["response_len"] for item in trajectory_items]
         response_lens = torch.tensor(response_len_list).float() if response_len_list else torch.tensor([0.0]).float()
 
         with open(save_path, "w", encoding="utf-8") as f:
@@ -1560,9 +1532,46 @@ class BaseRLTrainer:
             }
             json.dump(summary, f, ensure_ascii=False, separators=(",", ":"))
             f.write("\n")
-            for item in trajectory_items:
-                json.dump(item, f, ensure_ascii=False, separators=(",", ":"))
-                f.write("\n")
+            for group in data_groups:
+                for data in group:
+                    reward = data.reward["score"] if data.reward is not None and "score" in data.reward else 0.0
+                    response_ids = self._get_trajectory_response_ids(data)
+                    ground_truth = None
+                    if data.reward_model is not None:
+                        ground_truth = data.reward_model.get("ground_truth")
+
+                    item = {
+                        "rollout_id": data.rollout_id,
+                        "group_id": data.group_id,
+                        "task_name": data.task_name,
+                        "data_source": data.data_source,
+                        "status": data.status.value if hasattr(data.status, "value") else str(data.status),
+                        "prompt": data.message,
+                        "response": data.response or "",
+                        "prompt_len": data.num_tokens,
+                        "response_len": len(response_ids),
+                        "label": ground_truth,
+                        "reward": reward,
+                        "reward_payload": data.reward or {"score": reward},
+                        "finish_reason": data.finish_reason,
+                        "error_msg": data.error_msg,
+                        "agent": {
+                            "name": data.extra_fields.get("agent_name"),
+                            "selected": data.extra_fields.get("agent_selected"),
+                            "status": data.extra_fields.get("agent_status", None),
+                            "judgers": data.extra_fields.get("agent_judgers", None),
+                            "finish_info": data.extra_fields.get("agent_finish_info", None),
+                            "tool_turns": data.extra_fields.get("agent_tool_turns", None),
+                            "session_id": str(data.session_id) if data.session_id is not None else None,
+                            "segment_index": data.extra_fields.get("agent_trace_segment_index"),
+                            "segment_count": data.extra_fields.get("agent_trace_segment_count"),
+                            "artifacts": data.extra_fields.get("agent_artifacts"),
+                            "messages": data.extra_fields.get("agent_messages"),
+                            "tools": data.extra_fields.get("agent_tools"),
+                        },
+                    }
+                    json.dump(item, f, ensure_ascii=False, separators=(",", ":"))
+                    f.write("\n")
 
     def _get_trajectory_response_ids(self, data: RolloutState) -> list[int]:
         if data.response_ids is not None:


### PR DESCRIPTION
## Summary

This PR fixes the repeated ownership and serialization of session-level agent artifacts after a sandbox rollout is split into multiple trainable segments.

- Keep the complete artifacts on segment 0 instead of deep-copying them into every segment.
- Preserve artifacts on the single state returned by failed train rollouts and eval rollouts.
- Keep per-segment messages and tools, and expose the session ID, segment index, and segment count in trajectory rows.
- Stream rows into the existing trajectory JSONL instead of staging all serialized rows in memory.

## Root Cause

#1926 added complete agent artifacts to RolloutState for rollout observability. #1934 later added multi-segment training by deep-copying the base RolloutState once per trainable segment.

The artifacts were attached before that deep copy. A session with N trainable segments therefore retained N independent copies of the same session-level payload. The trajectory writer then materialized every row in memory and serialized the repeated artifacts into every segment row, amplifying both CPU memory and filesystem I/O by the segment count.

The model training path does not consume agent artifacts. By the time a segment reaches training, the required input IDs, labels, log probabilities, routed experts, and reward have already been materialized.

## Fix

For successful training rollouts, build every segment from a base state that does not contain agent artifacts, then attach one JSON-safe artifacts payload to segment 0 after segment construction. Failed train rollouts and eval rollouts still return one state and retain their complete artifacts.

The trajectory writer continues to produce one train_rollout or eval_rollout JSONL file. The summary remains the first line, followed by segment rows written one at a time. Each row includes session_id, segment_index, and segment_count. The artifacts field remains in its existing location: it contains the complete payload on segment 0 and is null on later segments.

This keeps ownership explicit at the rollout source. The writer does not maintain a seen-session cache, create a companion file, or silently repair duplicated input states.

## Impact

- Training tensors, rewards, advantages, messages, tools, and segment ordering are unchanged.
- Complete artifacts remain available once per session for debugging and observability.
- Existing non-agent rollouts keep null agent metadata.
- No configuration option, new session abstraction, ObjectRef store, compression layer, or companion-file lifecycle is introduced.

Consumers that previously read agent.artifacts from every segment should read it from segment 0, identified by session_id and segment_index.

## Reproduction

The issue was observed in a train_rollout_1.jsonl file with 1,275 segment rows and a total size of 68.8 GB. In one sampled session:

| Metric | Value |
| --- | ---: |
| Trainable segments | 22 |
| One serialized artifacts payload | 3,358,105 bytes |
| Artifacts bytes written before this fix | 73,878,310 bytes |
| Artifacts bytes written after this fix | 3,358,105 bytes |

The sampled artifacts payload was identical across all 22 segment rows. Routed experts were not serialized in the JSONL and are unrelated to this issue.

## Test Plan

- Trajectory ownership and logging regression tests: 8 passed.
- Related colocated and disaggregated trainer lifecycle tests: 6 passed.
- Upstream GitHub Actions lint workflow: passed.
- Local codespell, docformatter, pyupgrade, Ruff lint, Ruff format, and git diff checks: passed.

The full repository unit-test matrix is left to upstream CI.

## Out of Scope

This PR does not change routed-expert storage, trace-store lifetime, replay-buffer grouping, JSON compression, or the contents of the artifacts payload itself.