### PR TITLE
[Refactor] Move sample validation into AgentLoop

### DIFF
--- a/autotest/config/rl_interns2_preview_dapo.py
+++ b/autotest/config/rl_interns2_preview_dapo.py
@@ -184,7 +184,6 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=1000000,
 )
 agent_loop_manager_cfg = AgentLoopManagerConfig(
@@ -192,6 +191,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=sampler_config,
     ),

--- a/autotest/config/rl_interns2_preview_dapo.py
+++ b/autotest/config/rl_interns2_preview_dapo.py
@@ -191,7 +191,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=sampler_config,
     ),

--- a/autotest/config/rl_interns2_preview_vl_dapo.py
+++ b/autotest/config/rl_interns2_preview_vl_dapo.py
@@ -267,7 +267,6 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=1000000,
 )
 
@@ -281,6 +280,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/autotest/config/rl_interns2_preview_vl_dapo.py
+++ b/autotest/config/rl_interns2_preview_vl_dapo.py
@@ -280,7 +280,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/autotest/config/rl_interns2_preview_vl_dapo_ep2_resume.py
+++ b/autotest/config/rl_interns2_preview_vl_dapo_ep2_resume.py
@@ -267,7 +267,6 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=1000000,
 )
 
@@ -281,6 +280,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/autotest/config/rl_interns2_preview_vl_dapo_ep2_resume.py
+++ b/autotest/config/rl_interns2_preview_vl_dapo_ep2_resume.py
@@ -280,7 +280,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/autotest/config/rl_interns2_preview_vl_grpo.py
+++ b/autotest/config/rl_interns2_preview_vl_grpo.py
@@ -267,7 +267,6 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=1000000,
 )
 
@@ -281,6 +280,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/autotest/config/rl_interns2_preview_vl_grpo.py
+++ b/autotest/config/rl_interns2_preview_vl_grpo.py
@@ -280,7 +280,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/autotest/config/rl_qwen3p5_vl_35B_mtp_ep.py
+++ b/autotest/config/rl_qwen3p5_vl_35B_mtp_ep.py
@@ -295,7 +295,6 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=3,
 )
 
@@ -309,6 +308,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/autotest/config/rl_qwen3p5_vl_35B_mtp_ep.py
+++ b/autotest/config/rl_qwen3p5_vl_35B_mtp_ep.py
@@ -308,7 +308,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
+++ b/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
@@ -291,10 +291,9 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=3,
 )
-# produce_strategy_config= SyncProduceStrategyConfig(is_valid_sample_fn=group_sample_filter_func)
+# produce_strategy_config = SyncProduceStrategyConfig()
 
 # 6. agent loop managers
 agent_loop_config = SingleTurnAgentLoopConfig(
@@ -306,6 +305,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
+++ b/examples/v1/config/reasoning_rl_qwen3p5vl_mtp_ep.py
@@ -305,7 +305,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/examples/v1/config/rl_dapo_math_async_filter.py
+++ b/examples/v1/config/rl_dapo_math_async_filter.py
@@ -157,13 +157,13 @@ produce_strategy_config = AsyncProduceStrategyConfig(
     enable_partial_rollout=True,
     max_staleness=0,
     tail_batch_trigger_size=256,
-    is_valid_sample_fn=group_samples_filter_func
 )
 agent_loop_manager_cfg = AgentLoopManagerConfig(
     tasks=TaskSpecConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
+        filter_func=group_samples_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=sampler_config,
     ),

--- a/examples/v1/config/rl_dapo_math_async_filter.py
+++ b/examples/v1/config/rl_dapo_math_async_filter.py
@@ -163,7 +163,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
         task_name="train_task",
         agent_loop_config=agent_loop_config,
         judger_config=judger_config,
-        filter_func=group_samples_filter_func,
+        is_valid_sample_fn=group_samples_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=sampler_config,
     ),

--- a/examples/v1/config/rl_interns2_preview_gsm8k_dapo.py
+++ b/examples/v1/config/rl_interns2_preview_gsm8k_dapo.py
@@ -193,7 +193,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
             sample_params=training_sample_params,
         ),
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=AsyncProduceStrategyConfig(
             over_sample_threshold=1,
             enable_partial_rollout=1,

--- a/examples/v1/config/rl_interns2_preview_gsm8k_dapo.py
+++ b/examples/v1/config/rl_interns2_preview_gsm8k_dapo.py
@@ -193,10 +193,10 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
             sample_params=training_sample_params,
         ),
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=AsyncProduceStrategyConfig(
             over_sample_threshold=1,
             enable_partial_rollout=1,
-            is_valid_sample_fn=group_sample_filter_func,
             max_staleness=1000000,
         ),
         sampler_config=SamplerConfig(

--- a/examples/v1/config/rl_interns2_preview_vl_dapo.py
+++ b/examples/v1/config/rl_interns2_preview_vl_dapo.py
@@ -284,7 +284,6 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=1000000,
 )
 
@@ -297,6 +296,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
             sample_params=training_sample_params,
         ),
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/examples/v1/config/rl_interns2_preview_vl_dapo.py
+++ b/examples/v1/config/rl_interns2_preview_vl_dapo.py
@@ -296,7 +296,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
             sample_params=training_sample_params,
         ),
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/examples/v1/config/rl_interns2_preview_vl_grpo.py
+++ b/examples/v1/config/rl_interns2_preview_vl_grpo.py
@@ -292,7 +292,6 @@ def group_sample_filter_func(group_samples):
 produce_strategy_config = AsyncProduceStrategyConfig(
     over_sample_threshold=1,
     enable_partial_rollout=1,
-    is_valid_sample_fn=group_sample_filter_func,
     max_staleness=1000000,
 )
 
@@ -305,6 +304,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
             sample_params=training_sample_params,
         ),
         judger_config=judger_config,
+        filter_func=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/examples/v1/config/rl_interns2_preview_vl_grpo.py
+++ b/examples/v1/config/rl_interns2_preview_vl_grpo.py
@@ -304,7 +304,7 @@ agent_loop_manager_cfg = AgentLoopManagerConfig(
             sample_params=training_sample_params,
         ),
         judger_config=judger_config,
-        filter_func=group_sample_filter_func,
+        is_valid_sample_fn=group_sample_filter_func,
         produce_strategy_config=produce_strategy_config,
         sampler_config=SamplerConfig(dataloader_cfg=dataloader_cfg, prompt_repeat_k=prompt_repeat_k),
     ),

--- a/tests/rl/test_multi_task_agent_loop_manager.py
+++ b/tests/rl/test_multi_task_agent_loop_manager.py
@@ -216,6 +216,43 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(manager_config.tasks.task_name, "single_task")
 
+    def test_manager_config_injects_filter_when_building_agent_loop(self):
+        filter_func = MagicMock()
+        built_agent_loop = _fake_agent_loop()
+        agent_loop_config = MagicMock()
+        agent_loop_config.build.return_value = built_agent_loop
+        produce_strategy_config = MagicMock()
+        produce_strategy_config.build.return_value = _FakeProduceStrategy()
+        sampler_config = MagicMock()
+        sampler_config.build.return_value = _FakeSampler()
+        task = TaskSpecConfig.model_construct(
+            task_name="filtered_task",
+            agent_loop_config=agent_loop_config,
+            judger_config=None,
+            filter_func=filter_func,
+            produce_strategy_config=produce_strategy_config,
+            sampler_config=sampler_config,
+            weight=1.0,
+        )
+        rollout_controller = _fake_rollout_controller()
+        tokenizer = MagicMock()
+        replay_buffer = MagicMock()
+
+        manager = AgentLoopManagerConfig(tasks=task).build(
+            rollout_controller=rollout_controller,
+            tokenizer=tokenizer,
+            replay_buffer=replay_buffer,
+        )
+
+        agent_loop_config.build.assert_called_once_with(
+            rollout_controller=rollout_controller,
+            judger=None,
+            logger=None,
+            filter_func=filter_func,
+        )
+        self.assertIs(manager.task_runners[0].agent_loop, built_agent_loop)
+        self.assertFalse(hasattr(manager.task_runners[0], "is_valid_sample_fn"))
+
     async def test_take_train_batch_applies_token_staleness_mask(self):
         # 启用 token staleness 时，公开 produce_batch 路径应返回最终 effective mask。
         state = RolloutState(

--- a/tests/rl/test_multi_task_agent_loop_manager.py
+++ b/tests/rl/test_multi_task_agent_loop_manager.py
@@ -11,6 +11,7 @@
 
 import asyncio
 import unittest
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -22,12 +23,17 @@ from xtuner.v1.rl.agent_loop_manager.agent_loop_manager import (
 )
 from xtuner.v1.rl.agent_loop_manager.disagg_agent_loop_manager import (
     DisaggAgentLoopManager,
+    DisaggAgentLoopManagerConfig,
+    DisaggTaskSpecConfig,
 )
+from xtuner.v1.rl.agent_loop_manager.disagg_producer import DisaggAsyncProduceStrategyConfig
 from xtuner.v1.rl.agent_loop_manager.produce_utils import (
     GROUP_GENERATE_TIME_KEY,
     ProduceBatchStatus,
     _TaskRunner,
 )
+from xtuner.v1.rl.agent_loop_manager.producer import SyncProduceStrategyConfig
+from xtuner.v1.train.rl_trainer import _migrate_legacy_is_valid_sample_fn
 
 
 class _FakeSampler:
@@ -216,8 +222,8 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(manager_config.tasks.task_name, "single_task")
 
-    def test_manager_config_injects_filter_when_building_agent_loop(self):
-        filter_func = MagicMock()
+    def test_manager_config_injects_validity_check_when_building_agent_loop(self):
+        is_valid_sample_fn = MagicMock()
         built_agent_loop = _fake_agent_loop()
         agent_loop_config = MagicMock()
         agent_loop_config.build.return_value = built_agent_loop
@@ -229,7 +235,7 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
             task_name="filtered_task",
             agent_loop_config=agent_loop_config,
             judger_config=None,
-            filter_func=filter_func,
+            is_valid_sample_fn=is_valid_sample_fn,
             produce_strategy_config=produce_strategy_config,
             sampler_config=sampler_config,
             weight=1.0,
@@ -248,10 +254,61 @@ class TestMultiTaskAgentLoopManager(unittest.IsolatedAsyncioTestCase):
             rollout_controller=rollout_controller,
             judger=None,
             logger=None,
-            filter_func=filter_func,
+            is_valid_sample_fn=is_valid_sample_fn,
         )
         self.assertIs(manager.task_runners[0].agent_loop, built_agent_loop)
-        self.assertFalse(hasattr(manager.task_runners[0], "is_valid_sample_fn"))
+
+    def test_trainer_migrates_legacy_validity_check_from_produce_strategy(self):
+        is_valid_sample_fn = MagicMock()
+        colocate_task = TaskSpecConfig.model_construct(
+            task_name="colocate",
+            agent_loop_config=MagicMock(),
+            judger_config=None,
+            is_valid_sample_fn=None,
+            produce_strategy_config=SyncProduceStrategyConfig(is_valid_sample_fn=is_valid_sample_fn),
+            sampler_config=MagicMock(),
+            weight=1.0,
+        )
+        disagg_task = DisaggTaskSpecConfig.model_construct(
+            task_name="disagg",
+            agent_loop_config=MagicMock(),
+            judger_config=None,
+            is_valid_sample_fn=None,
+            produce_strategy_config=DisaggAsyncProduceStrategyConfig(is_valid_sample_fn=is_valid_sample_fn),
+            sampler_config=MagicMock(),
+            weight=1.0,
+        )
+        cfg = SimpleNamespace(
+            agent_loop_manager_cfg=DisaggAgentLoopManagerConfig(tasks=disagg_task),
+            eval_agent_loop_manager_cfg=AgentLoopManagerConfig(tasks=colocate_task),
+        )
+        logger = MagicMock()
+
+        _migrate_legacy_is_valid_sample_fn(cfg, logger)
+
+        self.assertIs(cfg.agent_loop_manager_cfg.tasks.is_valid_sample_fn, is_valid_sample_fn)
+        self.assertIsNone(cfg.agent_loop_manager_cfg.tasks.produce_strategy_config.is_valid_sample_fn)
+        self.assertIs(cfg.eval_agent_loop_manager_cfg.tasks.is_valid_sample_fn, is_valid_sample_fn)
+        self.assertIsNone(cfg.eval_agent_loop_manager_cfg.tasks.produce_strategy_config.is_valid_sample_fn)
+        self.assertEqual(logger.warning.call_count, 2)
+
+    def test_trainer_rejects_conflicting_legacy_and_task_validity_checks(self):
+        task = TaskSpecConfig.model_construct(
+            task_name="conflict",
+            agent_loop_config=MagicMock(),
+            judger_config=None,
+            is_valid_sample_fn=MagicMock(),
+            produce_strategy_config=SyncProduceStrategyConfig(is_valid_sample_fn=MagicMock()),
+            sampler_config=MagicMock(),
+            weight=1.0,
+        )
+        cfg = SimpleNamespace(
+            agent_loop_manager_cfg=AgentLoopManagerConfig(tasks=task),
+            eval_agent_loop_manager_cfg=None,
+        )
+
+        with self.assertRaisesRegex(ValueError, "configures is_valid_sample_fn in both"):
+            _migrate_legacy_is_valid_sample_fn(cfg, MagicMock())
 
     async def test_take_train_batch_applies_token_staleness_mask(self):
         # 启用 token staleness 时，公开 produce_batch 路径应返回最终 effective mask。

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -12,7 +12,7 @@ Bad Tests:
 
 本文件主要覆盖的 public 行为:
 - sampler 优先复用可重试 Rollout Group，耗尽后回退 dataloader。
