### PR TITLE
[Fix] Preserve MTP gradients with detached checkpoint inputs

### DIFF
--- a/tests/model/test_glm52_mtp_checkpoint_repro.py
+++ b/tests/model/test_glm52_mtp_checkpoint_repro.py
@@ -1,7 +1,7 @@
 """GLM-5.2 MTP reentrant checkpoint 的真实训练回归测试。
 
 TestGlm52CompiledMTPCheckpoint
-    test_shared_mtp_depths_train_with_compile_and_topk_offload: 共享 MTP 深度可在 compile/offload 下训练。
+    test_shared_mtp_depths_train_with_compile_and_topk_offload: 全 detach 的共享 MTP 可在 compile/offload 下训练。
 TestGlm52MicroBatchMTPCheckpoint
     test_nested_micro_batch_inputs_preserve_gradients: EP2 micro2 的嵌套 embedding 梯度可正确反传。
 """
@@ -12,6 +12,7 @@ import unittest
 from unittest import mock
 
 import torch
+from torch.distributed.tensor import DTensor
 
 from xtuner._testing import DeterministicDDPTestCase
 from xtuner.v1.config import AdamWConfig, FSDPConfig
@@ -25,7 +26,14 @@ from xtuner.v1.module.mtp import MTPConfig
 from xtuner.v1.module.router.noaux_router import NoAuxRouterConfig
 
 
-def _tiny_mtp_config(ep_size: int, mtp_num_layers: int, compile_model: bool) -> Glm52MoEConfig:
+def _tiny_mtp_config(
+    ep_size: int,
+    mtp_num_layers: int,
+    compile_model: bool,
+    *,
+    detach_mtp_inputs: bool = False,
+    detach_mtp_lm_head_weight: bool = False,
+) -> Glm52MoEConfig:
     return Glm52MoEConfig(
         vocab_size=32,
         max_position_embeddings=64,
@@ -63,7 +71,12 @@ def _tiny_mtp_config(ep_size: int, mtp_num_layers: int, compile_model: bool) -> 
             router_scaling_factor=2.5,
         ),
         mlp_layer_types=["sparse", "sparse"],
-        mtp_config=MTPConfig(num_layers=mtp_num_layers, share_weights=True),
+        mtp_config=MTPConfig(
+            num_layers=mtp_num_layers,
+            share_weights=True,
+            detach_mtp_inputs=detach_mtp_inputs,
+            detach_mtp_lm_head_weight=detach_mtp_lm_head_weight,
+        ),
         lm_loss_cfg=CELossConfig(mode="eager"),
         compile_cfg=None if compile_model else False,
         dispatcher="all2all" if ep_size > 1 else None,