-- ProduceContext 统一处理生成结果落库、过滤、raw reward 和模型版本记录。
+- AgentLoop 负责过滤，ProduceContext 统一处理生成结果落库、raw reward 和模型版本记录。
 - SyncProduceStrategy / AsyncProduceStrategy 通过共卡入口完成生产，不返回状态控制信号。
 - DisaggAsyncProduceStrategy 返回 UPDATE_WEIGHT_AND_ABORT、EXPIRED_BATCH 的后台生产状态。
 - AsyncProduceStrategy 的 oversample、tail-batch、partial rollout、pause drain 和 staleness 结果。
@@ -23,6 +23,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status, discard_rollout_state
+from xtuner.v1.rl.agent_loop import AgentLoop
 from xtuner.v1.rl.agent_loop_manager import (
     AsyncProduceStrategyConfig,
     DisaggAsyncProduceStrategyConfig,
@@ -117,6 +118,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             return rs
 
         mock_agent_loop.generate_group = mock_gen
+        mock_agent_loop.collect_rollout_group = AgentLoop.collect_rollout_group.__get__(mock_agent_loop)
         return mock_agent_loop
 
     def _build_context(
@@ -130,6 +132,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         train_step: int = 0,
         model_step: int = 0,
         progress: ProduceProgress | None = None,
+        is_valid_sample_fn=None,
     ) -> ProduceContext:
         # 测试只走新的 ProduceContext 入口，不再覆盖旧散装参数兼容逻辑。
         if progress is None:
@@ -143,7 +146,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             train_step=train_step,
             model_step=model_step,
             progress=progress,
-            is_valid_sample_fn=strategy.is_valid_sample_fn,
+            is_valid_sample_fn=is_valid_sample_fn,
             stale_threshold=getattr(strategy, "stale_threshold", None),
             token_stale_threshold=getattr(strategy, "token_stale_threshold", None),
             expired_groups_retryable=getattr(strategy, "tail_batch_trigger_size", -1) >= 0,
@@ -180,6 +183,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         model_step: int = 0,
         progress: DisaggProduceProgress | None = None,
         update_event: asyncio.Event | None = None,
+        is_valid_sample_fn=None,
     ) -> DisaggProduceContext:
         if progress is None:
             progress = self._build_disagg_progress(task_name, target=batch_size, train_step=train_step)
@@ -195,7 +199,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             update_event=update_event,
             model_step=model_step,
             progress=progress,
-            is_valid_sample_fn=strategy.is_valid_sample_fn,
+            is_valid_sample_fn=is_valid_sample_fn,
             stale_threshold=getattr(strategy, "stale_threshold", None),
             token_stale_threshold=getattr(strategy, "token_stale_threshold", None),
             expired_groups_retryable=getattr(strategy, "tail_batch_trigger_size", -1) >= 0,
@@ -331,8 +335,8 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(discarded.routed_experts)
         self.assertEqual(discarded.extra_fields, {})
 
-    async def test_put_generated_group_only_validates_completed_group(self):
-        # 验证 ProduceContext 只对 completed group 执行业务过滤，aborted group 保持可重试状态。
+    async def test_collection_filters_only_completed_group(self):
+        # 过滤由 AgentLoop collection 执行；Producer 只处理返回状态和数据所有权。
         task_name = "test_valid_completed_only"
         valid_checked_statuses = []
 
@@ -340,16 +344,18 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             valid_checked_statuses.append([sample.status for sample in samples])
             return False
 
-        strategy = SyncProduceStrategyConfig(is_valid_sample_fn=is_valid_sample_fn).build()
+        strategy = SyncProduceStrategyConfig().build()
         ctx = self._build_context(
             strategy,
             task_name,
             self._build_agent_loop(),
             self._build_sampler(),
             batch_size=1,
+            is_valid_sample_fn=is_valid_sample_fn,
         )
 
         completed_group = [make_rollout_state(1, status=Status.COMPLETED)]
+        completed_group = await ctx.collect_rollout_group(completed_group)
         self.assertFalse(await ctx.put_generated_group(completed_group))
         self.assertIsNone(completed_group[0].uid)
 
@@ -391,13 +397,14 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         )
         for status, is_valid, session_id in cases:
             with self.subTest(status=status):
-                strategy = SyncProduceStrategyConfig(is_valid_sample_fn=lambda _samples: is_valid).build()
+                strategy = SyncProduceStrategyConfig().build()
                 ctx = self._build_context(
                     strategy,
                     f"non_retryable_{status.name.lower()}",
                     self._build_agent_loop(),
                     self._build_sampler(),
                     batch_size=1,
+                    is_valid_sample_fn=lambda _samples: is_valid,
                 )
                 item = make_rollout_state(session_id, status=status, reward_score=1.0)
                 item.session_id = session_id
@@ -407,7 +414,10 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                     "xtuner.v1.rl.rollout.trace_store.release_existing_sessions",
                     new=AsyncMock(return_value={str(session_id)}),
                 ) as release_sessions:
-                    self.assertFalse(await ctx.put_generated_group([item]))
+                    group = [item]
+                    if status == Status.COMPLETED:
+                        group = await ctx.collect_rollout_group(group)
+                    self.assertFalse(await ctx.put_generated_group(group))
 
                 release_sessions.assert_awaited_once_with([str(session_id)])
                 self.assertIsNone(item.session_id)
@@ -420,19 +430,21 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         def is_valid_sample_fn(samples):
             return False
 
-        strategy = SyncProduceStrategyConfig(is_valid_sample_fn=is_valid_sample_fn).build()
+        strategy = SyncProduceStrategyConfig().build()
         ctx = self._build_context(
             strategy,
             task_name,
             self._build_agent_loop(),
             self._build_sampler(),
             batch_size=1,
+            is_valid_sample_fn=is_valid_sample_fn,
         )
 
         completed_group = [
             make_rollout_state(1, status=Status.COMPLETED, reward_score=0.25),
             make_rollout_state(2, status=Status.COMPLETED, reward_score=0.75),
         ]
+        completed_group = await ctx.collect_rollout_group(completed_group)
         self.assertFalse(await ctx.put_generated_group(completed_group))
 
         self.assertTrue(all(item.uid is None for item in completed_group))
@@ -506,7 +518,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
 
         mock_agent_loop = self._build_agent_loop()
         mock_agent_loop.generate_group = mock_gen
-        strategy = SyncProduceStrategyConfig(is_valid_sample_fn=is_valid_sample_fn).build()
+        strategy = SyncProduceStrategyConfig().build()
         sampler = self._build_sampler()
         ctx = self._build_context(
             strategy,
@@ -517,6 +529,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             train_step=4,
             model_step=3,
             progress=self._build_progress(task_name, target=2),
+            is_valid_sample_fn=is_valid_sample_fn,
         )
 
         await strategy.produce_batch(ctx)
@@ -547,7 +560,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                 r.status = Status.COMPLETED
             return rs
 
-        mock_agent_loop.generate_group = mock_gen
+        mock_agent_loop.collect_rollout_group = mock_gen
 
         sampler_cfg = SamplerConfig.model_construct(dataloader_cfg=self.mock_dataloader_cfg)
         produce_strategy_cfg = AsyncProduceStrategyConfig(over_sample_threshold=1)

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -97,7 +97,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             target_samples={task_name: target},
         )
 
-    def _build_agent_loop(self, sleep_by_id: dict[int, float] | None = None):
+    def _build_agent_loop(self, sleep_by_id: dict[int, float] | None = None, filter_func=None):
         mock_agent_loop = MagicMock()
         mock_agent_loop.rollout_ctl.continue_generation.remote = AsyncMock(return_value=None)
         mock_agent_loop.rollout_ctl.pause_generation.remote = AsyncMock(return_value=None)
@@ -118,6 +118,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             return rs
 
         mock_agent_loop.generate_group = mock_gen
+        mock_agent_loop.filter_func = filter_func
         mock_agent_loop.collect_rollout_group = AgentLoop.collect_rollout_group.__get__(mock_agent_loop)
         return mock_agent_loop
 
@@ -132,7 +133,6 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         train_step: int = 0,
         model_step: int = 0,
         progress: ProduceProgress | None = None,
-        is_valid_sample_fn=None,
     ) -> ProduceContext:
         # 测试只走新的 ProduceContext 入口，不再覆盖旧散装参数兼容逻辑。
         if progress is None:
@@ -146,7 +146,6 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             train_step=train_step,
             model_step=model_step,
             progress=progress,
-            is_valid_sample_fn=is_valid_sample_fn,
             stale_threshold=getattr(strategy, "stale_threshold", None),
             token_stale_threshold=getattr(strategy, "token_stale_threshold", None),
             expired_groups_retryable=getattr(strategy, "tail_batch_trigger_size", -1) >= 0,
@@ -183,7 +182,6 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         model_step: int = 0,
         progress: DisaggProduceProgress | None = None,
         update_event: asyncio.Event | None = None,
-        is_valid_sample_fn=None,
     ) -> DisaggProduceContext:
         if progress is None:
             progress = self._build_disagg_progress(task_name, target=batch_size, train_step=train_step)
@@ -199,7 +197,6 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             update_event=update_event,
             model_step=model_step,
             progress=progress,
-            is_valid_sample_fn=is_valid_sample_fn,
             stale_threshold=getattr(strategy, "stale_threshold", None),
             token_stale_threshold=getattr(strategy, "token_stale_threshold", None),
             expired_groups_retryable=getattr(strategy, "tail_batch_trigger_size", -1) >= 0,
@@ -226,6 +223,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             ),
         )
         self.assertEqual(colocate_ctx.batch_target, 1)
+        self.assertFalse(hasattr(colocate_ctx, "is_valid_sample_fn"))
         for disagg_only_name in ("update_event", "should_abort", "available_count", "total_target"):
             self.assertFalse(hasattr(colocate_ctx, disagg_only_name), disagg_only_name)
 
@@ -243,6 +241,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             update_event=update_event,
         )
         self.assertEqual(disagg_ctx.total_target, 2)
+        self.assertFalse(hasattr(disagg_ctx, "is_valid_sample_fn"))
         self.assertEqual(await disagg_ctx.available_count(), 1)
         self.assertFalse(disagg_ctx.should_abort())
         update_event.set()
@@ -348,10 +347,9 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         ctx = self._build_context(
             strategy,
             task_name,
-            self._build_agent_loop(),
+            self._build_agent_loop(filter_func=is_valid_sample_fn),
             self._build_sampler(),
             batch_size=1,
-            is_valid_sample_fn=is_valid_sample_fn,
         )
 
         completed_group = [make_rollout_state(1, status=Status.COMPLETED)]
@@ -401,10 +399,9 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                 ctx = self._build_context(
                     strategy,
                     f"non_retryable_{status.name.lower()}",
-                    self._build_agent_loop(),
+                    self._build_agent_loop(filter_func=lambda _samples: is_valid),
                     self._build_sampler(),
                     batch_size=1,
-                    is_valid_sample_fn=lambda _samples: is_valid,
                 )
                 item = make_rollout_state(session_id, status=status, reward_score=1.0)
                 item.session_id = session_id
@@ -434,10 +431,9 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         ctx = self._build_context(
             strategy,
             task_name,
-            self._build_agent_loop(),
+            self._build_agent_loop(filter_func=is_valid_sample_fn),
             self._build_sampler(),
             batch_size=1,
-            is_valid_sample_fn=is_valid_sample_fn,
         )
 
         completed_group = [
@@ -516,7 +512,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                     r.reward = {"score": 1.0}
             return rs
 
-        mock_agent_loop = self._build_agent_loop()
+        mock_agent_loop = self._build_agent_loop(filter_func=is_valid_sample_fn)
         mock_agent_loop.generate_group = mock_gen
         strategy = SyncProduceStrategyConfig().build()
         sampler = self._build_sampler()
@@ -529,7 +525,6 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             train_step=4,
             model_step=3,
             progress=self._build_progress(task_name, target=2),
-            is_valid_sample_fn=is_valid_sample_fn,
         )
 
         await strategy.produce_batch(ctx)

--- a/tests/rl/test_producer.py
+++ b/tests/rl/test_producer.py
@@ -23,7 +23,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xtuner.v1.data_proto.rl_data import RolloutState, Status, discard_rollout_state
-from xtuner.v1.rl.agent_loop import AgentLoop
+from xtuner.v1.rl.agent_loop import maybe_filter_invalid_sample
 from xtuner.v1.rl.agent_loop_manager import (
     AsyncProduceStrategyConfig,
     DisaggAsyncProduceStrategyConfig,
@@ -97,7 +97,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             target_samples={task_name: target},
         )
 
-    def _build_agent_loop(self, sleep_by_id: dict[int, float] | None = None, filter_func=None):
+    def _build_agent_loop(self, sleep_by_id: dict[int, float] | None = None, is_valid_sample_fn=None):
         mock_agent_loop = MagicMock()
         mock_agent_loop.rollout_ctl.continue_generation.remote = AsyncMock(return_value=None)
         mock_agent_loop.rollout_ctl.pause_generation.remote = AsyncMock(return_value=None)
@@ -115,11 +115,10 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             for r in rs:
                 r.seq_staleness = kwargs.get("model_step", kwargs.get("train_step", 0))
                 r.status = Status.COMPLETED
-            return rs
+            return maybe_filter_invalid_sample(rs, is_valid_sample_fn, mock_agent_loop.logger)
 
         mock_agent_loop.generate_group = mock_gen
-        mock_agent_loop.filter_func = filter_func
-        mock_agent_loop.collect_rollout_group = AgentLoop.collect_rollout_group.__get__(mock_agent_loop)
+        mock_agent_loop.is_valid_sample_fn = is_valid_sample_fn
         return mock_agent_loop
 
     def _build_context(
@@ -334,8 +333,8 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(discarded.routed_experts)
         self.assertEqual(discarded.extra_fields, {})
 
-    async def test_collection_filters_only_completed_group(self):
-        # 过滤由 AgentLoop collection 执行；Producer 只处理返回状态和数据所有权。
+    async def test_generation_filters_only_completed_group(self):
+        # 过滤由 AgentLoop generation 执行；Producer 只处理返回状态和数据所有权。
         task_name = "test_valid_completed_only"
         valid_checked_statuses = []
 
@@ -347,13 +346,13 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         ctx = self._build_context(
             strategy,
             task_name,
-            self._build_agent_loop(filter_func=is_valid_sample_fn),
+            self._build_agent_loop(is_valid_sample_fn=is_valid_sample_fn),
             self._build_sampler(),
             batch_size=1,
         )
 
         completed_group = [make_rollout_state(1, status=Status.COMPLETED)]
-        completed_group = await ctx.collect_rollout_group(completed_group)
+        completed_group = await ctx.generate_group(completed_group)
         self.assertFalse(await ctx.put_generated_group(completed_group))
         self.assertIsNone(completed_group[0].uid)
 
@@ -399,7 +398,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                 ctx = self._build_context(
                     strategy,
                     f"non_retryable_{status.name.lower()}",
-                    self._build_agent_loop(filter_func=lambda _samples: is_valid),
+                    self._build_agent_loop(is_valid_sample_fn=lambda _samples: is_valid),
                     self._build_sampler(),
                     batch_size=1,
                 )
@@ -413,7 +412,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                 ) as release_sessions:
                     group = [item]
                     if status == Status.COMPLETED:
-                        group = await ctx.collect_rollout_group(group)
+                        group = await ctx.generate_group(group)
                     self.assertFalse(await ctx.put_generated_group(group))
 
                 release_sessions.assert_awaited_once_with([str(session_id)])
@@ -431,7 +430,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
         ctx = self._build_context(
             strategy,
             task_name,
-            self._build_agent_loop(filter_func=is_valid_sample_fn),
+            self._build_agent_loop(is_valid_sample_fn=is_valid_sample_fn),
             self._build_sampler(),
             batch_size=1,
         )
@@ -440,7 +439,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
             make_rollout_state(1, status=Status.COMPLETED, reward_score=0.25),
             make_rollout_state(2, status=Status.COMPLETED, reward_score=0.75),
         ]
-        completed_group = await ctx.collect_rollout_group(completed_group)
+        completed_group = await ctx.generate_group(completed_group)
         self.assertFalse(await ctx.put_generated_group(completed_group))
 
         self.assertTrue(all(item.uid is None for item in completed_group))
@@ -510,9 +509,9 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                     r.response = "ok"
                     r.response_ids = [1, 2]
                     r.reward = {"score": 1.0}
-            return rs
+            return maybe_filter_invalid_sample(rs, is_valid_sample_fn, mock_agent_loop.logger)
 
-        mock_agent_loop = self._build_agent_loop(filter_func=is_valid_sample_fn)
+        mock_agent_loop = self._build_agent_loop(is_valid_sample_fn=is_valid_sample_fn)
         mock_agent_loop.generate_group = mock_gen
         strategy = SyncProduceStrategyConfig().build()
         sampler = self._build_sampler()
@@ -555,7 +554,7 @@ class TestProducer(unittest.IsolatedAsyncioTestCase):
                 r.status = Status.COMPLETED
             return rs
 
-        mock_agent_loop.collect_rollout_group = mock_gen
+        mock_agent_loop.generate_group = mock_gen
 
         sampler_cfg = SamplerConfig.model_construct(dataloader_cfg=self.mock_dataloader_cfg)
         produce_strategy_cfg = AsyncProduceStrategyConfig(over_sample_threshold=1)

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -100,7 +100,6 @@ def _build_fake_agent_loop():
         return rollout_states
 
     agent_loop.generate_group = generate_group
-    agent_loop.collect_rollout_group = generate_group
     return agent_loop
 
 

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -100,6 +100,7 @@ def _build_fake_agent_loop():
         return rollout_states
 
     agent_loop.generate_group = generate_group
+    agent_loop.collect_rollout_group = generate_group
     return agent_loop
 
 

--- a/tests/rl/test_single_turn_agent_loop.py
+++ b/tests/rl/test_single_turn_agent_loop.py
@@ -4,7 +4,7 @@
 当前测试点：
 - batch judge 只在整组样本全部 COMPLETED 时触发。
 - batch judge 返回结果必须保持输入顺序。
-- rollout group filter 在 batch judge 之后执行。
+- rollout group validity check 在 batch judge 之后执行。
 - 组内存在 ABORTED / FAILED 等非 COMPLETED 样本时跳过 judge。
 - pause 发生在 slow judger 期间时，整组样本被标记为 ABORTED。
 """
@@ -68,7 +68,7 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
             extra_fields={},
         )
 
-    def _build_loop(self, statuses_by_uid: dict[int, Status], judger=None, filter_func=None):
+    def _build_loop(self, statuses_by_uid: dict[int, Status], judger=None, is_valid_sample_fn=None):
         loop = SingleTurnAgentLoop.__new__(SingleTurnAgentLoop)
         rollout_ctl = MagicMock()
         rollout_ctl.generate = _RemoteGenerate(statuses_by_uid)
@@ -77,25 +77,25 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
         loop.sample_params = SampleParams(max_tokens=8, temperature=0.7)
         loop.judger = judger
         loop.enable_batch_judge = True
-        loop.filter_func = filter_func
+        loop.is_valid_sample_fn = is_valid_sample_fn
         loop._judger_pause_event = asyncio.Event()
         loop.logger = MagicMock()
         return loop
 
-    def test_config_binds_filter_to_local_agent_loop_once(self):
-        filter_func = MagicMock()
+    def test_config_binds_validity_check_to_local_agent_loop_once(self):
+        is_valid_sample_fn = MagicMock()
         local_loop = MagicMock()
         config = SingleTurnAgentLoopConfig.model_construct(hf_checkpoint="unused", cpu_resources=None)
 
         with patch.object(SingleTurnAgentLoopConfig, "build_local", return_value=local_loop) as build_local:
-            result = config.build(MagicMock(), filter_func=filter_func)
+            result = config.build(MagicMock(), is_valid_sample_fn=is_valid_sample_fn)
 
         self.assertIs(result, local_loop)
-        self.assertIs(local_loop.filter_func, filter_func)
+        self.assertIs(local_loop.is_valid_sample_fn, is_valid_sample_fn)
         build_local.assert_called_once()
 
-    def test_config_forwards_filter_when_building_ray_actor(self):
-        filter_func = MagicMock()
+    def test_config_forwards_validity_check_when_building_ray_actor(self):
+        is_valid_sample_fn = MagicMock()
         ray_agent_loop = MagicMock()
         cpu_resources = MagicMock()
         cpu_resources.num_workers = 1
@@ -108,38 +108,39 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
             patch("xtuner.v1.rl.agent_loop.agent_loop.register_cpu_resources"),
             patch.object(SingleTurnAgentLoopConfig, "_build_ray_actor", return_value=ray_agent_loop) as build_actor,
         ):
-            result = config.build(MagicMock(), filter_func=filter_func)
+            result = config.build(MagicMock(), is_valid_sample_fn=is_valid_sample_fn)
 
         self.assertIs(result, ray_agent_loop)
-        self.assertIs(build_actor.call_args.kwargs["filter_func"], filter_func)
+        self.assertIs(build_actor.call_args.kwargs["is_valid_sample_fn"], is_valid_sample_fn)
 
-    def test_actor_binds_filter_during_construction(self):
-        filter_func = MagicMock()
+    def test_actor_binds_validity_check_during_construction(self):
+        is_valid_sample_fn = MagicMock()
         local_loop = MagicMock()
         config = MagicMock()
         config.build_local.return_value = local_loop
 
-        actor = AgentLoopActor(config, MagicMock(), filter_func=filter_func)
+        actor = AgentLoopActor(config, MagicMock(), is_valid_sample_fn=is_valid_sample_fn)
 
-        self.assertIs(actor.agent_loop.filter_func, filter_func)
+        self.assertIs(actor.agent_loop.is_valid_sample_fn, is_valid_sample_fn)
 
-    async def test_collect_filters_completed_group_after_batch_judge(self):
+    async def test_generate_filters_completed_group_after_batch_judge_and_logs(self):
         filtered_rewards = []
 
-        def filter_func(samples):
+        def is_valid_sample_fn(samples):
             filtered_rewards.extend(state.reward for state in samples)
             return False
 
         loop = self._build_loop(
             {1: Status.COMPLETED, 2: Status.COMPLETED},
             judger=_BatchJudger(),
-            filter_func=filter_func,
+            is_valid_sample_fn=is_valid_sample_fn,
         )
 
-        result = await loop.collect_rollout_group([self._state(1), self._state(2)])
+        result = await loop.generate_group([self._state(1), self._state(2)])
 
         self.assertEqual(filtered_rewards, [{"score": 1.0}, {"score": 2.0}])
         self.assertTrue(all(state.status == Status.FILTERED for state in result))
+        loop.logger.info.assert_called_once()
 
     async def test_batch_judge_runs_once_when_all_samples_completed_and_preserves_order(self):
         # 整组样本全部 COMPLETED 时才触发 batch judger；返回顺序必须和输入顺序一致。

--- a/tests/rl/test_single_turn_agent_loop.py
+++ b/tests/rl/test_single_turn_agent_loop.py
@@ -4,6 +4,7 @@
 当前测试点：
 - batch judge 只在整组样本全部 COMPLETED 时触发。
 - batch judge 返回结果必须保持输入顺序。
+- rollout group filter 在 batch judge 之后执行。
 - 组内存在 ABORTED / FAILED 等非 COMPLETED 样本时跳过 judge。
 - pause 发生在 slow judger 期间时，整组样本被标记为 ABORTED。
 """