@@ -77,9 +90,17 @@ def _build_engine(
     ep_size: int,
     mtp_num_layers: int,
     compile_model: bool,
+    detach_mtp_inputs: bool = False,
+    detach_mtp_lm_head_weight: bool = False,
 ) -> TrainEngine:
     engine = TrainEngine(
-        model_cfg=_tiny_mtp_config(ep_size, mtp_num_layers, compile_model),
+        model_cfg=_tiny_mtp_config(
+            ep_size,
+            mtp_num_layers,
+            compile_model,
+            detach_mtp_inputs=detach_mtp_inputs,
+            detach_mtp_lm_head_weight=detach_mtp_lm_head_weight,
+        ),
         optim_cfg=AdamWConfig(lr=1e-3, foreach=False),
         fsdp_cfg=FSDPConfig(
             ep_size=ep_size,
@@ -104,13 +125,15 @@ def _model_item(engine: TrainEngine, start: int) -> ModelItem:
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
 class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
     def test_shared_mtp_depths_train_with_compile_and_topk_offload(self):
-        # 验证默认 reentrant checkpoint 可训练共享 MTP 深度且 loss 有限。
+        # 验证全 detach 输入仍会触发默认 reentrant replay，并为共享 MTP 参数生成梯度。
         self.create_pg("cuda")
         engine = _build_engine(
             intra_layer_micro_batch=1,
             ep_size=1,
             mtp_num_layers=2,
             compile_model=True,
+            detach_mtp_inputs=True,
+            detach_mtp_lm_head_weight=True,
         )
         try:
             with mock.patch.dict(
@@ -121,6 +144,17 @@ class TestGlm52CompiledMTPCheckpoint(DeterministicDDPTestCase):
 
             assert math.isfinite(step_info["total_loss"])
             assert math.isfinite(step_info["logs_info"]["reduced_mtp_loss"])
+            mtp_projection_grads = [
+                parameter.grad
+                for name, parameter in engine.model.named_parameters()
+                if "mtp_block" in name and name.endswith("eh_proj.weight")
+            ]
+            assert len(mtp_projection_grads) == 1
+            projection_grad = mtp_projection_grads[0]
+            assert projection_grad is not None
+            local_grad = projection_grad.to_local() if isinstance(projection_grad, DTensor) else projection_grad
+            assert torch.isfinite(local_grad).all()
+            assert local_grad.norm() > 0
         finally:
             del engine
             torch.cuda.empty_cache()

--- a/tests/utils/test_pytree_reentrant_checkpoint.py
+++ b/tests/utils/test_pytree_reentrant_checkpoint.py
@@ -2,6 +2,7 @@
 
 TestPytreeReentrantCheckpoint
     test_nested_inputs_preserve_both_gradient_paths: 嵌套输入在 checkpoint 内外复用时梯度正确汇合。
+    test_detached_inputs_still_update_module_parameters: 全 detached 输入仍可触发重算并更新模块参数。
 """
 
 import torch
@@ -14,6 +15,15 @@ from xtuner.v1.model.utils import checkpoint_wrapper, pytree_reentrant_checkpoin
 class NestedTensorBlock(nn.Module):
     def forward(self, direct: torch.Tensor, nested: list[torch.Tensor]) -> torch.Tensor:
         return direct * nested[0]
+
+
+class ParameterOnlyBlock(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor([2.0]))
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.weight * inputs
 
 
 class TestPytreeReentrantCheckpoint:
@@ -34,3 +44,22 @@ class TestPytreeReentrantCheckpoint:
 
         torch.testing.assert_close(direct_source.grad, torch.tensor([30.0]))
         torch.testing.assert_close(nested_source.grad, torch.tensor([102.0]))
+
+    def test_detached_inputs_still_update_module_parameters(self):
+        # MTP 会刻意 detach backbone 输入，但 checkpoint 仍须重算模块以生成其参数梯度。
+        module = ParameterOnlyBlock()
+        block = checkpoint_wrapper(
+            module,
+            checkpoint_impl=CheckpointImpl.REENTRANT,
+            checkpoint_fn=pytree_reentrant_checkpoint,
+        )
+        detached_inputs = torch.tensor([3.0])
+        unrelated_parameter = nn.Parameter(torch.tensor([1.0]))
+
+        loss = block(detached_inputs).sum() + unrelated_parameter.sum() * 0.0
+        loss.backward()
+
+        assert module.weight.grad is not None
+        torch.testing.assert_close(module.weight.grad, torch.tensor([3.0]))
+        assert detached_inputs.grad is None
+        torch.testing.assert_close(unrelated_parameter.grad, torch.tensor([0.0]))

--- a/xtuner/v1/model/utils/checkpointing.py
+++ b/xtuner/v1/model/utils/checkpointing.py
@@ -111,10 +111,21 @@ def pytree_reentrant_checkpoint(
     # 这样 checkpoint 能逐个 detach；tree_unflatten 再在 replay 前把 list 还原。
     flat_inputs, input_spec = tree_flatten((args, kwargs))
 
+    has_grad_input = any(isinstance(value, torch.Tensor) and value.requires_grad for value in flat_inputs)
+    checkpoint_inputs = flat_inputs
+    if not has_grad_input:
+        # Reentrant checkpoint 没有 grad 输入时不会重算。这个零元素 leaf 只负责
+        # 保留 backward 入口，不参与模块计算，也不会把梯度接回已 detach 的原图。
+        first_tensor = next(value for value in flat_inputs if isinstance(value, torch.Tensor))
+        checkpoint_entry = torch.empty(0, device=first_tensor.device, requires_grad=True)
+        checkpoint_inputs = [checkpoint_entry, *flat_inputs]
+
     def run_function(*replayed_flat_inputs: Any) -> torch.Tensor | tuple[torch.Tensor, ...]:
         # 这里只还原参数结构，不会把 detached Tensor 重新连接到旧 graph；梯度由
         # CheckpointFunction.backward 的返回值交回原始 Tensor。
+        if not has_grad_input:
+            replayed_flat_inputs = replayed_flat_inputs[1:]
         replayed_args, replayed_kwargs = tree_unflatten(list(replayed_flat_inputs), input_spec)
         return function(*replayed_args, **replayed_kwargs)
 
-    return checkpoint(run_function, *flat_inputs, use_reentrant=True)
+    return checkpoint(run_function, *checkpoint_inputs, use_reentrant=True)

--- a/xtuner/v1/rl/trainer/worker.py
+++ b/xtuner/v1/rl/trainer/worker.py
@@ -193,6 +193,7 @@ class WorkerTrainLogItem(TypedDict, total=False):
     step_consumed_tokens: int
     efficient_attn_ratio: float
     grad_norm: float
+    mtp_grad_parameter_coverage: float
     max_memory: float
     reserved_memory: float
 
@@ -276,6 +277,11 @@ class TrainingWorker(SingleAcceleratorWorker):
         elif hasattr(worker_cfg.model_cfg, "mtp_config"):
             # 非 compose 模型的 mtp_config 直接放在了 model_cfg 中
             self.mtp_config = worker_cfg.model_cfg.mtp_config
+        self._mtp_trainable_parameters = (
+            [parameter for name, parameter in self._engine.model.trainable_parameters() if "mtp_block" in name]
+            if self.mtp_config is not None
+            else []
+        )
 
         self.update_weighter = WeightUpdater(
             rank=self.rank,
@@ -829,6 +835,14 @@ class TrainingWorker(SingleAcceleratorWorker):
                 f"Rank{self.rank} Rollout {rollout_idx} GlobalStep {global_train_step} "
                 f"train_step[{i}].engine_train_step elapsed={time.perf_counter() - train_step_begin:.4f}s"
             )
+            mtp_grad_metrics: dict[str, float] = {}
+            if self._mtp_trainable_parameters:
+                # `grad is None` is a structural signal: unlike a zero-valued grad,
+                # it means the MTP loss never reached that trainable parameter.
+                present_grad_count = sum(parameter.grad is not None for parameter in self._mtp_trainable_parameters)
+                mtp_grad_metrics = {
+                    "mtp_grad_parameter_coverage": present_grad_count / len(self._mtp_trainable_parameters),
+                }
             grad_norm = self._engine.clip_grad_norm()
             self._engine.step_optimizer(grad_norm)
 
@@ -854,6 +868,7 @@ class TrainingWorker(SingleAcceleratorWorker):
                 **engine_logs_info,  # type: ignore[typeddict-item]
                 **train_step_info,
                 **extra_info_dict,
+                **mtp_grad_metrics,  # type: ignore[typeddict-item]
                 grad_norm=grad_norm.item(),
                 max_memory=max_memory,
                 reserved_memory=reserved_memory,


### PR DESCRIPTION
## Motivation

When MTP detaches both its backbone inputs and LM-head inputs, the reentrant checkpoint receives no tensor requiring gradients. PyTorch then skips checkpoint replay, so the MTP loss can be non-zero while all trainable MTP parameters keep `grad=None`.

## Changes

- Add a zero-element, grad-bearing checkpoint entry only when all flattened checkpoint inputs are detached, and remove it before reconstructing the original pytree inputs.
- Preserve the intended detach boundary and the existing reentrant replay lifecycle, including DSA cache cleanup.
- Add regression coverage for detached checkpoint inputs and the real GLM-5.2 shared-MTP path.
- Report the low-cost `mtp_grad_parameter_coverage` signal from the training worker.

## Validation

- `pytest -q tests/utils/test_pytree_reentrant_checkpoint.py tests/module/attention/test_dsa_mla.py::TestDSAAttention::test_reentrant_checkpoint_reuses_and_releases_topk` — 3 passed
- `ruff check` on all changed files — passed
- `ruff format --check` on all changed files — passed
- `git diff --check` — passed