@@ -13,7 +14,8 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
-from xtuner.v1.rl.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
+from xtuner.v1.rl.agent_loop import AgentLoopActor
+from xtuner.v1.rl.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop, SingleTurnAgentLoopConfig
 
 
 class _RemoteGenerate:
@@ -66,7 +68,7 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
             extra_fields={},
         )
 
-    def _build_loop(self, statuses_by_uid: dict[int, Status], judger=None):
+    def _build_loop(self, statuses_by_uid: dict[int, Status], judger=None, filter_func=None):
         loop = SingleTurnAgentLoop.__new__(SingleTurnAgentLoop)
         rollout_ctl = MagicMock()
         rollout_ctl.generate = _RemoteGenerate(statuses_by_uid)
@@ -75,9 +77,69 @@ class TestSingleTurnAgentLoop(unittest.IsolatedAsyncioTestCase):
         loop.sample_params = SampleParams(max_tokens=8, temperature=0.7)
         loop.judger = judger
         loop.enable_batch_judge = True
+        loop.filter_func = filter_func
         loop._judger_pause_event = asyncio.Event()
         loop.logger = MagicMock()
         return loop
+
+    def test_config_binds_filter_to_local_agent_loop_once(self):
+        filter_func = MagicMock()
+        local_loop = MagicMock()
+        config = SingleTurnAgentLoopConfig.model_construct(hf_checkpoint="unused", cpu_resources=None)
+
+        with patch.object(SingleTurnAgentLoopConfig, "build_local", return_value=local_loop) as build_local:
+            result = config.build(MagicMock(), filter_func=filter_func)
+
+        self.assertIs(result, local_loop)
+        self.assertIs(local_loop.filter_func, filter_func)
+        build_local.assert_called_once()
+
+    def test_config_forwards_filter_when_building_ray_actor(self):
+        filter_func = MagicMock()
+        ray_agent_loop = MagicMock()
+        cpu_resources = MagicMock()
+        cpu_resources.num_workers = 1
+        config = SingleTurnAgentLoopConfig.model_construct(
+            hf_checkpoint="unused",
+            cpu_resources=cpu_resources,
+        )
+
+        with (
+            patch("xtuner.v1.rl.agent_loop.agent_loop.register_cpu_resources"),
+            patch.object(SingleTurnAgentLoopConfig, "_build_ray_actor", return_value=ray_agent_loop) as build_actor,
+        ):
+            result = config.build(MagicMock(), filter_func=filter_func)
+
+        self.assertIs(result, ray_agent_loop)
+        self.assertIs(build_actor.call_args.kwargs["filter_func"], filter_func)
+
+    def test_actor_binds_filter_during_construction(self):
+        filter_func = MagicMock()
+        local_loop = MagicMock()
+        config = MagicMock()
+        config.build_local.return_value = local_loop
+
+        actor = AgentLoopActor(config, MagicMock(), filter_func=filter_func)
+
+        self.assertIs(actor.agent_loop.filter_func, filter_func)
+
+    async def test_collect_filters_completed_group_after_batch_judge(self):
+        filtered_rewards = []
+
+        def filter_func(samples):
+            filtered_rewards.extend(state.reward for state in samples)
+            return False
+
+        loop = self._build_loop(
+            {1: Status.COMPLETED, 2: Status.COMPLETED},
+            judger=_BatchJudger(),
+            filter_func=filter_func,
+        )
+
+        result = await loop.collect_rollout_group([self._state(1), self._state(2)])
+
+        self.assertEqual(filtered_rewards, [{"score": 1.0}, {"score": 2.0}])
+        self.assertTrue(all(state.status == Status.FILTERED for state in result))
 
     async def test_batch_judge_runs_once_when_all_samples_completed_and_preserves_order(self):
         # 整组样本全部 COMPLETED 时才触发 batch judger；返回顺序必须和输入顺序一致。

--- a/xtuner/v1/rl/agent_loop/__init__.py
+++ b/xtuner/v1/rl/agent_loop/__init__.py
@@ -3,11 +3,12 @@ from .agent_loop import (
     AgentLoopActor,
     AgentLoopConfig,
     AgentLoopSpec,
+    IsValidSampleFn,
     RayAgentLoop,
     RayAgentLoopProxy,
-    RolloutGroupFilter,
     RouterAgentLoop,
     get_agent_loop_rollout_ctl,
+    maybe_filter_invalid_sample,
 )
 from .single_turn_agent_loop import SingleTurnAgentLoop, SingleTurnAgentLoopConfig
 
@@ -17,11 +18,12 @@ __all__ = [
     "SingleTurnAgentLoopConfig",
     "AgentLoop",
     "AgentLoopSpec",
+    "IsValidSampleFn",
     "AgentLoopActor",
     "RouterAgentLoop",
     "RayAgentLoop",
     "RayAgentLoopProxy",
-    "RolloutGroupFilter",
+    "maybe_filter_invalid_sample",
     "SingleTurnAgentLoop",
     "get_agent_loop_rollout_ctl",
 ]

--- a/xtuner/v1/rl/agent_loop/__init__.py
+++ b/xtuner/v1/rl/agent_loop/__init__.py
@@ -5,6 +5,7 @@ from .agent_loop import (
     AgentLoopSpec,
     RayAgentLoop,
     RayAgentLoopProxy,
+    RolloutGroupFilter,
     RouterAgentLoop,
     get_agent_loop_rollout_ctl,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "RouterAgentLoop",
     "RayAgentLoop",
     "RayAgentLoopProxy",
+    "RolloutGroupFilter",
     "SingleTurnAgentLoop",
     "get_agent_loop_rollout_ctl",
 ]

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -30,6 +30,7 @@ from xtuner.v1.utils.processing_utils import load_processor, load_tokenizer
 
 
 AGENT_LOOP_CONCURRENCY_GROUP_GENERATE = "generate"
+RolloutGroupFilter: TypeAlias = Callable[[list[RolloutState]], bool]
 
 
 class AgentLoopConfig(ABC, BaseModel):
@@ -40,13 +41,22 @@ class AgentLoopConfig(ABC, BaseModel):
     enable_batch_judge: bool = False
     requires_rollout_proxy: bool = False
 
-    def build(self, rollout_controller, judger: Judger | None = None, logger=None) -> AgentLoopSpec:
+    def build(
+        self,
+        rollout_controller,
+        judger: Judger | None = None,
+        logger=None,
+        *,
+        filter_func: RolloutGroupFilter | None = None,
+    ) -> AgentLoopSpec:
         if self.cpu_resources is None:
-            return self.build_local(
+            agent_loop = self.build_local(
                 rollout_controller=rollout_controller,
                 judger=judger,
                 logger=logger,
             )
+            agent_loop.filter_func = filter_func
+            return agent_loop
 
         concurrency = AGENT_LOOP_RAY_GENERATE_MAX_CONCURRENCY
 
@@ -62,6 +72,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 concurrency=concurrency,
                 judger=judger,
                 logger=logger,
+                filter_func=filter_func,
             )
         return self._build_ray_actor(
             rollout_controller=rollout_controller,
@@ -69,6 +80,7 @@ class AgentLoopConfig(ABC, BaseModel):
             concurrency=concurrency,
             judger=judger,
             logger=logger,
+            filter_func=filter_func,
         )
 
     @abstractmethod
@@ -87,6 +99,7 @@ class AgentLoopConfig(ABC, BaseModel):
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
         logger=None,
+        filter_func: RolloutGroupFilter | None = None,
     ) -> RayAgentLoopProxy:
         ray_agent_loop = ray.remote(
             concurrency_groups={
@@ -105,6 +118,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 actor_num_cpus=cpu_resources.num_cpus_per_worker,
                 actor_memory=cpu_resources.cpu_memory_per_worker,
                 capture_child_tasks=True,
+                filter_func=filter_func,
             ),
         )
 
@@ -117,6 +131,7 @@ class AgentLoopConfig(ABC, BaseModel):
         judger: Judger | None = None,
         logger=None,
         start_bundle_idx: int = 0,
+        filter_func: RolloutGroupFilter | None = None,
     ) -> list[RayAgentLoopProxy]:
         ray_agent_loop = ray.remote(
             concurrency_groups={
@@ -136,6 +151,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 actor_num_cpus_per_worker=cpu_resources.num_cpus_per_worker,
                 actor_memory_per_worker=cpu_resources.cpu_memory_per_worker,
                 capture_child_tasks=True,
+                filter_func=filter_func,
             ),
         )
 
@@ -148,6 +164,7 @@ class AgentLoopConfig(ABC, BaseModel):
         judger: Judger | None = None,
         logger=None,
         start_bundle_idx: int = 0,
+        filter_func: RolloutGroupFilter | None = None,
     ) -> RouterAgentLoop:
         return RouterAgentLoop(
             workers=self._build_ray_actors(
@@ -158,6 +175,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 judger=judger,
                 logger=logger,
                 start_bundle_idx=start_bundle_idx,
+                filter_func=filter_func,
             ),
             rollout_ctl=rollout_controller,
         )
@@ -180,6 +198,7 @@ class AgentLoop(ABC):
         self.sample_params: SampleParams = sample_params if sample_params is not None else SampleParams()
         self.judger = judger
         self.enable_batch_judge = enable_batch_judge
+        self.filter_func: RolloutGroupFilter | None = None
         if logger is None:
             self.logger = get_logger()
         else:
@@ -205,14 +224,12 @@ class AgentLoop(ABC):
     async def collect_rollout_group(
         self,
         rollout_state: list[RolloutState],
-        *,
-        is_valid_sample_fn: Callable[[list[RolloutState]], bool] | None = None,
         **kwargs,
     ) -> list[RolloutState]:
         group = await self.generate_group(rollout_state, **kwargs)
         if get_group_status(group) != Status.COMPLETED:
             return group
-        if is_valid_sample_fn is not None and not is_valid_sample_fn(group):
+        if self.filter_func is not None and not self.filter_func(group):
             for state in group:
                 state.status = Status.FILTERED
         return group
@@ -337,12 +354,14 @@ class AgentLoopActor:
         rollout_controller: RolloutController,
         judger: Judger | None = None,
         logger=None,
+        filter_func: RolloutGroupFilter | None = None,
     ):
         self.agent_loop = agent_loop_config.build_local(
             rollout_controller=rollout_controller,
             judger=judger,
             logger=logger,
         )
+        self.agent_loop.filter_func = filter_func
 
     @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState:

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -30,7 +30,26 @@ from xtuner.v1.utils.processing_utils import load_processor, load_tokenizer
 
 
 AGENT_LOOP_CONCURRENCY_GROUP_GENERATE = "generate"
-RolloutGroupFilter: TypeAlias = Callable[[list[RolloutState]], bool]
+IsValidSampleFn: TypeAlias = Callable[[list[RolloutState]], bool]
+
+
+def maybe_filter_invalid_sample(
+    group: list[RolloutState],
+    is_valid_sample_fn: IsValidSampleFn | None,
+    logger,
+) -> list[RolloutState]:
+    """Mark a completed rollout group as filtered when it is invalid."""
+    if get_group_status(group) != Status.COMPLETED:
+        return group
+    if is_valid_sample_fn is None or is_valid_sample_fn(group):
+        return group
+
+    for state in group:
+        state.status = Status.FILTERED
+    group_id = group[0].group_id if group else None
+    rollout_ids = [state.rollout_id for state in group]
+    logger.info(f"Filtered invalid rollout group: group_id={group_id}, rollout_ids={rollout_ids}.")
+    return group
 
 
 class AgentLoopConfig(ABC, BaseModel):
@@ -47,7 +66,7 @@ class AgentLoopConfig(ABC, BaseModel):
         judger: Judger | None = None,
         logger=None,
         *,
-        filter_func: RolloutGroupFilter | None = None,
+        is_valid_sample_fn: IsValidSampleFn | None = None,
     ) -> AgentLoopSpec:
         if self.cpu_resources is None:
             agent_loop = self.build_local(
@@ -55,7 +74,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 judger=judger,
                 logger=logger,
             )
-            agent_loop.filter_func = filter_func
+            agent_loop.is_valid_sample_fn = is_valid_sample_fn
             return agent_loop
 
         concurrency = AGENT_LOOP_RAY_GENERATE_MAX_CONCURRENCY
@@ -72,7 +91,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 concurrency=concurrency,
                 judger=judger,
                 logger=logger,
-                filter_func=filter_func,
+                is_valid_sample_fn=is_valid_sample_fn,
             )
         return self._build_ray_actor(
             rollout_controller=rollout_controller,
@@ -80,7 +99,7 @@ class AgentLoopConfig(ABC, BaseModel):
             concurrency=concurrency,
             judger=judger,
             logger=logger,
-            filter_func=filter_func,
+            is_valid_sample_fn=is_valid_sample_fn,
         )
 
     @abstractmethod
@@ -99,7 +118,7 @@ class AgentLoopConfig(ABC, BaseModel):
         pg: PlacementGroup | None = None,
         judger: Judger | None = None,
         logger=None,
-        filter_func: RolloutGroupFilter | None = None,
+        is_valid_sample_fn: IsValidSampleFn | None = None,
     ) -> RayAgentLoopProxy:
         ray_agent_loop = ray.remote(
             concurrency_groups={
@@ -118,7 +137,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 actor_num_cpus=cpu_resources.num_cpus_per_worker,
                 actor_memory=cpu_resources.cpu_memory_per_worker,
                 capture_child_tasks=True,
-                filter_func=filter_func,
+                is_valid_sample_fn=is_valid_sample_fn,
             ),
         )
 
@@ -131,7 +150,7 @@ class AgentLoopConfig(ABC, BaseModel):
         judger: Judger | None = None,
         logger=None,
         start_bundle_idx: int = 0,
-        filter_func: RolloutGroupFilter | None = None,
+        is_valid_sample_fn: IsValidSampleFn | None = None,
     ) -> list[RayAgentLoopProxy]:
         ray_agent_loop = ray.remote(
             concurrency_groups={
@@ -151,7 +170,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 actor_num_cpus_per_worker=cpu_resources.num_cpus_per_worker,
                 actor_memory_per_worker=cpu_resources.cpu_memory_per_worker,
                 capture_child_tasks=True,
-                filter_func=filter_func,
+                is_valid_sample_fn=is_valid_sample_fn,
             ),
         )
 
@@ -164,7 +183,7 @@ class AgentLoopConfig(ABC, BaseModel):
         judger: Judger | None = None,
         logger=None,
         start_bundle_idx: int = 0,
-        filter_func: RolloutGroupFilter | None = None,
+        is_valid_sample_fn: IsValidSampleFn | None = None,
     ) -> RouterAgentLoop:
         return RouterAgentLoop(
             workers=self._build_ray_actors(
@@ -175,7 +194,7 @@ class AgentLoopConfig(ABC, BaseModel):
                 judger=judger,
                 logger=logger,
                 start_bundle_idx=start_bundle_idx,
-                filter_func=filter_func,
+                is_valid_sample_fn=is_valid_sample_fn,
             ),
             rollout_ctl=rollout_controller,
         )
@@ -198,7 +217,7 @@ class AgentLoop(ABC):
         self.sample_params: SampleParams = sample_params if sample_params is not None else SampleParams()
         self.judger = judger
         self.enable_batch_judge = enable_batch_judge
-        self.filter_func: RolloutGroupFilter | None = None
+        self.is_valid_sample_fn: IsValidSampleFn | None = None
         if logger is None:
             self.logger = get_logger()
         else:
@@ -219,20 +238,7 @@ class AgentLoop(ABC):
         if self.judger is not None and self.enable_batch_judge:
             if all(sample.status == Status.COMPLETED for sample in group_samples):
                 group_samples = await self.run_judger(group_samples)
-        return group_samples
-
-    async def collect_rollout_group(
-        self,
-        rollout_state: list[RolloutState],
-        **kwargs,
-    ) -> list[RolloutState]:
-        group = await self.generate_group(rollout_state, **kwargs)
-        if get_group_status(group) != Status.COMPLETED:
-            return group
-        if self.filter_func is not None and not self.filter_func(group):
-            for state in group:
-                state.status = Status.FILTERED
-        return group
+        return maybe_filter_invalid_sample(group_samples, self.is_valid_sample_fn, self.logger)
 
     @overload
     async def run_judger(self, rollout_state: RolloutState) -> RolloutState: ...
@@ -320,13 +326,6 @@ class RouterAgentLoop:
         finally:
             await self._release_worker(worker)
 
-    async def collect_rollout_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
-        worker = await self._pick_worker()
-        try:
-            return await worker.collect_rollout_group.remote(rollout_state, **kwargs)
-        finally:
-            await self._release_worker(worker)
-
     def get_worker_status(self) -> dict[str, int]:
         return {str(worker): load for worker, load in self._worker_loads.items()}
 
@@ -354,14 +353,14 @@ class AgentLoopActor:
         rollout_controller: RolloutController,
         judger: Judger | None = None,
         logger=None,
-        filter_func: RolloutGroupFilter | None = None,
+        is_valid_sample_fn: IsValidSampleFn | None = None,
     ):
         self.agent_loop = agent_loop_config.build_local(
             rollout_controller=rollout_controller,
             judger=judger,
             logger=logger,
         )
-        self.agent_loop.filter_func = filter_func
+        self.agent_loop.is_valid_sample_fn = is_valid_sample_fn
 
     @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState:
@@ -370,10 +369,6 @@ class AgentLoopActor:
     @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
     async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
         return await self.agent_loop.generate_group(rollout_state, **kwargs)
-
-    @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
-    async def collect_rollout_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
-        return await self.agent_loop.collect_rollout_group(rollout_state, **kwargs)
 
     @ray_method
     async def get_rollout_ctl(self):

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, TypeAlias, cast, overload
 
 import ray
@@ -9,7 +10,7 @@ from pydantic import BaseModel, ConfigDict
 from ray.actor import ActorClass, ActorProxy
 from ray.util.placement_group import PlacementGroup
 
-from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status
+from xtuner.v1.data_proto.rl_data import RolloutState, SampleParams, Status, get_group_status
 from xtuner.v1.rl.judger import Judger
 from xtuner.v1.rl.rollout import RolloutController
 from xtuner.v1.rl.rollout.constants import AGENT_LOOP_RAY_GENERATE_MAX_CONCURRENCY
@@ -201,6 +202,21 @@ class AgentLoop(ABC):
                 group_samples = await self.run_judger(group_samples)
         return group_samples
 
+    async def collect_rollout_group(
+        self,
+        rollout_state: list[RolloutState],
+        *,
+        is_valid_sample_fn: Callable[[list[RolloutState]], bool] | None = None,
+        **kwargs,
+    ) -> list[RolloutState]:
+        group = await self.generate_group(rollout_state, **kwargs)
+        if get_group_status(group) != Status.COMPLETED:
+            return group
+        if is_valid_sample_fn is not None and not is_valid_sample_fn(group):
+            for state in group:
+                state.status = Status.FILTERED
+        return group
+
     @overload
     async def run_judger(self, rollout_state: RolloutState) -> RolloutState: ...
 
@@ -287,6 +303,13 @@ class RouterAgentLoop:
         finally:
             await self._release_worker(worker)
 
+    async def collect_rollout_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
+        worker = await self._pick_worker()
+        try:
+            return await worker.collect_rollout_group.remote(rollout_state, **kwargs)
+        finally:
+            await self._release_worker(worker)
+
     def get_worker_status(self) -> dict[str, int]:
         return {str(worker): load for worker, load in self._worker_loads.items()}
 
@@ -328,6 +351,10 @@ class AgentLoopActor:
     @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
     async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
         return await self.agent_loop.generate_group(rollout_state, **kwargs)
+
+    @ray_method(concurrency_group=AGENT_LOOP_CONCURRENCY_GROUP_GENERATE)
+    async def collect_rollout_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
+        return await self.agent_loop.collect_rollout_group(rollout_state, **kwargs)
 
     @ray_method
     async def get_rollout_ctl(self):

--- a/xtuner/v1/rl/agent_loop/agent_loop.py
+++ b/xtuner/v1/rl/agent_loop/agent_loop.py
@@ -38,7 +38,18 @@ def maybe_filter_invalid_sample(
     is_valid_sample_fn: IsValidSampleFn | None,
     logger,
 ) -> list[RolloutState]:
-    """Mark a completed rollout group as filtered when it is invalid."""
+    """Finalize rollout-group validity after all generation post-processing.
+
+    Every custom ``AgentLoop.generate_group`` implementation must return through
+    this helper after generation, judging, flattening, and failure cleanup::
+
+        # Keep sample validation as the final group-generation step.
+        return maybe_filter_invalid_sample(
+            samples,
+            self.is_valid_sample_fn,
+            self.logger,
+        )
+    """
     if get_group_status(group) != Status.COMPLETED:
         return group
     if is_valid_sample_fn is None or is_valid_sample_fn(group):
@@ -228,6 +239,13 @@ class AgentLoop(ABC):
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState: ...
 
     async def generate_group(self, rollout_state: list[RolloutState], **kwargs) -> list[RolloutState]:
+        """Generate one rollout group.
+
+        Warning:
+            Subclasses overriding this method MUST call
+            ``maybe_filter_invalid_sample`` as the final step before returning.
+            Otherwise ``TaskSpecConfig.is_valid_sample_fn`` will be silently ignored.
+        """
         pending_tasks = []
         for state in rollout_state:
             state.sample_params = self.sample_params
@@ -238,6 +256,7 @@ class AgentLoop(ABC):
         if self.judger is not None and self.enable_batch_judge:
             if all(sample.status == Status.COMPLETED for sample in group_samples):
                 group_samples = await self.run_judger(group_samples)
+        # Keep sample validation as the final group-generation step.
         return maybe_filter_invalid_sample(group_samples, self.is_valid_sample_fn, self.logger)
 
     @overload

--- a/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
+++ b/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
@@ -148,6 +148,7 @@ class AgentInLocalhostLoop(AgentLoop):
 
         samples = await asyncio.gather(*tasks)
         samples = _drop_failed_train_samples(samples, self.mode)
+        # Keep sample validation as the final group-generation step.
         return maybe_filter_invalid_sample(samples, self.is_valid_sample_fn, self.logger)
 
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState:

--- a/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
+++ b/xtuner/v1/rl/agent_loop/localhost_agent_loop/agent_in_localhost_loop.py
@@ -20,7 +20,7 @@ from xtuner.v1.rl.rollout.chat_template import canonicalize_messages_for_chat_te
 from xtuner.v1.rl.rollout.trace_store import get_store
 from xtuner.v1.rl.utils import create_task
 
-from ..agent_loop import AgentLoop, AgentLoopConfig
+from ..agent_loop import AgentLoop, AgentLoopConfig, maybe_filter_invalid_sample
 
 
 def _import_from_path(path: str) -> Any:
@@ -147,7 +147,8 @@ class AgentInLocalhostLoop(AgentLoop):
             tasks.append(task)
 
         samples = await asyncio.gather(*tasks)
-        return _drop_failed_train_samples(samples, self.mode)
+        samples = _drop_failed_train_samples(samples, self.mode)
+        return maybe_filter_invalid_sample(samples, self.is_valid_sample_fn, self.logger)
 
     async def generate_sample(self, rollout_state: RolloutState, **kwargs) -> RolloutState:
         try:

--- a/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
+++ b/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
@@ -17,7 +17,7 @@ from xtuner.v1.rl.utils import create_task
 
 from ...rollout.chat_template import canonicalize_messages_for_chat_template
 from ...rollout.trace_store import get_store
-from ..agent_loop import AgentLoop, AgentLoopConfig
+from ..agent_loop import AgentLoop, AgentLoopConfig, maybe_filter_invalid_sample
 from .schemas import AgentRolloutItem, RolloutStatus
 
 
@@ -243,7 +243,8 @@ class AgentInSandboxLoop(AgentLoop):
         generated_samples = asyncio.gather(*pending_tasks)
         sample_groups = await generated_samples
         samples = [sample for sample_group in sample_groups for sample in sample_group]
-        return _drop_failed_train_samples(samples, self.mode)
+        samples = _drop_failed_train_samples(samples, self.mode)
+        return maybe_filter_invalid_sample(samples, self.is_valid_sample_fn, self.logger)
 
     # NOTE: A single sandbox session may yield multiple trainable segments, so this returns a list
     # rather than the base class's single RolloutState. The base contract is never exercised for

--- a/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
+++ b/xtuner/v1/rl/agent_loop/sandbox_agent_loop/agent_in_sandbox_loop.py
@@ -244,6 +244,7 @@ class AgentInSandboxLoop(AgentLoop):
         sample_groups = await generated_samples
         samples = [sample for sample_group in sample_groups for sample in sample_group]
         samples = _drop_failed_train_samples(samples, self.mode)
+        # Keep sample validation as the final group-generation step.
         return maybe_filter_invalid_sample(samples, self.is_valid_sample_fn, self.logger)
 
     # NOTE: A single sandbox session may yield multiple trainable segments, so this returns a list

--- a/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from xtuner.v1.data_proto.rl_data import Status
-from xtuner.v1.rl.agent_loop import AgentLoopConfig, RolloutGroupFilter
+from xtuner.v1.rl.agent_loop import AgentLoopConfig, IsValidSampleFn
 from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig, build_judger
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
 from xtuner.v1.rl.rollout import RolloutController
@@ -55,8 +55,8 @@ class TaskSpecConfig(BaseModel):
         judger_config (JudgerConfig | ComposedJudgerConfig | None): Optional
             judger configuration used to score generated samples. Defaults to
             None.
-        filter_func (RolloutGroupFilter | None): Optional group filter applied by
-            the agent loop after generation. Defaults to None.
+        is_valid_sample_fn (IsValidSampleFn | None): Optional validity check
+            applied by the agent loop after generation. Defaults to None.
         produce_strategy_config (ProduceStrategyConfig): Strategy used to
             produce rollout samples. Defaults to ``SyncProduceStrategyConfig``.
         sampler_config (SamplerConfig): Dataset sampler configuration for this
@@ -84,7 +84,7 @@ class TaskSpecConfig(BaseModel):
     weight: float = Field(default=1.0, ge=0.0)
     agent_loop_config: AgentLoopConfig
     judger_config: JudgerConfig | ComposedJudgerConfig | None = None
-    filter_func: RolloutGroupFilter | None = None
+    is_valid_sample_fn: IsValidSampleFn | None = None
     produce_strategy_config: ProduceStrategyConfig = SyncProduceStrategyConfig()
     sampler_config: SamplerConfig
 
@@ -145,7 +145,7 @@ class AgentLoopManagerConfig(BaseModel):
                 rollout_controller=rollout_controller,
                 judger=build_judger(task_cfg.judger_config) if task_cfg.judger_config is not None else None,
                 logger=logger,
-                filter_func=task_cfg.filter_func,
+                is_valid_sample_fn=task_cfg.is_valid_sample_fn,
             )
             produce_strategy = task_cfg.produce_strategy_config.build(
                 sync_weights_interval=sync_weights_interval,

--- a/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
@@ -18,6 +18,7 @@ from .produce_utils import (
     _MANAGER_STATE_PATH,
     _STATUS_POLL_INTERVAL_S,
     _TASK_CHECKPOINT_DIR,
+    IsValidSampleFn,
     ProduceBatchResult,
     _TaskRunner,
     _TaskSamplerView,
@@ -55,6 +56,8 @@ class TaskSpecConfig(BaseModel):
         judger_config (JudgerConfig | ComposedJudgerConfig | None): Optional
             judger configuration used to score generated samples. Defaults to
             None.
+        filter_func (IsValidSampleFn | None): Optional group filter applied by
+            the agent loop after generation. Defaults to None.
         produce_strategy_config (ProduceStrategyConfig): Strategy used to
             produce rollout samples. Defaults to ``SyncProduceStrategyConfig``.
         sampler_config (SamplerConfig): Dataset sampler configuration for this
@@ -82,6 +85,7 @@ class TaskSpecConfig(BaseModel):
     weight: float = Field(default=1.0, ge=0.0)
     agent_loop_config: AgentLoopConfig
     judger_config: JudgerConfig | ComposedJudgerConfig | None = None
+    filter_func: IsValidSampleFn | None = None
     produce_strategy_config: ProduceStrategyConfig = SyncProduceStrategyConfig()
     sampler_config: SamplerConfig
 
@@ -154,6 +158,7 @@ class AgentLoopManagerConfig(BaseModel):
                     agent_loop=agent_loop,
                     produce_strategy=produce_strategy,
                     sampler=sampler,
+                    is_valid_sample_fn=task_cfg.filter_func,
                     weight=task_cfg.weight,
                     order=order,
                 )

--- a/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/agent_loop_manager.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from xtuner.v1.data_proto.rl_data import Status
-from xtuner.v1.rl.agent_loop import AgentLoopConfig
+from xtuner.v1.rl.agent_loop import AgentLoopConfig, RolloutGroupFilter
 from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig, build_judger
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
 from xtuner.v1.rl.rollout import RolloutController
@@ -18,7 +18,6 @@ from .produce_utils import (
     _MANAGER_STATE_PATH,
     _STATUS_POLL_INTERVAL_S,
     _TASK_CHECKPOINT_DIR,
-    IsValidSampleFn,
     ProduceBatchResult,
     _TaskRunner,
     _TaskSamplerView,
@@ -56,7 +55,7 @@ class TaskSpecConfig(BaseModel):
         judger_config (JudgerConfig | ComposedJudgerConfig | None): Optional
             judger configuration used to score generated samples. Defaults to
             None.
-        filter_func (IsValidSampleFn | None): Optional group filter applied by
+        filter_func (RolloutGroupFilter | None): Optional group filter applied by
             the agent loop after generation. Defaults to None.
         produce_strategy_config (ProduceStrategyConfig): Strategy used to
             produce rollout samples. Defaults to ``SyncProduceStrategyConfig``.
@@ -85,7 +84,7 @@ class TaskSpecConfig(BaseModel):
     weight: float = Field(default=1.0, ge=0.0)
     agent_loop_config: AgentLoopConfig
     judger_config: JudgerConfig | ComposedJudgerConfig | None = None
-    filter_func: IsValidSampleFn | None = None
+    filter_func: RolloutGroupFilter | None = None
     produce_strategy_config: ProduceStrategyConfig = SyncProduceStrategyConfig()
     sampler_config: SamplerConfig
 
@@ -146,6 +145,7 @@ class AgentLoopManagerConfig(BaseModel):
                 rollout_controller=rollout_controller,
                 judger=build_judger(task_cfg.judger_config) if task_cfg.judger_config is not None else None,
                 logger=logger,
+                filter_func=task_cfg.filter_func,
             )
             produce_strategy = task_cfg.produce_strategy_config.build(
                 sync_weights_interval=sync_weights_interval,
@@ -158,7 +158,6 @@ class AgentLoopManagerConfig(BaseModel):
                     agent_loop=agent_loop,
                     produce_strategy=produce_strategy,
                     sampler=sampler,
-                    is_valid_sample_fn=task_cfg.filter_func,
                     weight=task_cfg.weight,
                     order=order,
                 )
@@ -255,7 +254,6 @@ class AgentLoopManager:
                         train_step=train_step,
                         model_step=model_step,
                         progress=local_progress,
-                        is_valid_sample_fn=task.is_valid_sample_fn,
                         stale_threshold=task.stale_threshold,
                         token_stale_threshold=task.token_stale_threshold,
                         expired_groups_retryable=task.expired_groups_retryable,
@@ -281,7 +279,6 @@ class AgentLoopManager:
                     train_step=train_step,
                     model_step=model_step,
                     progress=local_progress,
-                    is_valid_sample_fn=task.is_valid_sample_fn,
                     stale_threshold=task.stale_threshold,
                     token_stale_threshold=task.token_stale_threshold,
                     expired_groups_retryable=task.expired_groups_retryable,

--- a/xtuner/v1/rl/agent_loop_manager/disagg_agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/disagg_agent_loop_manager.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from xtuner.v1.data_proto.rl_data import Status
-from xtuner.v1.rl.agent_loop import AgentLoopConfig
+from xtuner.v1.rl.agent_loop import AgentLoopConfig, RolloutGroupFilter
 from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig, build_judger
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
 from xtuner.v1.rl.rollout import RolloutController
@@ -27,7 +27,6 @@ from .produce_utils import (
     _MANAGER_STATE_PATH,
     _STATUS_POLL_INTERVAL_S,
     _TASK_CHECKPOINT_DIR,
-    IsValidSampleFn,
     ProduceBatchResult,
     ProduceBatchStatus,
     _TaskRunner,
@@ -51,7 +50,7 @@ class DisaggTaskSpecConfig(BaseModel):
     weight: float = Field(default=1.0, ge=0.0)
     agent_loop_config: AgentLoopConfig
     judger_config: JudgerConfig | ComposedJudgerConfig | None = None
-    filter_func: IsValidSampleFn | None = None
+    filter_func: RolloutGroupFilter | None = None
     produce_strategy_config: DisaggProduceStrategyConfig = DisaggAsyncProduceStrategyConfig()
     sampler_config: SamplerConfig
 
@@ -86,6 +85,7 @@ class DisaggAgentLoopManagerConfig(BaseModel):
                 rollout_controller=rollout_controller,
                 judger=build_judger(task_cfg.judger_config) if task_cfg.judger_config is not None else None,
                 logger=logger,
+                filter_func=task_cfg.filter_func,
             )
             produce_strategy = task_cfg.produce_strategy_config.build(
                 sync_weights_interval=sync_weights_interval,
@@ -98,7 +98,6 @@ class DisaggAgentLoopManagerConfig(BaseModel):
                     agent_loop=agent_loop,
                     produce_strategy=produce_strategy,
                     sampler=sampler,
-                    is_valid_sample_fn=task_cfg.filter_func,
                     weight=task_cfg.weight,
                     order=order,
                 )
@@ -243,7 +242,6 @@ class DisaggAgentLoopManager:
                         model_step=self._model_step,
                         progress=progress,
                         update_event=self._update_event,
-                        is_valid_sample_fn=task.is_valid_sample_fn,
                         stale_threshold=task.stale_threshold,
                         token_stale_threshold=task.token_stale_threshold,
                         expired_groups_retryable=task.expired_groups_retryable,
@@ -273,7 +271,6 @@ class DisaggAgentLoopManager:
                 model_step=self._model_step,
                 progress=self._produce_progress,
                 update_event=self._update_event,
-                is_valid_sample_fn=task.is_valid_sample_fn,
                 stale_threshold=task.stale_threshold,
                 token_stale_threshold=task.token_stale_threshold,
                 expired_groups_retryable=task.expired_groups_retryable,

--- a/xtuner/v1/rl/agent_loop_manager/disagg_agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/disagg_agent_loop_manager.py
@@ -27,6 +27,7 @@ from .produce_utils import (
     _MANAGER_STATE_PATH,
     _STATUS_POLL_INTERVAL_S,
     _TASK_CHECKPOINT_DIR,
+    IsValidSampleFn,
     ProduceBatchResult,
     ProduceBatchStatus,
     _TaskRunner,
@@ -50,6 +51,7 @@ class DisaggTaskSpecConfig(BaseModel):
     weight: float = Field(default=1.0, ge=0.0)
     agent_loop_config: AgentLoopConfig
     judger_config: JudgerConfig | ComposedJudgerConfig | None = None
+    filter_func: IsValidSampleFn | None = None
     produce_strategy_config: DisaggProduceStrategyConfig = DisaggAsyncProduceStrategyConfig()
     sampler_config: SamplerConfig
 
@@ -96,6 +98,7 @@ class DisaggAgentLoopManagerConfig(BaseModel):
                     agent_loop=agent_loop,
                     produce_strategy=produce_strategy,
                     sampler=sampler,
+                    is_valid_sample_fn=task_cfg.filter_func,
                     weight=task_cfg.weight,
                     order=order,
                 )

--- a/xtuner/v1/rl/agent_loop_manager/disagg_agent_loop_manager.py
+++ b/xtuner/v1/rl/agent_loop_manager/disagg_agent_loop_manager.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from xtuner.v1.data_proto.rl_data import Status
-from xtuner.v1.rl.agent_loop import AgentLoopConfig, RolloutGroupFilter
+from xtuner.v1.rl.agent_loop import AgentLoopConfig, IsValidSampleFn
 from xtuner.v1.rl.judger import ComposedJudgerConfig, JudgerConfig, build_judger
 from xtuner.v1.rl.replay_buffer import ReplayBuffer
 from xtuner.v1.rl.rollout import RolloutController
@@ -50,7 +50,7 @@ class DisaggTaskSpecConfig(BaseModel):
     weight: float = Field(default=1.0, ge=0.0)
     agent_loop_config: AgentLoopConfig
     judger_config: JudgerConfig | ComposedJudgerConfig | None = None
-    filter_func: RolloutGroupFilter | None = None
+    is_valid_sample_fn: IsValidSampleFn | None = None
     produce_strategy_config: DisaggProduceStrategyConfig = DisaggAsyncProduceStrategyConfig()
     sampler_config: SamplerConfig
 
@@ -85,7 +85,7 @@ class DisaggAgentLoopManagerConfig(BaseModel):
                 rollout_controller=rollout_controller,
                 judger=build_judger(task_cfg.judger_config) if task_cfg.judger_config is not None else None,
                 logger=logger,
-                filter_func=task_cfg.filter_func,
+                is_valid_sample_fn=task_cfg.is_valid_sample_fn,
             )
             produce_strategy = task_cfg.produce_strategy_config.build(
                 sync_weights_interval=sync_weights_interval,

--- a/xtuner/v1/rl/agent_loop_manager/disagg_producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/disagg_producer.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 from xtuner.v1.data_proto.rl_data import Status
+from xtuner.v1.rl.agent_loop import IsValidSampleFn
 from xtuner.v1.rl.utils import calculate_seq_staleness, create_task
 from xtuner.v1.utils import get_logger
 
@@ -228,6 +229,8 @@ class DisaggProduceStrategyConfig(ABC, BaseModel):
     """非共卡后台 producer strategy 配置。"""
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    # Deprecated compatibility field; RLTrainer moves it to DisaggTaskSpecConfig.
+    is_valid_sample_fn: IsValidSampleFn | None = None
     should_continue_fn: ShouldContinueFn = default_should_continue_fn
 
     @abstractmethod
@@ -421,7 +424,7 @@ class DisaggAsyncProduceStrategy(DisaggProduceStrategy):
         async def spawn_one() -> asyncio.Task:
             rollout_state = await ctx.sample_group(from_expired_pool=sample_expired)
             return create_task(
-                ctx.collect_rollout_group(
+                ctx.generate_group(
                     rollout_state,
                     enable_partial_rollout=self.enable_partial_rollout,
                 )

--- a/xtuner/v1/rl/agent_loop_manager/disagg_producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/disagg_producer.py
@@ -13,14 +13,12 @@ from xtuner.v1.utils import get_logger
 from .produce_utils import (
     PERIODIC_ABORT_INTERVAL_S,
     BaseProduceContext,
-    IsValidSampleFn,
     ProduceBatchStatus,
     ShouldContinueFn,
     _PendingTasks,
     _ProgressDisplayer,
     _put_claimed_tasks,
     calculate_stale_threshold,
-    default_is_valid_sample_fn,
     default_should_continue_fn,
     pause_pending_tasks,
 )
@@ -230,7 +228,6 @@ class DisaggProduceStrategyConfig(ABC, BaseModel):
     """非共卡后台 producer strategy 配置。"""
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
-    is_valid_sample_fn: IsValidSampleFn = default_is_valid_sample_fn
     should_continue_fn: ShouldContinueFn = default_should_continue_fn
 
     @abstractmethod
@@ -246,9 +243,6 @@ class DisaggAsyncProduceStrategyConfig(DisaggProduceStrategyConfig):
     """Configuration for disaggregated asynchronous rollout production.
 
     Args:
-        is_valid_sample_fn (IsValidSampleFn): Function used to decide whether a
-            generated rollout group is trainable. Defaults to
-            ``default_is_valid_sample_fn``.
         should_continue_fn (ShouldContinueFn): Function used to decide whether
             production should continue after a group is processed. Defaults to
             ``default_should_continue_fn``.
@@ -307,7 +301,6 @@ class DisaggAsyncProduceStrategyConfig(DisaggProduceStrategyConfig):
             max_token_staleness=self.max_token_staleness,
             sync_weights_interval=sync_weights_interval,
             tail_batch_trigger_size=self.tail_batch_trigger_size,
-            is_valid_sample_fn=self.is_valid_sample_fn,
             should_continue_fn=self.should_continue_fn,
         )
 
@@ -315,10 +308,8 @@ class DisaggAsyncProduceStrategyConfig(DisaggProduceStrategyConfig):
 class DisaggProduceStrategy(ABC):
     def __init__(
         self,
-        is_valid_sample_fn: IsValidSampleFn,
         should_continue_fn: ShouldContinueFn,
     ):
-        self.is_valid_sample_fn = is_valid_sample_fn
         self.should_continue_fn = should_continue_fn
 
     @abstractmethod
@@ -347,10 +338,9 @@ class DisaggAsyncProduceStrategy(DisaggProduceStrategy):
         max_staleness: int,
         max_token_staleness: int | None,
         sync_weights_interval: int,
-        is_valid_sample_fn: IsValidSampleFn,
         should_continue_fn: ShouldContinueFn,
     ):
-        super().__init__(is_valid_sample_fn, should_continue_fn)
+        super().__init__(should_continue_fn)
 
         if not enable_partial_rollout and max_staleness > 0:
             logger.warning(
@@ -431,7 +421,7 @@ class DisaggAsyncProduceStrategy(DisaggProduceStrategy):
         async def spawn_one() -> asyncio.Task:
             rollout_state = await ctx.sample_group(from_expired_pool=sample_expired)
             return create_task(
-                ctx.generate_group(
+                ctx.collect_rollout_group(
                     rollout_state,
                     enable_partial_rollout=self.enable_partial_rollout,
                 )

--- a/xtuner/v1/rl/agent_loop_manager/produce_utils.py
+++ b/xtuner/v1/rl/agent_loop_manager/produce_utils.py
@@ -86,10 +86,6 @@ class ProduceBatchStatus(Enum):
     EXPIRED_BATCH = auto()
 
 
-def default_is_valid_sample_fn(samples: list[RolloutState]) -> bool:
-    return True
-
-
 def default_should_continue_fn(completed_count: int, batch_size: int, **kwargs) -> bool:
     return completed_count < batch_size
 
@@ -121,7 +117,7 @@ class BaseProduceContext:
     train_step: int
     model_step: int
     progress: ProduceProgress | DisaggProduceProgress
-    is_valid_sample_fn: IsValidSampleFn = default_is_valid_sample_fn
+    is_valid_sample_fn: IsValidSampleFn | None = None
     stale_threshold: int | None = None
     expired_groups_retryable: bool = True
     token_stale_threshold: int | None = None
@@ -137,7 +133,7 @@ class BaseProduceContext:
         group_status = [Status.EXPIRED, Status.ABORTED] if from_expired_pool else [Status.ABORTED]
         return await self.sampler.sample(task_name=self.task_name, group_status=group_status)
 
-    async def generate_group(
+    async def collect_rollout_group(
         self,
         rollout_state: list[RolloutState],
         *,
@@ -151,13 +147,15 @@ class BaseProduceContext:
 
         start = time.perf_counter()
         if isinstance(self.agent_loop, ray.actor.ActorHandle):
-            result = await self.agent_loop.generate_group.remote(
+            result = await self.agent_loop.collect_rollout_group.remote(
                 rollout_state,
+                is_valid_sample_fn=self.is_valid_sample_fn,
                 enable_partial_rollout=enable_partial_rollout,
             )
         else:
-            result = await self.agent_loop.generate_group(
+            result = await self.agent_loop.collect_rollout_group(
                 rollout_state,
+                is_valid_sample_fn=self.is_valid_sample_fn,
                 enable_partial_rollout=enable_partial_rollout,
             )
         elapsed = time.perf_counter() - start
@@ -172,31 +170,25 @@ class BaseProduceContext:
     async def put_generated_group(self, group: list[RolloutState]) -> bool:
         produced_tokens = sum(len(item.response_ids or []) - len(item.response_model_steps or []) for item in group)
         initial_status = get_group_status(group)
-        discard_status: Status | None = None
 
-        if initial_status == Status.COMPLETED:
+        if initial_status in (Status.COMPLETED, Status.FILTERED):
             rewards_sum = 0.0
             rewards_count = 0
             for item in group:
                 if item.reward is None or "score" not in item.reward:
                     logger.warning(
-                        f"Missing reward score in item (rollout_id: {item.rollout_id}) of completed group for task {self.task_name}. This item will be skipped in reward statistics."
+                        f"Missing reward score in item (rollout_id: {item.rollout_id}) of generated group for task {self.task_name}. This item will be skipped in reward statistics."
                     )
                     continue
                 # TODO: 在 agent 存在一拆多的情况下，这个 raw reward 统计会不准，但是考虑到在这区分有点 hard code，应该暂时不处理
-                rewards_sum += float(item.reward["score"])  # type: ignore[index]
+                rewards_sum += float(item.reward["score"])
                 rewards_count += 1
             self.progress.add_raw_rewards(self.task_name, rewards_sum, rewards_count)
 
-            if not self.is_valid_sample_fn(group):
-                discard_status = Status.FILTERED
-        elif initial_status == Status.FAILED:
-            discard_status = Status.FAILED
-
-        if discard_status is not None:
+        if initial_status in (Status.FAILED, Status.FILTERED):
             # 失败样本和业务过滤样本都不进入 replay buffer。
             self.progress.add_produced(self.task_name, samples=len(group), tokens=produced_tokens)
-            self.progress.add_discarded(self.task_name, discard_status, samples=len(group))
+            self.progress.add_discarded(self.task_name, initial_status, samples=len(group))
             await release_and_discard_rollout_groups([group])
             return False
 
@@ -273,12 +265,9 @@ class _TaskRunner:
     agent_loop: AgentLoopSpec
     produce_strategy: Any
     sampler: Sampler
+    is_valid_sample_fn: IsValidSampleFn | None = None
     weight: float = 1.0
     order: int = 0
-
-    @property
-    def is_valid_sample_fn(self) -> IsValidSampleFn:
-        return getattr(self.produce_strategy, "is_valid_sample_fn", default_is_valid_sample_fn)
 
     @property
     def stale_threshold(self) -> int | None:

--- a/xtuner/v1/rl/agent_loop_manager/produce_utils.py
+++ b/xtuner/v1/rl/agent_loop_manager/produce_utils.py
@@ -96,11 +96,6 @@ def calculate_stale_threshold(max_staleness: int, sync_weights_interval: int) ->
 
 
 @runtime_checkable
-class IsValidSampleFn(Protocol):
-    def __call__(self, samples: list[RolloutState]) -> bool: ...
-
-
-@runtime_checkable
 class ShouldContinueFn(Protocol):
     def __call__(self, completed_count: int, batch_size: int, **kwargs) -> bool: ...
 
@@ -117,7 +112,6 @@ class BaseProduceContext:
     train_step: int
     model_step: int
     progress: ProduceProgress | DisaggProduceProgress
-    is_valid_sample_fn: IsValidSampleFn | None = None
     stale_threshold: int | None = None
     expired_groups_retryable: bool = True
     token_stale_threshold: int | None = None
@@ -149,13 +143,11 @@ class BaseProduceContext:
         if isinstance(self.agent_loop, ray.actor.ActorHandle):
             result = await self.agent_loop.collect_rollout_group.remote(
                 rollout_state,
-                is_valid_sample_fn=self.is_valid_sample_fn,
                 enable_partial_rollout=enable_partial_rollout,
             )
         else:
             result = await self.agent_loop.collect_rollout_group(
                 rollout_state,
-                is_valid_sample_fn=self.is_valid_sample_fn,
                 enable_partial_rollout=enable_partial_rollout,
             )
         elapsed = time.perf_counter() - start
@@ -265,7 +257,6 @@ class _TaskRunner:
     agent_loop: AgentLoopSpec
     produce_strategy: Any
     sampler: Sampler
-    is_valid_sample_fn: IsValidSampleFn | None = None
     weight: float = 1.0
     order: int = 0
 

--- a/xtuner/v1/rl/agent_loop_manager/produce_utils.py
+++ b/xtuner/v1/rl/agent_loop_manager/produce_utils.py
@@ -127,7 +127,7 @@ class BaseProduceContext:
         group_status = [Status.EXPIRED, Status.ABORTED] if from_expired_pool else [Status.ABORTED]
         return await self.sampler.sample(task_name=self.task_name, group_status=group_status)
 
-    async def collect_rollout_group(
+    async def generate_group(
         self,
         rollout_state: list[RolloutState],
         *,
@@ -141,12 +141,12 @@ class BaseProduceContext:
 
         start = time.perf_counter()
         if isinstance(self.agent_loop, ray.actor.ActorHandle):
-            result = await self.agent_loop.collect_rollout_group.remote(
+            result = await self.agent_loop.generate_group.remote(
                 rollout_state,
                 enable_partial_rollout=enable_partial_rollout,
             )
         else:
-            result = await self.agent_loop.collect_rollout_group(
+            result = await self.agent_loop.generate_group(
                 rollout_state,
                 enable_partial_rollout=enable_partial_rollout,
             )

--- a/xtuner/v1/rl/agent_loop_manager/producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/producer.py
@@ -13,12 +13,10 @@ from xtuner.v1.utils import get_logger
 from .produce_utils import (
     PERIODIC_ABORT_INTERVAL_S,
     BaseProduceContext,
-    IsValidSampleFn,
     ShouldContinueFn,
     _ProgressDisplayer,
     _put_claimed_tasks,
     calculate_stale_threshold,
-    default_is_valid_sample_fn,
     default_should_continue_fn,
     pause_pending_tasks,
 )
@@ -127,16 +125,12 @@ class ProduceStrategyConfig(ABC, BaseModel):
     when it should stop producing samples for the current training step.
 
     Args:
-        is_valid_sample_fn (IsValidSampleFn): Function used to decide whether a
-            generated rollout group is trainable. Defaults to
-            ``default_is_valid_sample_fn``.
         should_continue_fn (ShouldContinueFn): Function used to decide whether
             production should continue after a group is processed. Defaults to
             ``default_should_continue_fn``.
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
-    is_valid_sample_fn: IsValidSampleFn = default_is_valid_sample_fn
     should_continue_fn: ShouldContinueFn = default_should_continue_fn
 
     @abstractmethod
@@ -156,9 +150,6 @@ class SyncProduceStrategyConfig(ProduceStrategyConfig):
     in a colocated or tightly synchronized workflow.
 
     Args:
-        is_valid_sample_fn (IsValidSampleFn): Function used to decide whether a
-            generated rollout group is trainable. Defaults to
-            ``default_is_valid_sample_fn``.
         should_continue_fn (ShouldContinueFn): Function used to decide whether
             production should continue after a group is processed. Defaults to
             ``default_should_continue_fn``.
@@ -176,10 +167,7 @@ class SyncProduceStrategyConfig(ProduceStrategyConfig):
         sync_weights_interval: int = 1,
         rollout_controller: "Optional[RolloutControllerProxy]" = None,
     ) -> "SyncProduceStrategy":
-        return SyncProduceStrategy(
-            is_valid_sample_fn=self.is_valid_sample_fn,
-            should_continue_fn=self.should_continue_fn,
-        )
+        return SyncProduceStrategy(should_continue_fn=self.should_continue_fn)
 
 
 class AsyncProduceStrategyConfig(ProduceStrategyConfig):
@@ -191,9 +179,6 @@ class AsyncProduceStrategyConfig(ProduceStrategyConfig):
     discard samples that are too stale relative to the current training step.
 
     Args:
-        is_valid_sample_fn (IsValidSampleFn): Function used to decide whether a
-            generated rollout group is trainable. Defaults to
-            ``default_is_valid_sample_fn``.
         should_continue_fn (ShouldContinueFn): Function used to decide whether
             production should continue after a group is processed. Defaults to
             ``default_should_continue_fn``.
@@ -261,7 +246,6 @@ class AsyncProduceStrategyConfig(ProduceStrategyConfig):
             max_token_staleness=self.max_token_staleness,
             sync_weights_interval=sync_weights_interval,
             tail_batch_trigger_size=self.tail_batch_trigger_size,
-            is_valid_sample_fn=self.is_valid_sample_fn,
             should_continue_fn=self.should_continue_fn,
         )
 
@@ -269,10 +253,8 @@ class AsyncProduceStrategyConfig(ProduceStrategyConfig):
 class ProduceStrategy(ABC):
     def __init__(
         self,
-        is_valid_sample_fn: IsValidSampleFn,
         should_continue_fn: ShouldContinueFn,
     ):
-        self.is_valid_sample_fn = is_valid_sample_fn
         self.should_continue_fn = should_continue_fn
 
     @abstractmethod
@@ -292,7 +274,7 @@ class SyncProduceStrategy(ProduceStrategy):
 
         for _ in range(ctx.task_batch_size):
             rollout_state = await ctx.sampler.sample(task_name=ctx.task_name)
-            task = create_task(ctx.generate_group(rollout_state))
+            task = create_task(ctx.collect_rollout_group(rollout_state))
             pending_tasks.add(task)
 
         logger.info(f"[SyncProduceStrategy] Started {len(pending_tasks)} initial tasks.")
@@ -310,7 +292,7 @@ class SyncProduceStrategy(ProduceStrategy):
             done_tasks, pending_tasks = await asyncio.wait(
                 pending_tasks, timeout=1, return_when=asyncio.FIRST_COMPLETED
             )
-            # put_generated_group 负责过滤和入库。
+            # AgentLoop 已完成过滤；put_generated_group 只处理状态、数据入库和释放。
             for task in done_tasks:
                 items = task.result()
 
@@ -325,7 +307,7 @@ class SyncProduceStrategy(ProduceStrategy):
                 completed_sample_count, ctx.task_batch_size
             ):
                 rollout_state = await ctx.sampler.sample(task_name=ctx.task_name)
-                task = create_task(ctx.generate_group(rollout_state))
+                task = create_task(ctx.collect_rollout_group(rollout_state))
                 pending_tasks.add(task)
         progress_displayer.close()
 
@@ -341,10 +323,9 @@ class AsyncProduceStrategy(ProduceStrategy):
         max_staleness: int,
         max_token_staleness: int | None,
         sync_weights_interval: int,
-        is_valid_sample_fn: IsValidSampleFn,
         should_continue_fn: ShouldContinueFn,
     ):
-        super().__init__(is_valid_sample_fn, should_continue_fn)
+        super().__init__(should_continue_fn)
 
         # TODO: 需要添加 tail_batch_max_tries
         # 作用是：如果一个样本多次重试，则将它置为特殊状态 MAX_TRIES，这类样本和过期样本一起触发tail batch逻辑
@@ -413,7 +394,7 @@ class AsyncProduceStrategy(ProduceStrategy):
         async def spawn_one() -> asyncio.Task:
             rollout_state = await ctx.sample_group(from_expired_pool=sample_expired)
             return create_task(
-                ctx.generate_group(
+                ctx.collect_rollout_group(
                     rollout_state,
                     enable_partial_rollout=self.enable_partial_rollout,
                 )

--- a/xtuner/v1/rl/agent_loop_manager/producer.py
+++ b/xtuner/v1/rl/agent_loop_manager/producer.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 from xtuner.v1.data_proto.rl_data import Status
+from xtuner.v1.rl.agent_loop import IsValidSampleFn
 from xtuner.v1.rl.utils import create_task
 from xtuner.v1.utils import get_logger
 
@@ -125,12 +126,15 @@ class ProduceStrategyConfig(ABC, BaseModel):
     when it should stop producing samples for the current training step.
 
     Args:
+        is_valid_sample_fn (IsValidSampleFn | None): Deprecated compatibility
+            field. RLTrainer moves it to the task's agent loop configuration.
         should_continue_fn (ShouldContinueFn): Function used to decide whether
             production should continue after a group is processed. Defaults to
             ``default_should_continue_fn``.
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    is_valid_sample_fn: IsValidSampleFn | None = None
     should_continue_fn: ShouldContinueFn = default_should_continue_fn
 
     @abstractmethod
@@ -274,7 +278,7 @@ class SyncProduceStrategy(ProduceStrategy):
 
         for _ in range(ctx.task_batch_size):
             rollout_state = await ctx.sampler.sample(task_name=ctx.task_name)
-            task = create_task(ctx.collect_rollout_group(rollout_state))
+            task = create_task(ctx.generate_group(rollout_state))
             pending_tasks.add(task)
 
         logger.info(f"[SyncProduceStrategy] Started {len(pending_tasks)} initial tasks.")
@@ -307,7 +311,7 @@ class SyncProduceStrategy(ProduceStrategy):
                 completed_sample_count, ctx.task_batch_size
             ):
                 rollout_state = await ctx.sampler.sample(task_name=ctx.task_name)
-                task = create_task(ctx.collect_rollout_group(rollout_state))
+                task = create_task(ctx.generate_group(rollout_state))
                 pending_tasks.add(task)
         progress_displayer.close()
 
@@ -394,7 +398,7 @@ class AsyncProduceStrategy(ProduceStrategy):
         async def spawn_one() -> asyncio.Task:
             rollout_state = await ctx.sample_group(from_expired_pool=sample_expired)
             return create_task(
-                ctx.collect_rollout_group(
+                ctx.generate_group(
                     rollout_state,
                     enable_partial_rollout=self.enable_partial_rollout,
                 )

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -104,6 +104,60 @@ def _agent_loop_manager_uses_trace_store(
     return _agent_loop_manager_requires_rollout_proxy(cfg)
 
 
+def _migrate_manager_is_valid_sample_fn(
+    manager_cfg: AgentLoopManagerConfig | DisaggAgentLoopManagerConfig | None,
+    logger,
+) -> AgentLoopManagerConfig | DisaggAgentLoopManagerConfig | None:
+    """Move the legacy produce-strategy validity check to its task config."""
+    if manager_cfg is None:
+        return None
+
+    tasks = manager_cfg.tasks if isinstance(manager_cfg.tasks, list) else [manager_cfg.tasks]
+    migrated_tasks = []
+    changed = False
+    for task in tasks:
+        strategy_cfg = task.produce_strategy_config
+        legacy_fn = strategy_cfg.is_valid_sample_fn
+        if legacy_fn is None:
+            migrated_tasks.append(task)
+            continue
+        if task.is_valid_sample_fn is not None and task.is_valid_sample_fn is not legacy_fn:
+            raise ValueError(
+                f"Task {task.task_name!r} configures is_valid_sample_fn in both the task and its "
+                "produce strategy. Remove the deprecated produce-strategy value."
+            )
+
+        logger.warning(
+            f"Task {task.task_name!r} uses deprecated produce_strategy_config.is_valid_sample_fn; "
+            "move it to TaskSpecConfig.is_valid_sample_fn."
+        )
+        migrated_tasks.append(
+            task.model_copy(
+                update={
+                    "is_valid_sample_fn": legacy_fn,
+                    "produce_strategy_config": strategy_cfg.model_copy(update={"is_valid_sample_fn": None}),
+                }
+            )
+        )
+        changed = True
+
+    if not changed:
+        return manager_cfg
+    migrated_value = migrated_tasks if isinstance(manager_cfg.tasks, list) else migrated_tasks[0]
+    return manager_cfg.model_copy(update={"tasks": migrated_value})
+
+
+def _migrate_legacy_is_valid_sample_fn(cfg: "BaseRLTrainerConfig", logger) -> None:
+    cfg.agent_loop_manager_cfg = cast(
+        AgentLoopManagerConfig | DisaggAgentLoopManagerConfig,
+        _migrate_manager_is_valid_sample_fn(cfg.agent_loop_manager_cfg, logger),
+    )
+    cfg.eval_agent_loop_manager_cfg = cast(
+        AgentLoopManagerConfig | None,
+        _migrate_manager_is_valid_sample_fn(cfg.eval_agent_loop_manager_cfg, logger),
+    )
+
+
 def _trace_session_ids(rollout_batches: list[list[RolloutState]]) -> list[str]:
     """Return stable, unique trace session ids owned by rollout batches."""
     return list(
@@ -592,6 +646,7 @@ class BaseRLTrainer:
         self._init_load_source(cfg)
         self._init_save_config(cfg)
         log_dir = self._init_logger(cfg, logger_tag)
+        _migrate_legacy_is_valid_sample_fn(cfg, self.logger)
         self._init_trace(cfg)
         self._save_runtime_environment(log_dir)
         self._init_train_state(cfg)


### PR DESCRIPTION
## Motivation

Sample validity filtering currently lives in the producer path, coupling task-level validation with scheduling and replay-buffer management. This PR moves validation into AgentLoop collection so producers only handle returned statuses, data ownership, metrics, and buffer insertion.

## Changes

- Add collect_rollout_group to local, Ray actor, and router AgentLoop paths.
- Validate only completed rollout groups after judging and mark rejected groups as FILTERED.
- Move the filter configuration from ProduceStrategyConfig to TaskSpecConfig.filter_func for colocated and disaggregated managers.
- Bind filter_func once when each local or Ray AgentLoop is constructed.
- Remove the filter callback from _TaskRunner, ProduceContext, and per-rollout RPC arguments.
- Keep raw-reward accounting and failed/filtered sample cleanup in the producer.
- Migrate all affected example and autotest configurations.

## Testing

- 44 focused tests passed: test_producer.py, test_multi_task_agent_loop_manager.py, and test_single_turn_agent_loop.py.
- AgentLoopManager checkpoint tests passed.
- Python compileall and git diff --check passed.
- All repository pre-commit hooks passed, including Ruff, Ruff format, Mypy, and pydantic-extra-check.