### PR TITLE
[WIP] Add index-based data packing and worker-side materialization

### DIFF
--- a/tests/rl/conftest.py
+++ b/tests/rl/conftest.py
@@ -140,6 +140,8 @@ def _install_rl_trainer_worker_stubs() -> None:
     class TrainingController:
         pass
 
+    TrainingLogInfo = dict
+
     class WorkerConfig(BaseModel):
         model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
@@ -148,8 +150,8 @@ def _install_rl_trainer_worker_stubs() -> None:
 
     controller_mod = _new_module("xtuner.v1.rl.trainer.controller")
     controller_mod.TrainingController = TrainingController
-    controller_mod.ColateItem = object
-    controller_mod.__all__ = ["TrainingController", "ColateItem"]
+    controller_mod.TrainingLogInfo = TrainingLogInfo
+    controller_mod.__all__ = ["TrainingController", "TrainingLogInfo"]
 
     worker_mod = _new_module("xtuner.v1.rl.trainer.worker")
     worker_mod.TrainingWorker = TrainingWorker
@@ -166,12 +168,12 @@ def _install_rl_trainer_worker_stubs() -> None:
     ]
 
     trainer_pkg.TrainingController = TrainingController
+    trainer_pkg.TrainingLogInfo = TrainingLogInfo
     trainer_pkg.WorkerConfig = WorkerConfig
     trainer_pkg.TrainingWorker = TrainingWorker
     trainer_pkg.WorkerInputItem = dict
     trainer_pkg.WorkerLogItem = dict
     trainer_pkg.WorkerTrainLogItem = dict
-    trainer_pkg.ColateItem = object
 
     sys.modules.setdefault("xtuner.v1.rl.trainer", trainer_pkg)
     sys.modules.setdefault("xtuner.v1.rl.trainer.controller", controller_mod)

--- a/tests/rl/test_pack.py
+++ b/tests/rl/test_pack.py
@@ -1,0 +1,166 @@
+import unittest
+import torch
+from xtuner.v1.data_proto.sequence_context import SequenceContext
+from xtuner.v1.rl.base.pack import RLDataPacker
+
+class TestDataBatchPacker(unittest.TestCase):
+    def setUp(self):
+        self.pack_max_length = 3072
+        self.split_size = 1024
+
+    def _create_dummy_item(self, length: int, val=1):
+        input_ids = torch.full((1, length), val, dtype=torch.long)
+        cu_seq_lens_q = torch.tensor([0, length], dtype=torch.int32)
+        cu_seq_lens_k = torch.tensor([0, length], dtype=torch.int32)
+        max_length_q = torch.tensor(length, dtype=torch.int32)
+        max_length_k = torch.tensor(length, dtype=torch.int32)
+        seq_ctx = SequenceContext(
+            input_ids=input_ids,
+            cu_seq_lens_q=cu_seq_lens_q,
+            cu_seq_lens_k=cu_seq_lens_k,
+            max_length_q=max_length_q,
+            max_length_k=max_length_k,
+            num_padding=0,
+            device="cpu",
+        )
+        return {
+            "seq_ctx": seq_ctx,
+            "shifted_labels": torch.full((1, length), val, dtype=torch.long),
+            "advantages": torch.full((1, length), float(val), dtype=torch.float),
+            "rollout_logprobs": torch.full((1, length), float(val), dtype=torch.float),
+        }
+
+    def _run_strategy_test(self, strategy, world_size, optimizer_steps, lengths, pack_max_length, expected_padding = None):
+        data_batches = [self._create_dummy_item(l, val=7) for l in lengths]
+        total_data_tokens = sum(lengths)
+        
+        packer = RLDataPacker(
+            pack_max_length=pack_max_length,
+            world_size=world_size,
+            data_replicate_size=1,
+            optimizer_steps=optimizer_steps,
+            pack_strategy=strategy
+        )
+        
+        packed_res, padding_tokens = packer.pack(data_batches)
+        
+        # 验证均衡性：理想情况下，balance 策略分配给各卡的 token 总数差异应该小于单个样本的最大长度
+        if strategy == "balance":
+            rank_token_counts = []
+            for  rank_data in packed_res:
+                rank_total_valid_tokens = 0
+                for step_data in rank_data:
+                    for pack in step_data:
+                        # 统计非零（非 padding）的有效 token 数量
+                        valid_tokens = (pack["seq_ctx"].input_ids != 0).sum().item()
+                        rank_total_valid_tokens += valid_tokens
+                rank_token_counts.append(rank_total_valid_tokens)
+            
+            max_tokens = max(rank_token_counts)
+            min_tokens = min(rank_token_counts)
+            diff = max_tokens - min_tokens
+            max_sample_len = max(lengths) if lengths else 0
+            self.assertLessEqual(diff, max_sample_len, 
+                f"Balance strategy failed: Token distribution is too skewed. "
+                f"Rank counts: {rank_token_counts}, Max diff: {diff}")
+
+        # 对于固定输入，验证padding_tokens是否符合预期来验证pack逻辑正确性
+        if expected_padding is not None:    
+            self.assertEqual(padding_tokens, expected_padding, f"Strategy {strategy} padding mismatch. Expected {expected_padding}, got {padding_tokens}")
+            
+        all_packs = []
+        for rank_data in packed_res:
+            for step_data in rank_data:
+                for pack in step_data:
+                    self.assertEqual(pack["seq_ctx"].input_ids.numel(), pack_max_length, f"Strategy {strategy} pack length mismatch.")
+                    all_packs.append(pack)
+
+        # 验证pack前后的总有效token数是否一致
+        total_capacity = len(all_packs) * pack_max_length
+        self.assertEqual(total_capacity, total_data_tokens + padding_tokens)
+
+        all_input_ids = torch.cat([p["seq_ctx"].input_ids for p in all_packs], dim=1)
+        valid_token_count = (all_input_ids != 0).sum().item()
+        all_labels = torch.cat([p["shifted_labels"] for p in all_packs], dim=1)
+        valid_label_count = (all_labels != -100).sum().item()
+        all_advantages = torch.cat([p["advantages"] for p in all_packs], dim=1)
+        valid_adv_count = (all_advantages != -100).sum().item()
+
+        self.assertEqual(valid_token_count, total_data_tokens)
+        self.assertEqual(valid_label_count, total_data_tokens)
+        self.assertEqual(valid_adv_count, total_data_tokens)
+
+    def test_variable_packs(self):
+        """随机tokens数输入, dp=2, optimizer_steps=2
+        - Native: 
+            1. 预处理，保证样本数量能被整除, padding到1024, 这样可以与有效的样本一起Pack
+               [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800] -> padding: [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800, 1024]
+            2. DP Rank 切分： 
+                rank0: [1500, 1000, 2800, 3000, 1500]
+                rank1: [2000, 2100, 1000,  800, 1024]
+            3. Optimizer steps切分：
+                rank0: [1500, 1000, 2800], [3000, 1500]
+                rank1: [2000, 2100, 1000], [ 800, 1024]
+            4 pack and padding
+                rank0: step0: [2500 -> 3072], [2800 -> 3072],                 step1: [3000 -> 3072], [1500 -> 3072], 
+                rank1: step0: [2000 -> 3072], [2100 -> 3072], [1000 -> 3072], step1: [1824 -> 3072]
+            5. 跨卡对齐pack数量： 
+                rank0: step0: [2500 -> 3072], [2800 -> 3072], [0 -> 3072]     step1: [3000 -> 3072], [1500 -> 3072], 
+                rank1: step0: [2100 -> 3072], [2000 -> 3072], [1000 -> 3072], step1: [1824 -> 3072], [0 -> 3072]
+            padding_tokens: 1024 + 3072 - 2500 + 3072 - 2800 + 3072 + 3072 - 3000 + 3072 - 1500 + 3072 - 2100 + 3072 - 2000 + 3072 - 1000 + 3072 - 1824 + 3072 = 15020
+        - Balance: 
+            1. 对原始输入数据进行排序：
+                [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800] -> [3000, 2800, 2100, 2000, 1500, 1500, 1000, 1000, 800]
+            2. 相近长度的N个样本分到N张卡上, 每N个样本为作为N张卡的一次optimizer step的数据
+                rank0: [3000, 1500, 800], [2100, 1000],
+                rank1: [2800, 1500],      [2000, 1000],
+            3. pack and pad:
+                rank0: step0: [3000 -> 3072], [2300 -> 3072],   step1: [2100 ->3072], [1000 -> 3072],
+                rank1: step0: [2800 -> 3072], [1500 -> 3072],   step1: [3000 ->3072], [.  0 -> 3072],
+            4. 跨卡对齐pack数量：
+                skip
+            padding_tokens: 3072 - 3000 + 3072 - 2300 + 3072 - 2100 + 3072 - 1000 + 3072 - 2800 + 3072 - 1500 + 3072 - 3000 + 3072 = 8876
+        - Greedy: 追求 Pack 填充率最大化
+            1. pack and padding:
+               Pack 1: [1500, 1000] -> [2500 -> 3072]
+               Pack 2: [2800]       -> [2800 -> 3072]
+               Pack 3: [3000]       -> [3000 -> 3072]
+               Pack 4: [1500]       -> [1500 -> 3072]
+               Pack 5: [2000]       -> [2000 -> 3072]
+               Pack 6: [2100]       -> [2100 -> 3072]
+               Pack 7: [1000, 800]  -> [1800 -> 3072]
+               Pack 8: [ ]          -> [0    -> 3072] (padding)
+            2. DP 切分:
+               rank0: [Pack 1, Pack 2, Pack 3, Pack 4]
+               rank1: [Pack 5, Pack 6, Pack 7, Pack 8]
+            3. Opitmizer steps 切分:
+               rank0: step0: [Pack 1, Pack 2], step1: [Pack 3, Pack 4]
+               rank1: step0: [Pack 5, Pack 6], step1: [Pack 7, Pack 8]
+            4. 跨卡对齐pack数量：
+               skip
+            padding_tokens: 3072 - 2500 + 3072 - 2800 + 3072 - 3000 + 3072 - 1500 + 3072 - 2000 + 3072 - 2100 + 3072 - 1800 + 3072 = 8876
+        """
+        lengths = [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800]
+        self._run_strategy_test("native", 2, 2, lengths, self.pack_max_length, 15020)
+        self._run_strategy_test("balance", 2, 2, lengths, self.pack_max_length, 8876)
+        self._run_strategy_test("greedy", 2, 2, lengths, self.pack_max_length, 8876)
+
+    def test_imbalance_dp_size(self):
+        lengths = [500]
+        for strat in ["native", "balance", "greedy"]:
+            self._run_strategy_test(strat, 2, 1, lengths, self.pack_max_length, 5644)
+
+    def test_imbalanced_steps(self):
+        lengths = [100, 200, 2500, 3000, 50, 400, 1000, 1500]
+        self._run_strategy_test("native", 2, 4, lengths, self.pack_max_length, 15826)
+        self._run_strategy_test("balance", 2, 4, lengths, self.pack_max_length, 15826)
+        self._run_strategy_test("greedy", 2, 4, lengths, self.pack_max_length, 3538)
+
+    def test_random_lengths(self):
+        import random
+        lengths = [random.randint(1, 32768) for _ in range(1024)]
+        for strat in ["native", "balance", "greedy"]:
+            self._run_strategy_test(strat, 8, 16, lengths, 32768)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/rl/test_pack.py
+++ b/tests/rl/test_pack.py
@@ -33,7 +33,7 @@ class TestDataBatchPacker(unittest.TestCase):
     def _run_strategy_test(self, strategy, world_size, optimizer_steps, lengths, pack_max_length, expected_padding = None):
         data_batches = [self._create_dummy_item(l, val=7) for l in lengths]
         total_data_tokens = sum(lengths)
-        
+
         packer = RLDataPacker(
             pack_max_length=pack_max_length,
             world_size=world_size,
@@ -41,9 +41,9 @@ class TestDataBatchPacker(unittest.TestCase):
             optimizer_steps=optimizer_steps,
             pack_strategy=strategy
         )
-        
+
         packed_res, padding_tokens = packer.pack(data_batches)
-        
+
         # 验证均衡性：理想情况下，balance 策略分配给各卡的 token 总数差异应该小于单个样本的最大长度
         if strategy == "balance":
             rank_token_counts = []
@@ -55,19 +55,19 @@ class TestDataBatchPacker(unittest.TestCase):
                         valid_tokens = (pack["seq_ctx"].input_ids != 0).sum().item()
                         rank_total_valid_tokens += valid_tokens
                 rank_token_counts.append(rank_total_valid_tokens)
-            
+
             max_tokens = max(rank_token_counts)
             min_tokens = min(rank_token_counts)
             diff = max_tokens - min_tokens
             max_sample_len = max(lengths) if lengths else 0
-            self.assertLessEqual(diff, max_sample_len, 
+            self.assertLessEqual(diff, max_sample_len,
                 f"Balance strategy failed: Token distribution is too skewed. "
                 f"Rank counts: {rank_token_counts}, Max diff: {diff}")
 
         # 对于固定输入，验证padding_tokens是否符合预期来验证pack逻辑正确性
-        if expected_padding is not None:    
+        if expected_padding is not None:
             self.assertEqual(padding_tokens, expected_padding, f"Strategy {strategy} padding mismatch. Expected {expected_padding}, got {padding_tokens}")
-            
+
         all_packs = []
         for rank_data in packed_res:
             for step_data in rank_data:
@@ -92,23 +92,23 @@ class TestDataBatchPacker(unittest.TestCase):
 
     def test_variable_packs(self):
         """随机tokens数输入, dp=2, optimizer_steps=2
-        - Native: 
+        - Native:
             1. 预处理，保证样本数量能被整除, padding到1024, 这样可以与有效的样本一起Pack
                [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800] -> padding: [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800, 1024]
-            2. DP Rank 切分： 
+            2. DP Rank 切分：
                 rank0: [1500, 1000, 2800, 3000, 1500]
                 rank1: [2000, 2100, 1000,  800, 1024]
             3. Optimizer steps切分：
                 rank0: [1500, 1000, 2800], [3000, 1500]
                 rank1: [2000, 2100, 1000], [ 800, 1024]
             4 pack and padding
-                rank0: step0: [2500 -> 3072], [2800 -> 3072],                 step1: [3000 -> 3072], [1500 -> 3072], 
+                rank0: step0: [2500 -> 3072], [2800 -> 3072],                 step1: [3000 -> 3072], [1500 -> 3072],
                 rank1: step0: [2000 -> 3072], [2100 -> 3072], [1000 -> 3072], step1: [1824 -> 3072]
-            5. 跨卡对齐pack数量： 
-                rank0: step0: [2500 -> 3072], [2800 -> 3072], [0 -> 3072]     step1: [3000 -> 3072], [1500 -> 3072], 
+            5. 跨卡对齐pack数量：
+                rank0: step0: [2500 -> 3072], [2800 -> 3072], [0 -> 3072]     step1: [3000 -> 3072], [1500 -> 3072],
                 rank1: step0: [2100 -> 3072], [2000 -> 3072], [1000 -> 3072], step1: [1824 -> 3072], [0 -> 3072]
             padding_tokens: 1024 + 3072 - 2500 + 3072 - 2800 + 3072 + 3072 - 3000 + 3072 - 1500 + 3072 - 2100 + 3072 - 2000 + 3072 - 1000 + 3072 - 1824 + 3072 = 15020
-        - Balance: 
+        - Balance:
             1. 对原始输入数据进行排序：
                 [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800] -> [3000, 2800, 2100, 2000, 1500, 1500, 1000, 1000, 800]
             2. 相近长度的N个样本分到N张卡上, 每N个样本为作为N张卡的一次optimizer step的数据

--- a/tests/rl/test_pack.py
+++ b/tests/rl/test_pack.py
@@ -1,145 +1,65 @@
+import random
 import unittest
+from types import SimpleNamespace
+
 import torch
+
 from xtuner.v1.data_proto.sequence_context import SequenceContext
 from xtuner.v1.rl.trainer.pack import RLDataPacker
+from xtuner.v1.rl.trainer.worker import TrainingWorker
+
 
 class TestDataBatchPacker(unittest.TestCase):
     def setUp(self):
         self.pack_max_length = 3072
-        self.split_size = 1024
 
-    def _create_dummy_item(self, length: int, val=1):
-        input_ids = torch.full((1, length), val, dtype=torch.long)
-        cu_seq_lens_q = torch.tensor([0, length], dtype=torch.int32)
-        cu_seq_lens_k = torch.tensor([0, length], dtype=torch.int32)
-        max_length_q = torch.tensor(length, dtype=torch.int32)
-        max_length_k = torch.tensor(length, dtype=torch.int32)
-        seq_ctx = SequenceContext(
-            input_ids=input_ids,
-            cu_seq_lens_q=cu_seq_lens_q,
-            cu_seq_lens_k=cu_seq_lens_k,
-            max_length_q=max_length_q,
-            max_length_k=max_length_k,
-            num_padding=0,
-            device="cpu",
-        )
-        return {
-            "seq_ctx": seq_ctx,
-            "shifted_labels": torch.full((1, length), val, dtype=torch.long),
-            "advantages": torch.full((1, length), float(val), dtype=torch.float),
-            "rollout_logprobs": torch.full((1, length), float(val), dtype=torch.float),
-        }
-
-    def _run_strategy_test(self, strategy, world_size, optimizer_steps, lengths, pack_max_length, expected_padding = None):
-        data_batches = [self._create_dummy_item(l, val=7) for l in lengths]
-        total_data_tokens = sum(lengths)
-
+    def _run_strategy_test(
+        self,
+        strategy,
+        world_size,
+        optimizer_steps,
+        lengths,
+        pack_max_length,
+        expected_padding=None,
+    ):
         packer = RLDataPacker(
             pack_max_length=pack_max_length,
             world_size=world_size,
             data_replicate_size=1,
             optimizer_steps=optimizer_steps,
-            pack_strategy=strategy
+            pack_strategy=strategy,
         )
 
-        packed_res, padding_tokens = packer.pack(data_batches)
+        packed_indices, padding_tokens = packer.pack(lengths)
 
-        # 验证均衡性：理想情况下，balance 策略分配给各卡的 token 总数差异应该小于单个样本的最大长度
+        all_packs = [
+            pack_indices
+            for rank_indices in packed_indices
+            for step_indices in rank_indices
+            for pack_indices in step_indices
+        ]
+        seen_indices = [data_index for pack_indices in all_packs for data_index in pack_indices]
+        self.assertEqual(sorted(seen_indices), list(range(len(lengths))))
+        pack_token_counts = [sum(lengths[data_index] for data_index in pack_indices) for pack_indices in all_packs]
+        self.assertTrue(all(pack_tokens <= pack_max_length for pack_tokens in pack_token_counts))
+        self.assertEqual(len(all_packs) * pack_max_length, sum(lengths) + padding_tokens)
+
         if strategy == "balance":
-            rank_token_counts = []
-            for  rank_data in packed_res:
-                rank_total_valid_tokens = 0
-                for step_data in rank_data:
-                    for pack in step_data:
-                        # 统计非零（非 padding）的有效 token 数量
-                        valid_tokens = (pack["seq_ctx"].input_ids != 0).sum().item()
-                        rank_total_valid_tokens += valid_tokens
-                rank_token_counts.append(rank_total_valid_tokens)
+            rank_token_counts = [
+                sum(
+                    lengths[data_index]
+                    for step_indices in rank_indices
+                    for pack_indices in step_indices
+                    for data_index in pack_indices
+                )
+                for rank_indices in packed_indices
+            ]
+            self.assertLessEqual(max(rank_token_counts) - min(rank_token_counts), max(lengths))
 
-            max_tokens = max(rank_token_counts)
-            min_tokens = min(rank_token_counts)
-            diff = max_tokens - min_tokens
-            max_sample_len = max(lengths) if lengths else 0
-            self.assertLessEqual(diff, max_sample_len,
-                f"Balance strategy failed: Token distribution is too skewed. "
-                f"Rank counts: {rank_token_counts}, Max diff: {diff}")
-
-        # 对于固定输入，验证padding_tokens是否符合预期来验证pack逻辑正确性
         if expected_padding is not None:
-            self.assertEqual(padding_tokens, expected_padding, f"Strategy {strategy} padding mismatch. Expected {expected_padding}, got {padding_tokens}")
-
-        all_packs = []
-        for rank_data in packed_res:
-            for step_data in rank_data:
-                for pack in step_data:
-                    self.assertEqual(pack["seq_ctx"].input_ids.numel(), pack_max_length, f"Strategy {strategy} pack length mismatch.")
-                    all_packs.append(pack)
-
-        # 验证pack前后的总有效token数是否一致
-        total_capacity = len(all_packs) * pack_max_length
-        self.assertEqual(total_capacity, total_data_tokens + padding_tokens)
-
-        all_input_ids = torch.cat([p["seq_ctx"].input_ids for p in all_packs], dim=1)
-        valid_token_count = (all_input_ids != 0).sum().item()
-        all_labels = torch.cat([p["shifted_labels"] for p in all_packs], dim=1)
-        valid_label_count = (all_labels != -100).sum().item()
-        all_advantages = torch.cat([p["advantages"] for p in all_packs], dim=1)
-        valid_adv_count = (all_advantages != -100).sum().item()
-
-        self.assertEqual(valid_token_count, total_data_tokens)
-        self.assertEqual(valid_label_count, total_data_tokens)
-        self.assertEqual(valid_adv_count, total_data_tokens)
+            self.assertEqual(padding_tokens, expected_padding)
 
     def test_variable_packs(self):
-        """随机tokens数输入, dp=2, optimizer_steps=2
-        - Native:
-            1. 预处理，保证样本数量能被整除, padding到1024, 这样可以与有效的样本一起Pack
-               [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800] -> padding: [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800, 1024]
-            2. DP Rank 切分：
-                rank0: [1500, 1000, 2800, 3000, 1500]
-                rank1: [2000, 2100, 1000,  800, 1024]
-            3. Optimizer steps切分：
-                rank0: [1500, 1000, 2800], [3000, 1500]
-                rank1: [2000, 2100, 1000], [ 800, 1024]
-            4 pack and padding
-                rank0: step0: [2500 -> 3072], [2800 -> 3072],                 step1: [3000 -> 3072], [1500 -> 3072],
-                rank1: step0: [2000 -> 3072], [2100 -> 3072], [1000 -> 3072], step1: [1824 -> 3072]
-            5. 跨卡对齐pack数量：
-                rank0: step0: [2500 -> 3072], [2800 -> 3072], [0 -> 3072]     step1: [3000 -> 3072], [1500 -> 3072],
-                rank1: step0: [2100 -> 3072], [2000 -> 3072], [1000 -> 3072], step1: [1824 -> 3072], [0 -> 3072]
-            padding_tokens: 1024 + 3072 - 2500 + 3072 - 2800 + 3072 + 3072 - 3000 + 3072 - 1500 + 3072 - 2100 + 3072 - 2000 + 3072 - 1000 + 3072 - 1824 + 3072 = 15020
-        - Balance:
-            1. 对原始输入数据进行排序：
-                [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800] -> [3000, 2800, 2100, 2000, 1500, 1500, 1000, 1000, 800]
-            2. 相近长度的N个样本分到N张卡上, 每N个样本为作为N张卡的一次optimizer step的数据
-                rank0: [3000, 1500, 800], [2100, 1000],
-                rank1: [2800, 1500],      [2000, 1000],
-            3. pack and pad:
-                rank0: step0: [3000 -> 3072], [2300 -> 3072],   step1: [2100 ->3072], [1000 -> 3072],
-                rank1: step0: [2800 -> 3072], [1500 -> 3072],   step1: [3000 ->3072], [.  0 -> 3072],
-            4. 跨卡对齐pack数量：
-                skip
-            padding_tokens: 3072 - 3000 + 3072 - 2300 + 3072 - 2100 + 3072 - 1000 + 3072 - 2800 + 3072 - 1500 + 3072 - 3000 + 3072 = 8876
-        - Greedy: 追求 Pack 填充率最大化
-            1. pack and padding:
-               Pack 1: [1500, 1000] -> [2500 -> 3072]
-               Pack 2: [2800]       -> [2800 -> 3072]
-               Pack 3: [3000]       -> [3000 -> 3072]
-               Pack 4: [1500]       -> [1500 -> 3072]
-               Pack 5: [2000]       -> [2000 -> 3072]
-               Pack 6: [2100]       -> [2100 -> 3072]
-               Pack 7: [1000, 800]  -> [1800 -> 3072]
-               Pack 8: [ ]          -> [0    -> 3072] (padding)
-            2. DP 切分:
-               rank0: [Pack 1, Pack 2, Pack 3, Pack 4]
-               rank1: [Pack 5, Pack 6, Pack 7, Pack 8]
-            3. Opitmizer steps 切分:
-               rank0: step0: [Pack 1, Pack 2], step1: [Pack 3, Pack 4]
-               rank1: step0: [Pack 5, Pack 6], step1: [Pack 7, Pack 8]
-            4. 跨卡对齐pack数量：
-               skip
-            padding_tokens: 3072 - 2500 + 3072 - 2800 + 3072 - 3000 + 3072 - 1500 + 3072 - 2000 + 3072 - 2100 + 3072 - 1800 + 3072 = 8876
-        """
         lengths = [1500, 1000, 2800, 3000, 1500, 2000, 2100, 1000, 800]
         self._run_strategy_test("native", 2, 2, lengths, self.pack_max_length, 15020)
         self._run_strategy_test("balance", 2, 2, lengths, self.pack_max_length, 8876)
@@ -147,8 +67,8 @@ class TestDataBatchPacker(unittest.TestCase):
 
     def test_imbalance_dp_size(self):
         lengths = [500]
-        for strat in ["native", "balance", "greedy"]:
-            self._run_strategy_test(strat, 2, 1, lengths, self.pack_max_length, 5644)
+        for strategy in ["native", "balance", "greedy"]:
+            self._run_strategy_test(strategy, 2, 1, lengths, self.pack_max_length, 5644)
 
     def test_imbalanced_steps(self):
         lengths = [100, 200, 2500, 3000, 50, 400, 1000, 1500]
@@ -157,10 +77,39 @@ class TestDataBatchPacker(unittest.TestCase):
         self._run_strategy_test("greedy", 2, 4, lengths, self.pack_max_length, 3538)
 
     def test_random_lengths(self):
-        import random
         lengths = [random.randint(1, 32768) for _ in range(1024)]
-        for strat in ["native", "balance", "greedy"]:
-            self._run_strategy_test(strat, 8, 16, lengths, 32768)
+        for strategy in ["native", "balance", "greedy"]:
+            self._run_strategy_test(strategy, 8, 16, lengths, 32768)
+
+    def test_native_supports_pack_length_below_split_size(self):
+        self._run_strategy_test("native", 2, 1, [128], 256, 384)
+
+
+class TestTrainingWorkerPackMaterialization(unittest.TestCase):
+    @staticmethod
+    def _create_dummy_item(length: int, value: int):
+        input_ids = torch.full((1, length), value, dtype=torch.long)
+        seq_ctx = SequenceContext.from_input_ids((input_ids,), device="cpu")
+        return {
+            "seq_ctx": seq_ctx,
+            "shifted_labels": torch.full((1, length), value, dtype=torch.long),
+            "advantages": torch.full((1, length), float(value), dtype=torch.float32),
+            "rollout_logprobs": torch.full((1, length), float(value), dtype=torch.float32),
+        }
+
+    def test_worker_selects_indices_and_materializes_packs(self):
+        worker = TrainingWorker.__new__(TrainingWorker)
+        worker.config = SimpleNamespace(pack_max_length=8, model_cfg=None)
+        data_batches = [self._create_dummy_item(3, 1), self._create_dummy_item(2, 2)]
+
+        packed_data = worker._materialize_packs(data_batches, [[[0, 1]], [[]]])
+
+        self.assertEqual(len(packed_data), 2)
+        self.assertEqual(packed_data[0][0]["seq_ctx"].input_ids.numel(), 8)
+        self.assertEqual(packed_data[0][0]["seq_ctx"].num_padding, 3)
+        self.assertEqual(packed_data[1][0]["seq_ctx"].num_padding, 8)
+        self.assertEqual(packed_data[0][0]["seq_ctx"].input_ids[0, :5].tolist(), [1, 1, 1, 2, 2])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/rl/test_pack.py
+++ b/tests/rl/test_pack.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 from xtuner.v1.data_proto.sequence_context import SequenceContext
-from xtuner.v1.rl.base.pack import RLDataPacker
+from xtuner.v1.rl.trainer.pack import RLDataPacker
 
 class TestDataBatchPacker(unittest.TestCase):
     def setUp(self):

--- a/tests/rl/test_rl_colocate_trainer.py
+++ b/tests/rl/test_rl_colocate_trainer.py
@@ -167,16 +167,19 @@ class TestRLColocateTrainer(unittest.TestCase):
             offload=MagicMock(return_value="train_offloaded"),
             weight_update=MagicMock(return_value="weights_updated"),
             fit=MagicMock(
-                return_value=[
-                    {
+                return_value={
+                    "worker_log_infos": [{
                         "rollout_is_metrics": {},
                         "mismatch_metrics": {},
                         "rollout_entropy": 0.0,
                         "train_entropy": 0.0,
                         "train_metrics": [],
                         "sft_train_metrics": {},
-                    }
-                ]
+                    }],
+                    "padding_tokens": 0,
+                    "pack_time": 0.0,
+                    "train_time": 0.0,
+                }
             ),
         )
         return trainer

--- a/tests/rl/test_rl_colocate_trainer_integration.py
+++ b/tests/rl/test_rl_colocate_trainer_integration.py
@@ -263,14 +263,13 @@ class TestRLColocateTrainerIntegration(unittest.TestCase):
                 shifted_labels_tensor = torch.tensor(shifted_labels, dtype=torch.int64).unsqueeze(0)
 
                 adv_val = advantages[i].item()
-                # Controller._packing expects `advantage` as a list and will flatten it.
-                # Keep the length consistent with shifted_labels/input_ids.
                 advantage_list = [adv_val] * (len(prompt_ids) - 1) + [adv_val] * len(response_ids)
 
                 data_batches.append(dict(
                     seq_ctx=SequenceContext.from_input_ids((input_ids_tensor,), device="cpu"),
                     shifted_labels=shifted_labels_tensor,
-                    advantage=advantage_list,
+                    advantages=torch.tensor(advantage_list, dtype=torch.float32),
+                    rollout_logprobs=None,
                 ))
 
         # RLColocateTrainer initializes by offloading train workers to CPU.
@@ -286,7 +285,7 @@ class TestRLColocateTrainerIntegration(unittest.TestCase):
         train_controller.onload(target="all")
         log_infos = train_controller.fit(data_batches, pack_max_length=1024, rollout_idx=1)
         efficient_attn_ratio_list = []
-        for log_info in log_infos:
+        for log_info in log_infos["worker_log_infos"]:
             efficient_attn_ratio_list.append(log_info['sft_train_metrics']['efficient_attn_ratio'])
         self.assertTrue(all([ratio > 0 for ratio in efficient_attn_ratio_list]))
 
@@ -316,7 +315,7 @@ class TestRLColocateTrainerIntegration(unittest.TestCase):
         train_controller.onload(target="all")
         log_infos = train_controller.fit(data_batches, pack_max_length=1024, rollout_idx=1)
         new_efficient_attn_ratio_list = []
-        for log_info in log_infos:
+        for log_info in log_infos["worker_log_infos"]:
             new_efficient_attn_ratio_list.append(log_info['sft_train_metrics']['efficient_attn_ratio'])
 
         efficient_attn_ratio_list.sort()

--- a/tests/rl/test_rl_disaggregated_trainer.py
+++ b/tests/rl/test_rl_disaggregated_trainer.py
@@ -142,7 +142,14 @@ class TestRLDisaggregatedTrainer(unittest.TestCase):
         trainer._maybe_save_hf = MagicMock()
         trainer._checkpoint_no_save_replay_buffer = False
         trainer.train_controller = SimpleNamespace(
-            fit=MagicMock(return_value=[{"train_metrics": [], "sft_train_metrics": {}}]),
+            fit=MagicMock(
+                return_value={
+                    "worker_log_infos": [{"train_metrics": [], "sft_train_metrics": {}}],
+                    "padding_tokens": 0,
+                    "pack_time": 0.0,
+                    "train_time": 0.0,
+                }
+            ),
             onload=MagicMock(return_value="onload"),
             offload=MagicMock(return_value="offload"),
             weight_update=MagicMock(return_value="update"),

--- a/tests/rl/test_rl_trainer_checkpoint.py
+++ b/tests/rl/test_rl_trainer_checkpoint.py
@@ -152,16 +152,19 @@ class _FakeTrainController:
 
     def fit(self, data_batches, pack_max_length: int, rollout_idx: int):
         self.fit_steps.append(rollout_idx)
-        return [
-            {
+        return {
+            "worker_log_infos": [{
                 "rollout_is_metrics": {},
                 "mismatch_metrics": {},
                 "rollout_entropy": 0.0,
                 "train_entropy": 0.0,
                 "train_metrics": [],
                 "sft_train_metrics": {},
-            }
-        ]
+            }],
+            "padding_tokens": 0,
+            "pack_time": 0.0,
+            "train_time": 0.0,
+        }
 
     def save(self, checkpoint_path: str, no_save_optimizer: bool):
         path = Path(checkpoint_path)

--- a/tests/rl/test_training_worker_rank.py
+++ b/tests/rl/test_training_worker_rank.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+import pytest
+
+from xtuner.v1.rl.trainer.worker import TrainingWorker
+
+
+class TestTrainingWorkerDataParallelRank:
+    @pytest.mark.parametrize(
+        ("rank", "tp_size", "sp_size", "expected_dp_rank"),
+        [
+            (0, 1, 1, 0),
+            (3, 1, 1, 3),
+            (0, 2, 1, 0),
+            (1, 2, 1, 0),
+            (2, 2, 1, 1),
+            (3, 2, 1, 1),
+            (0, 2, 2, 0),
+            (3, 2, 2, 0),
+            (4, 2, 2, 1),
+            (7, 2, 2, 1),
+        ],
+    )
+    def test_get_dp_rank_accounts_for_all_data_replicas(
+        self,
+        rank: int,
+        tp_size: int,
+        sp_size: int,
+        expected_dp_rank: int,
+    ) -> None:
+        worker = SimpleNamespace(
+            rank=rank,
+            _engine=SimpleNamespace(data_replicate_size=tp_size),
+            sp_mesh=SimpleNamespace(size=lambda: sp_size),
+        )
+
+        assert TrainingWorker.get_dp_rank(worker) == expected_dp_rank

--- a/xtuner/v1/rl/base/pack.py
+++ b/xtuner/v1/rl/base/pack.py
@@ -1,0 +1,391 @@
+import math
+import random
+from pathlib import Path
+from typing import cast
+
+import numpy as np
+import torch
+
+from xtuner.v1.data_proto.sequence_context import SequenceContext
+from xtuner.v1.datasets.sampler import get_length_grouped_indices
+from xtuner.v1.model.base import TransformerConfig
+from xtuner.v1.model.compose.base import BaseComposeConfig
+from xtuner.v1.rl.base.worker import WorkerInputItem
+from xtuner.v1.utils import get_logger
+
+
+# TODO: use expand_soft pack strategy in sft for greedy pack
+def get_soft_pack_infos(data_batches, num_tokens, target):
+    pack_infos = []
+    current_indices = []
+    current_len = 0
+    current_max = 0
+
+    for i, token_len in enumerate(num_tokens):
+        if current_len + token_len <= target:
+            current_indices.append(i)
+            current_len += token_len
+            current_max = max(current_max, token_len)
+        else:
+            if current_indices:
+                pack_infos.append(
+                    {
+                        "indices": current_indices,
+                        "longest": int(current_max),
+                    }
+                )
+            current_indices = [i]
+            current_len = token_len
+            current_max = token_len
+
+    if current_indices:
+        pack_infos.append(
+            {
+                "indices": current_indices,
+                "longest": int(current_max),
+            }
+        )
+    return pack_infos
+
+
+class RLDataPacker:
+    def __init__(
+        self,
+        pack_max_length: int,
+        world_size: int,
+        data_replicate_size: int,
+        optimizer_steps: int,
+        pack_strategy: str = "greedy",
+        model_cfg: TransformerConfig | None = None,
+        worker_log_dir: str | None = None,
+        seed: int = 42,
+    ):
+        self.pack_max_length = pack_max_length
+        self.world_size = world_size
+        self.data_replicate_size = data_replicate_size
+        self.optimizer_steps = optimizer_steps
+        self.split_size = 1024
+        if worker_log_dir is not None:
+            self.worker_log_dir = Path(worker_log_dir) if isinstance(worker_log_dir, str) else worker_log_dir
+            self.logger = get_logger(log_dir=self.worker_log_dir, tag="TrainingController")
+        else:
+            self.logger = get_logger()
+
+        self.data_batch_properties = {
+            "is_qwen3_vl": False,
+            "has_rollout_routed_experts": False,
+            "has_rollout_logprobs": False,
+            "n_routed_experts": None,
+        }
+        self.strategy_map = {
+            "greedy": self.greedy_pack_and_split,
+            "balance": self.balance_split_and_pack,
+            "native": self.native_split_and_pack,
+        }
+        if pack_strategy not in self.strategy_map:
+            raise ValueError(f"Unknown packing strategy: {pack_strategy}")
+        self._impl = self.strategy_map[pack_strategy]
+        self.dp_size = self.world_size // self.data_replicate_size
+        self.padding_tokens = 0
+        self.model_cfg = model_cfg
+        self.seed = seed
+
+    def pack(self, data_batches: list[WorkerInputItem]) -> tuple[list[list[list[WorkerInputItem]]], int]:
+        self.padding_tokens = 0
+        if not data_batches:
+            return [], 0
+        self._set_data_batch_properties(data_batches)
+        return self._impl(data_batches), self.padding_tokens
+
+    def native_split_and_pack(self, data_batches: list[WorkerInputItem]) -> list[list[list[WorkerInputItem]]]:
+        # 1. 预处理，保证样本数量可以被 dp_size 整除
+        if len(data_batches) % self.dp_size != 0:
+            pad_num = self.dp_size - (len(data_batches) % self.dp_size)
+            padding_item = self._create_padding_item(self.split_size, self.pack_max_length)
+            data_batches.extend([padding_item] * pad_num)
+
+        # 2. 按照 dp_size 切分样本
+        batches_per_dp_group: list[list[WorkerInputItem]] = np.array_split(data_batches, self.dp_size)
+        actual_optimizer_steps = min(len(batches_per_dp_group[0]), self.optimizer_steps)
+        packed_data_batches: list[list[list[WorkerInputItem]]] = [
+            [[] for _ in range(actual_optimizer_steps)] for _ in range(self.dp_size)
+        ]
+        max_packs_per_step = [0] * actual_optimizer_steps
+
+        for dp_rank, dp_worker_data_batches in enumerate(batches_per_dp_group):
+            # 3. 按照 actual_optimizer_steps 切分样本
+            batches_for_optim_steps = np.array_split(dp_worker_data_batches, actual_optimizer_steps)
+            for step_idx, step_mini_batches in enumerate(batches_for_optim_steps):
+                # 4. 对每个 optimizer step 的样本进行打包
+                each_step_pack_list = self._pack(step_mini_batches, self.pack_max_length)
+                packed_data_batches[dp_rank][step_idx] = each_step_pack_list
+                max_packs_per_step[step_idx] = max(
+                    max_packs_per_step[step_idx], len(packed_data_batches[dp_rank][step_idx])
+                )
+
+        self.logger.info(f"Gradient accumulation for each optimizer steps: {max_packs_per_step}")
+
+        # 5. padding for each worker to have same number of packs in each optimizer step
+        for step_idx in range(actual_optimizer_steps):
+            max_packs = max_packs_per_step[step_idx]
+            for dp_rank in range(self.dp_size):
+                num_current_packs = len(packed_data_batches[dp_rank][step_idx])
+                num_padding_packs = max_packs - num_current_packs
+
+                if num_padding_packs > 0:
+                    padding_items = [
+                        self._create_padding_item(self.pack_max_length, self.pack_max_length)
+                        for _ in range(num_padding_packs)
+                    ]
+                    packed_data_batches[dp_rank][step_idx].extend(padding_items)
+        return packed_data_batches
+
+    def balance_split_and_pack(self, data_batches: list[WorkerInputItem]) -> list[list[list[WorkerInputItem]]]:
+        # 1. 保证每张卡获取的样本总长度大致相等
+        max_lengths = self._get_seqlen_from_data_batches(data_batches)
+
+        torch_generator = torch.Generator().manual_seed(self.seed)
+        random_generator = random.Random(self.seed)
+
+        indices = get_length_grouped_indices(
+            max_lengths=max_lengths,
+            group_batch_size=len(data_batches),
+            group_size=self.dp_size,
+            torch_generator=torch_generator,
+            random_generator=random_generator,
+        )
+
+        partitioned_data: list[list[list[WorkerInputItem]]] = [
+            [[] for _ in range(self.optimizer_steps)] for _ in range(self.dp_size)
+        ]
+
+        # 2. 根据indices将样本分配到每张卡的每个 optimizer step 上
+        for i, idx in enumerate(indices):
+            dp_rank = i % self.dp_size
+            step_idx = (i // self.dp_size) % self.optimizer_steps
+            partitioned_data[dp_rank][step_idx].append(data_batches[idx])
+
+        packed_data_batches: list[list[list[WorkerInputItem]]] = [
+            [[] for _ in range(self.optimizer_steps)] for _ in range(self.dp_size)
+        ]
+
+        max_packs_per_step = [0] * self.optimizer_steps
+
+        for dp_rank in range(self.dp_size):
+            for step_idx in range(self.optimizer_steps):
+                # 3. 对每个卡每个 optimizer step 的样本进行打包
+                step_data = partitioned_data[dp_rank][step_idx]
+                packed_step_data = self._pack(step_data, self.pack_max_length)
+                packed_data_batches[dp_rank][step_idx] = packed_step_data
+                max_packs_per_step[step_idx] = max(
+                    max_packs_per_step[step_idx], len(packed_data_batches[dp_rank][step_idx])
+                )
+
+        # 4. padding for each worker to have same number of packs in each optimizer step
+        for step_idx in range(self.optimizer_steps):
+            max_packs = max_packs_per_step[step_idx]
+            for dp_rank in range(self.dp_size):
+                num_current_packs = len(packed_data_batches[dp_rank][step_idx])
+                num_padding_packs = max_packs - num_current_packs
+
+                if num_padding_packs > 0:
+                    padding_items = [
+                        self._create_padding_item(self.pack_max_length, self.pack_max_length)
+                        for _ in range(num_padding_packs)
+                    ]
+                    packed_data_batches[dp_rank][step_idx].extend(padding_items)
+        return packed_data_batches
+
+    def greedy_pack_and_split(self, data_batches: list[WorkerInputItem]) -> list[list[list[WorkerInputItem]]]:
+        # 1. 使用贪心算法将所有样本打包成一个一维的 pack 列表。
+        total_data_batches = self._pack(data_batches, self.pack_max_length)
+        # 2. 为了均匀分配，填充整个 batch，使其总 pack 数能被 dp_size 整除。
+        dp_size = self.world_size // self.data_replicate_size
+        num_packed_data_batches = len(total_data_batches)
+        pad_num = math.ceil(num_packed_data_batches / dp_size) * dp_size - num_packed_data_batches
+        if pad_num > 0:
+            pad_data_samples = [
+                self._create_padding_item(self.pack_max_length, self.pack_max_length) for _ in range(pad_num)
+            ]
+            total_data_batches = total_data_batches + pad_data_samples
+
+        # 3. 将填充后的 pack 列表按 dp_size 和 optimizer_steps 重新分配。
+        each_dp_batches_num = len(total_data_batches) // dp_size
+        if each_dp_batches_num < self.optimizer_steps:
+            iters_per_step = 1  # each optimizer step has at least one batch
+            actual_optimizer_steps = each_dp_batches_num
+        else:
+            iters_per_step = math.ceil(each_dp_batches_num / self.optimizer_steps)
+            actual_optimizer_steps = math.ceil(each_dp_batches_num / iters_per_step)
+        packed_data_batches: list[list[list[WorkerInputItem]]] = [
+            [[] for _ in range(actual_optimizer_steps)] for _ in range(dp_size)
+        ]
+        for dp_rank in range(dp_size):
+            for step in range(actual_optimizer_steps):
+                start_idx = dp_rank * each_dp_batches_num + step * iters_per_step
+                end_idx = min(start_idx + iters_per_step, each_dp_batches_num * (dp_rank + 1))
+                packed_data_batches[dp_rank][step] = total_data_batches[start_idx:end_idx]
+        return packed_data_batches
+
+    def _get_seqlen_from_data_batches(self, data_batches: list[WorkerInputItem]) -> list[int]:
+        seqlen_list = []
+        for data in data_batches:
+            assert data["seq_ctx"].input_ids.numel() <= self.pack_max_length, (  # type: ignore[union-attr]
+                f"Single sample seq len {data['seq_ctx'].input_ids.numel()} exceeds pack_max_length {self.pack_max_length}"  # type: ignore[union-attr]
+            )
+            seqlen_list.append(data["seq_ctx"].input_ids.numel())  # type: ignore[union-attr]
+        return seqlen_list
+
+    def _set_data_batch_properties(self, data_batches: list[WorkerInputItem]):
+        if not data_batches:
+            return
+
+        first_item = data_batches[0]
+        seq_ctx = first_item["seq_ctx"]
+
+        self.data_batch_properties["is_qwen3_vl"] = (
+            seq_ctx.position_ids is not None and len(seq_ctx.position_ids.shape) == 3
+        )
+        self.data_batch_properties["has_rollout_logprobs"] = (
+            "rollout_logprobs" in first_item and first_item["rollout_logprobs"] is not None
+        )
+        self.data_batch_properties["has_rollout_routed_experts"] = seq_ctx.rollout_routed_experts is not None
+
+        language_cfg = None
+        if self.data_batch_properties["has_rollout_routed_experts"]:
+            language_cfg = self.model_cfg
+            if isinstance(self.model_cfg, BaseComposeConfig):
+                language_cfg = self.model_cfg.text_config
+
+        self.data_batch_properties["n_routed_experts"] = (
+            language_cfg.n_routed_experts if language_cfg is not None else None
+        )
+        self.logger.info(f"Data batch properties set: {self.data_batch_properties}")
+
+    def _pack(self, data_batches: list[WorkerInputItem], pack_max_length: int) -> list[WorkerInputItem]:
+        seqlen_list = self._get_seqlen_from_data_batches(data_batches)
+        total_length = sum(seqlen_list)
+        each_step_pack_list: list[WorkerInputItem] = []
+        if total_length > pack_max_length:
+            # TODO: add expand_soft pack strategy
+            pack_infos = get_soft_pack_infos(
+                data_batches,
+                seqlen_list,
+                pack_max_length,
+            )
+            for pack_info in pack_infos:
+                indices = pack_info["indices"]
+                batch4pack = [data_batches[i] for i in indices]
+                each_step_pack_list.append(self._single_pack(batch4pack, pack_max_length))
+        else:
+            each_step_pack_list.append(self._single_pack(data_batches, pack_max_length))
+        return each_step_pack_list
+
+    def _single_pack(self, data_batches: list[WorkerInputItem], pack_max_length: int) -> WorkerInputItem:
+        seq_ctx_list = [item["seq_ctx"] for item in data_batches]
+        label_list = [item["shifted_labels"] for item in data_batches]
+        advantage_list = []
+        for item in data_batches:
+            advantages = item["advantages"].reshape(1, -1)
+            advantage_list.append(advantages)
+
+        rollout_logprobs_list = [
+            item["rollout_logprobs"] if self.data_batch_properties["has_rollout_logprobs"] else None
+            for item in data_batches
+        ]
+        seqlen_list = self._get_seqlen_from_data_batches(data_batches)
+        cur_length = sum(seqlen_list)
+        padding_len = pack_max_length - cur_length
+
+        padding_item: WorkerInputItem | None = None
+        if padding_len > 0:
+            padding_item = self._create_padding_item(padding_len, pack_max_length)
+            seq_ctx_list.append(padding_item["seq_ctx"])
+            label_list.append(padding_item["shifted_labels"])
+            advantage_list.append(padding_item["advantages"])
+            rollout_logprobs_list.append(padding_item["rollout_logprobs"])
+
+        packed_seq_ctx = SequenceContext.cat(seq_ctx_list)
+        packed_shifted_labels = torch.cat(label_list, dim=1)  # type: ignore[arg-type]
+        packed_shifted_labels = cast(torch.LongTensor, packed_shifted_labels)
+        packed_advantages = torch.cat(advantage_list, dim=1)
+        if self.data_batch_properties["has_rollout_logprobs"]:
+            cast_rollout_logprobs_list = [cast(torch.Tensor, item) for item in rollout_logprobs_list]
+            packed_rollout_logprobs = torch.cat(cast_rollout_logprobs_list, dim=1)
+        else:
+            packed_rollout_logprobs = None
+
+        optimizer_step_packs: WorkerInputItem = {
+            "seq_ctx": packed_seq_ctx,
+            "shifted_labels": packed_shifted_labels,
+            "advantages": packed_advantages,
+            "rollout_logprobs": packed_rollout_logprobs,
+        }
+        packed_input_ids = cast(torch.Tensor, packed_seq_ctx.input_ids)
+        assert packed_input_ids.numel() == pack_max_length, (
+            f"Packed seq ctx length {packed_input_ids.numel()} does not match pack_max_length {pack_max_length}"
+            f"padding input_ids length: {padding_item['seq_ctx'].input_ids.shape if padding_item else 0}"  # type: ignore[union-attr]
+        )
+        assert packed_seq_ctx.num_padding == (packed_advantages != -100).sum().item(), (
+            f"Packed seq ctx num_padding {packed_seq_ctx.num_padding} and packed advantages num_padding "
+            f"{(packed_advantages != -100).sum().item()} mismatch after packing."
+        )
+        return optimizer_step_packs
+
+    def _create_padding_item(
+        self,
+        pad_len: int,
+        pack_max_length: int,
+    ) -> WorkerInputItem:
+        # padding input_ids
+        self.padding_tokens += pad_len
+        pad_tokens = tuple(
+            torch.zeros(1, self.split_size, dtype=torch.long, device="cpu") for _ in range(pad_len // self.split_size)
+        )
+        if pad_len % self.split_size > 0:
+            pad_tokens = pad_tokens + (torch.zeros(1, pad_len % self.split_size, dtype=torch.long, device="cpu"),)
+        pad_tokens = cast(tuple[torch.LongTensor, ...], pad_tokens)
+        pad_seq_ctx = SequenceContext.from_input_ids(pad_tokens, device="cpu")
+        pad_seq_ctx.num_padding = pad_len
+
+        # padding mm positions_ids
+        if self.data_batch_properties["is_qwen3_vl"]:
+            _position_ids_list = []
+            for pad_token in pad_tokens:
+                _position_ids = torch.arange(pad_token.size(-1)).view(1, 1, -1).expand(3, 1, -1)
+                _position_ids_list.append(_position_ids)
+            position_ids = torch.cat(_position_ids_list, dim=-1)
+            position_ids = cast(torch.LongTensor, position_ids)
+            pad_seq_ctx.position_ids = position_ids
+
+        # padding rollout routed experts
+        if self.data_batch_properties["has_rollout_routed_experts"]:
+            assert self.data_batch_properties["n_routed_experts"], (
+                "n_routed_experts must be provided when has_rollout_routed_experts is True"
+            )
+            if pad_len == pack_max_length:
+                pad_rand_index = torch.randint(
+                    low=0, high=1, size=(1, 1, 1)
+                )  # add dummy data, true data will be initialized in train worker.fit
+            else:
+                pad_rand_index = torch.randint(
+                    low=0, high=self.data_batch_properties["n_routed_experts"], size=(pad_len, 1, 1)
+                )
+            pad_seq_ctx.rollout_routed_experts = pad_rand_index
+
+        pad_labels = cast(torch.LongTensor, torch.full((1, pad_len), -100, dtype=torch.int64, device="cpu"))
+
+        pad_advantage = torch.full((1, pad_len), -100, dtype=torch.float32, device="cpu")
+        pad_rollout_logprobs = (
+            torch.zeros(1, pad_len, dtype=torch.float32, device="cpu")
+            if self.data_batch_properties["has_rollout_logprobs"]
+            else None
+        )
+
+        padding_item: WorkerInputItem = {
+            "seq_ctx": pad_seq_ctx,
+            "shifted_labels": pad_labels,
+            "advantages": pad_advantage,
+            "rollout_logprobs": pad_rollout_logprobs,
+        }
+        return padding_item

--- a/xtuner/v1/rl/trainer/__init__.py
+++ b/xtuner/v1/rl/trainer/__init__.py
@@ -5,13 +5,13 @@ from ..rollout_is import (
     compute_rollout_importance_weights,
     merge_rollout_is_metrics,
 )
-from .controller import ColateItem, TrainingController
+from .controller import TrainingController, TrainingLogInfo
 from .worker import TrainingWorker, WorkerConfig, WorkerInputItem, WorkerLogItem, WorkerTrainLogItem
 
 
 __all__ = [
-    "ColateItem",
     "TrainingController",
+    "TrainingLogInfo",
     "RolloutImportanceSampling",
     "compute_rollout_importance_weights",
     "compute_is_metrics",

--- a/xtuner/v1/rl/trainer/controller.py
+++ b/xtuner/v1/rl/trainer/controller.py
@@ -51,11 +51,10 @@ class TrainingController:
     def __init__(self, workers: list[TrainingWorker]) -> None:
         self.workers = workers
         refs = [
-            self.workers[0].get_model_cfg.remote(),
             self.workers[0].get_worker_cfg.remote(),
             self.workers[0].get_data_replicate_size.remote(),
         ]
-        self.model_cfg, self.worker_cfg, self.data_replicate_size = ray.get(refs)
+        self.worker_cfg, self.data_replicate_size = ray.get(refs)
         self.worker_dp_ranks = ray.get([worker.get_dp_rank.remote() for worker in self.workers])
         self.pack_max_length = self.worker_cfg.pack_max_length
         self.pack_strategy = self.worker_cfg.pack_strategy
@@ -65,8 +64,6 @@ class TrainingController:
             data_replicate_size=self.data_replicate_size,
             optimizer_steps=self.worker_cfg.optimizer_steps,
             pack_strategy=self.pack_strategy,
-            model_cfg=self.model_cfg,
-            worker_log_dir=self.worker_cfg.log_dir,
         )
         log_dir = self.worker_cfg.log_dir
         self.log_dir = Path(log_dir) if log_dir is not None else None
@@ -87,18 +84,20 @@ class TrainingController:
             )
 
         start_time = time.perf_counter()
-        packed_data_batches, padding_tokens_num = self.data_packer.pack(data_batches)
+        data_lengths = [data["seq_ctx"].input_ids.numel() for data in data_batches]  # type: ignore[union-attr]
+        packed_data_indices, padding_tokens_num = self.data_packer.pack(data_lengths)
         pack_end_time = time.perf_counter()
 
         handles = []
-        data_batch_refs: dict[int, ray.ObjectRef] = {}
+        data_batches_ref = ray.put(data_batches)
         for worker_idx, worker in enumerate(self.workers):
             dp_rank = self.worker_dp_ranks[worker_idx]
-            if dp_rank not in data_batch_refs:
-                data_batch_refs[dp_rank] = ray.put(packed_data_batches[dp_rank])
             handles.append(
                 worker.fit.remote(  # type: ignore[attr-defined]
-                    data_batches=data_batch_refs[dp_rank],
+                    # Keep the ObjectRef nested so Ray does not automatically
+                    # dereference it before entering TrainingWorker.fit.
+                    data_batch_refs=[data_batches_ref],
+                    data_batch_indices=packed_data_indices[dp_rank],
                     rollout_idx=rollout_idx,
                 )
             )
@@ -108,16 +107,14 @@ class TrainingController:
             train_end_time = time.perf_counter()
         finally:
             free_pixel_value_refs: list[ray.ObjectRef] = []
-            for dp_batches in packed_data_batches:
-                for step_batches in dp_batches:
-                    for data in step_batches:
-                        pixel_values = data["seq_ctx"].pixel_values
-                        if isinstance(pixel_values, list):
-                            free_pixel_value_refs.extend(pixel_values)
+            for data in data_batches:
+                pixel_values = data["seq_ctx"].pixel_values
+                if isinstance(pixel_values, list):
+                    free_pixel_value_refs.extend(pixel_values)
             if free_pixel_value_refs:
                 free_object_refs(free_pixel_value_refs)
-            del data_batch_refs
-            del packed_data_batches
+            del data_batches_ref
+            del packed_data_indices
 
         return {
             "worker_log_infos": worker_log_infos,

--- a/xtuner/v1/rl/trainer/controller.py
+++ b/xtuner/v1/rl/trainer/controller.py
@@ -1,27 +1,27 @@
-import math
 import os
+import time
+from pathlib import Path
 from typing import Any, Literal, TypedDict
 
 import ray
 import torch
 
-from xtuner.v1.data_proto.sequence_context import SequenceContext
-from xtuner.v1.model.compose.base import BaseComposeConfig
 from xtuner.v1.rl.utils import free_object_refs
 from xtuner.v1.train.trainer import LoadCheckpointConfig
 from xtuner.v1.utils import get_logger
 
-from .worker import TrainingWorker, WorkerLogItem
+from .pack import RLDataPacker
+from .worker import TrainingWorker, WorkerInputItem, WorkerLogItem
 
 
 TRAIN_RAY_GET_TIMEOUT = os.getenv("XTUNER_TRAIN_RAY_GET_TIMEOUT", 5 * 3600)  # default 5 hours
 
 
-class ColateItem(TypedDict):
-    seq_ctx: SequenceContext
-    shifted_labels: torch.Tensor
-    advantage: float
-    rollout_logprobs: torch.Tensor | None
+class TrainingLogInfo(TypedDict):
+    worker_log_infos: list[WorkerLogItem]
+    padding_tokens: int
+    pack_time: float
+    train_time: float
 
 
 def _summarize_process_group_results(results: list[dict[str, Any]]) -> str:
@@ -50,250 +50,81 @@ def _summarize_process_group_results(results: list[dict[str, Any]]) -> str:
 class TrainingController:
     def __init__(self, workers: list[TrainingWorker]) -> None:
         self.workers = workers
-        self.logger = get_logger()
-
-    # TODO(hha): 这个逻辑不够通用，应该复用 sft 函数，从而支持 expand soft pack
-    def _get_pack_infos(self, dataset, num_tokens, target, random=None):
-        inds = list(range(len(dataset)))
-        if random is not None:
-            random.shuffle(inds)
-
-        item_buffer = []
-        length_buffer = []
-        longest = 0
-
-        pack_infos = []
-        for shfl_i in inds:
-            if num_tokens[shfl_i] + sum(length_buffer) <= target:
-                item_buffer.append(shfl_i)
-                length_buffer.append(num_tokens[shfl_i])
-                longest = max(longest, num_tokens[shfl_i])
-            else:
-                if len(item_buffer) > 0:
-                    info = {
-                        "indices": item_buffer,
-                        "longest": int(longest),
-                    }
-                    pack_infos.append(info)
-
-                item_buffer = [shfl_i]
-                length_buffer = [num_tokens[shfl_i]]
-                longest = num_tokens[shfl_i]
-
-        if len(item_buffer) > 0:
-            info = {
-                "indices": item_buffer,
-                "longest": int(longest),
-            }
-
-            pack_infos.append(info)
-
-        return pack_infos
-
-    # TODO(hha): 这个逻辑不够通用，和模型绑定了
-    def _packing(self, data_batches, pack_max_length, language_cfg):
-        pack_infos = self._get_pack_infos(
-            data_batches,
-            [data["seq_ctx"].input_ids.numel() for data in data_batches],
-            pack_max_length,
+        refs = [
+            self.workers[0].get_model_cfg.remote(),
+            self.workers[0].get_worker_cfg.remote(),
+            self.workers[0].get_data_replicate_size.remote(),
+        ]
+        self.model_cfg, self.worker_cfg, self.data_replicate_size = ray.get(refs)
+        self.worker_dp_ranks = ray.get([worker.get_dp_rank.remote() for worker in self.workers])
+        self.pack_max_length = self.worker_cfg.pack_max_length
+        self.pack_strategy = self.worker_cfg.pack_strategy
+        self.data_packer = RLDataPacker(
+            pack_max_length=self.pack_max_length,
+            world_size=len(self.workers),
+            data_replicate_size=self.data_replicate_size,
+            optimizer_steps=self.worker_cfg.optimizer_steps,
+            pack_strategy=self.pack_strategy,
+            model_cfg=self.model_cfg,
+            worker_log_dir=self.worker_cfg.log_dir,
         )
-        packed_data_batches = []
+        log_dir = self.worker_cfg.log_dir
+        self.log_dir = Path(log_dir) if log_dir is not None else None
+        if self.log_dir is not None:
+            self.logger = get_logger(log_dir=self.log_dir, tag="TrainingController")
+        else:
+            self.logger = get_logger()
 
-        is_qwen3_vl = False
-        if len(data_batches[0]["seq_ctx"].position_ids.shape) == 3:
-            is_qwen3_vl = True
-
-        has_rollout_routed_experts = False
-        if data_batches[0]["seq_ctx"].rollout_routed_experts is not None:
-            assert language_cfg is not None
-            has_rollout_routed_experts = True
-            n_routed_experts = language_cfg.n_routed_experts
-
-        for pack_info in pack_infos:
-            indices = pack_info["indices"]
-            total_len = sum([data_batches[i]["seq_ctx"].input_ids.shape[1] for i in indices])
-            pad_len = pack_max_length - total_len
-            seq_ctx_list = [data_batches[i]["seq_ctx"] for i in indices]
-            label_list = [data_batches[i]["shifted_labels"] for i in indices]
-            advantage_list = [data_batches[i]["advantage"] for i in indices]
-
-            rollout_logprobs_list = None
-            if "rollout_logprobs" in data_batches[0] and data_batches[0]["rollout_logprobs"] is not None:
-                rollout_logprobs_list = [data_batches[i]["rollout_logprobs"] for i in indices]
-
-            if pad_len > 0:
-                # Reduce the attn calculation time by using multiple short sequence packs
-                pad_tokens = tuple(
-                    torch.zeros(1, 1024, dtype=data_batches[0]["seq_ctx"].input_ids.dtype, device="cpu")
-                    for _ in range(pad_len // 1024)
-                )
-                if pad_len % 1024 > 0:
-                    pad_tokens = pad_tokens + (
-                        torch.zeros(1, pad_len % 1024, dtype=data_batches[0]["seq_ctx"].input_ids.dtype, device="cpu"),
-                    )
-                pad_seq_ctx = SequenceContext.from_input_ids(pad_tokens, device="cpu")
-                pad_seq_ctx.num_padding = pad_len
-                pad_labels = torch.full(
-                    (1, pad_len),
-                    -100,
-                    dtype=data_batches[0]["shifted_labels"].dtype,
-                    device=data_batches[0]["shifted_labels"].device,
-                )
-                pad_advantages = [-100] * pad_len
-                if is_qwen3_vl:
-                    _position_ids_list = []
-                    for pad_token in pad_tokens:
-                        _position_ids = torch.arange(pad_token.size(-1)).view(1, 1, -1).expand(3, 1, -1)
-                        _position_ids_list.append(_position_ids)
-                    pad_seq_ctx.position_ids = torch.cat(_position_ids_list, dim=-1)
-
-                if has_rollout_routed_experts:
-                    pad_rand_index = torch.randint(low=0, high=n_routed_experts, size=(pad_len, 1, 1))
-                    pad_seq_ctx.rollout_routed_experts = pad_rand_index
-
-                seq_ctx_list.append(pad_seq_ctx)
-                label_list.append(pad_labels)
-                advantage_list.append(pad_advantages)
-                if rollout_logprobs_list is not None:
-                    pad_rollout_logprobs = torch.zeros(
-                        1,
-                        pad_len,
-                        dtype=data_batches[0]["rollout_logprobs"].dtype,
-                        device=data_batches[0]["shifted_labels"].device,
-                    )
-                    rollout_logprobs_list.append(pad_rollout_logprobs)
-
-            seq_ctx = SequenceContext.cat(seq_ctx_list)
-            shifted_labels = torch.cat(label_list, dim=1)  # (1, max_len)
-            advantage_flat = [item for sublist in advantage_list for item in sublist]
-            advantages = torch.tensor(advantage_flat, dtype=torch.float32).unsqueeze(0)
-
-            rollout_logprobs = None
-            if rollout_logprobs_list is not None:
-                rollout_logprobs = torch.cat(rollout_logprobs_list, dim=1)  # (1, max_len)
-
-            packed_data_batches.append(
-                {
-                    "seq_ctx": seq_ctx,
-                    "shifted_labels": shifted_labels,
-                    "advantages": advantages,
-                    "rollout_logprobs": rollout_logprobs,
-                }
-            )
-        return packed_data_batches
-
-    def _grouped_by_max_length(self, packed_data_batches):
-        # sort 过后可能第一个 batch 会有很多 pad tokens，因为最后一个 pack 可能只有少量真实数据。
-        # 比如组成了 16 个 pack，第 16 个 pack 可能只有几条真实数据，剩下的都是 pad tokens。
-        # 排序后这条 pack 会被放在最前面，导致 rank0 的第一个 step 消耗的有效 token 数往往少于其他 rank，是正常现象。
-        return sorted(packed_data_batches, key=lambda x: x["seq_ctx"].max_length_q, reverse=True)
-
-    def fit(self, data_batches: list[ColateItem], pack_max_length: int, rollout_idx: int) -> list[WorkerLogItem]:
-        has_rollout_routed_experts = False
-        language_cfg = None
-        if data_batches[0]["seq_ctx"].rollout_routed_experts is not None:
-            model_cfg = ray.get(self.workers[0].get_model_cfg.remote())  # type: ignore[attr-defined]
-            has_rollout_routed_experts = True
-            language_cfg = model_cfg
-            if isinstance(model_cfg, BaseComposeConfig):
-                language_cfg = model_cfg.text_config
-
-        packed_data_batches = self._packing(data_batches, pack_max_length, language_cfg)
-        # packed_data_batches = self._grouped_by_max_length(packed_data_batches)
-
-        # TODO(hha): 这个逻辑不够通用，和模型绑定了
-        is_qwen3_vl = False
-        if len(packed_data_batches[0]["seq_ctx"].position_ids.shape) == 3:
-            is_qwen3_vl = True
-
-        # todo: support round up
-        num_packed_data_batches = len(packed_data_batches)
-        data_replicate_size = ray.get(self.workers[0].get_data_replicate_size.remote())  # type: ignore[attr-defined]
-        dp_size = len(self.workers) // data_replicate_size
-        pad_num = math.ceil(num_packed_data_batches / dp_size) * dp_size - num_packed_data_batches
-        if pad_num > 0:
-            # Reduce the attn calculation time by using multiple short sequence packs
-            assert data_batches[0]["seq_ctx"].input_ids is not None
-            pad_tokens = tuple(
-                torch.zeros(1, 1024, dtype=data_batches[0]["seq_ctx"].input_ids.dtype, device="cpu")
-                for _ in range(pack_max_length // 1024)
-            )
-            if pack_max_length % 1024 > 0:
-                assert data_batches[0]["seq_ctx"].input_ids is not None
-                pad_tokens = pad_tokens + (
-                    torch.zeros(
-                        1, pack_max_length % 1024, dtype=data_batches[0]["seq_ctx"].input_ids.dtype, device="cpu"
-                    ),
-                )
-            pad_seq_ctx = SequenceContext.from_input_ids(pad_tokens, device="cpu")  # type: ignore
-            pad_seq_ctx.num_padding = pack_max_length
-            if is_qwen3_vl:
-                _position_ids_list = []
-                for pad_token in pad_tokens:
-                    _position_ids = torch.arange(pad_token.size(-1)).view(1, 1, -1).expand(3, 1, -1)
-                    _position_ids_list.append(_position_ids)
-                pad_seq_ctx.position_ids = torch.cat(_position_ids_list, dim=-1)  # type: ignore
-
-            pad_shifted_labels = torch.full(
-                (1, pack_max_length),
-                -100,
-                dtype=packed_data_batches[0]["shifted_labels"].dtype,
-                device="cpu",
-            )
-            pad_advantages = torch.full(
-                (1, pack_max_length),
-                -100,
-                dtype=packed_data_batches[0]["advantages"].dtype,
-                device="cpu",
+    def fit(
+        self,
+        data_batches: list[WorkerInputItem],
+        pack_max_length: int,
+        rollout_idx: int,
+    ) -> TrainingLogInfo:
+        if pack_max_length != self.pack_max_length:
+            raise ValueError(
+                f"pack_max_length {pack_max_length} does not match worker config {self.pack_max_length}"
             )
 
-            if has_rollout_routed_experts:
-                pad_rand_index = torch.randint(
-                    low=0,
-                    high=1,
-                    size=(1, 1, 1),  # add dummy data, true data will be initialized in train worker.fit
-                )
-                pad_seq_ctx.rollout_routed_experts = pad_rand_index
-
-            pad_rollout_logprobs = None
-            if "rollout_logprobs" in packed_data_batches[0] and packed_data_batches[0]["rollout_logprobs"] is not None:
-                pad_rollout_logprobs = torch.zeros(
-                    1, pack_max_length, dtype=packed_data_batches[0]["rollout_logprobs"].dtype, device="cpu"
-                )
-            pad_data = {
-                "seq_ctx": pad_seq_ctx,
-                "shifted_labels": pad_shifted_labels,
-                "advantages": pad_advantages,
-                "rollout_logprobs": pad_rollout_logprobs,
-            }
-            pad_data_samples = [pad_data for _ in range(pad_num)]
-            packed_data_batches = packed_data_batches + pad_data_samples
+        start_time = time.perf_counter()
+        packed_data_batches, padding_tokens_num = self.data_packer.pack(data_batches)
+        pack_end_time = time.perf_counter()
 
         handles = []
-        data_batch_refs = {}
+        data_batch_refs: dict[int, ray.ObjectRef] = {}
         for worker_idx, worker in enumerate(self.workers):
-            dp_idx = worker_idx // data_replicate_size
-            if dp_idx not in data_batch_refs:
-                data_batch_refs[dp_idx] = ray.put(packed_data_batches[dp_idx::dp_size])
+            dp_rank = self.worker_dp_ranks[worker_idx]
+            if dp_rank not in data_batch_refs:
+                data_batch_refs[dp_rank] = ray.put(packed_data_batches[dp_rank])
             handles.append(
                 worker.fit.remote(  # type: ignore[attr-defined]
-                    data_batches=data_batch_refs[dp_idx],
+                    data_batches=data_batch_refs[dp_rank],
                     rollout_idx=rollout_idx,
                 )
             )
+
         try:
-            log_infos = ray.get(handles, timeout=TRAIN_RAY_GET_TIMEOUT)
+            worker_log_infos = ray.get(handles, timeout=TRAIN_RAY_GET_TIMEOUT)
+            train_end_time = time.perf_counter()
         finally:
-            # free pixel values ref
             free_pixel_value_refs: list[ray.ObjectRef] = []
-            for data in packed_data_batches:
-                if data["seq_ctx"].pixel_values is not None:
-                    free_pixel_value_refs.extend(data["seq_ctx"].pixel_values)
-            if len(free_pixel_value_refs) > 0:
+            for dp_batches in packed_data_batches:
+                for step_batches in dp_batches:
+                    for data in step_batches:
+                        pixel_values = data["seq_ctx"].pixel_values
+                        if isinstance(pixel_values, list):
+                            free_pixel_value_refs.extend(pixel_values)
+            if free_pixel_value_refs:
                 free_object_refs(free_pixel_value_refs)
             del data_batch_refs
             del packed_data_batches
-        return log_infos
+
+        return {
+            "worker_log_infos": worker_log_infos,
+            "pack_time": pack_end_time - start_time,
+            "train_time": train_end_time - pack_end_time,
+            "padding_tokens": padding_tokens_num,
+        }
 
     def offload(self, target: Literal["model", "optimizer", "all"] = "all"):
         if target == "model":

--- a/xtuner/v1/rl/trainer/pack.py
+++ b/xtuner/v1/rl/trainer/pack.py
@@ -1,54 +1,51 @@
 import math
 import random
-from pathlib import Path
-from typing import cast
+from collections.abc import Sequence
+from typing import TypeAlias
 
 import numpy as np
 import torch
 
-from xtuner.v1.data_proto.sequence_context import SequenceContext
 from xtuner.v1.datasets.sampler import get_length_grouped_indices
-from xtuner.v1.model.base import TransformerConfig
-from xtuner.v1.model.compose.base import BaseComposeConfig
-from xtuner.v1.rl.trainer.worker import WorkerInputItem
-from xtuner.v1.utils import get_logger
 
 
-# TODO: use expand_soft pack strategy in sft for greedy pack
-def get_soft_pack_infos(data_batches, num_tokens, target):
-    pack_infos = []
-    current_indices = []
+PackIndices: TypeAlias = list[int]
+OptimizerStepPackIndices: TypeAlias = list[PackIndices]
+DPRankPackIndices: TypeAlias = list[OptimizerStepPackIndices]
+PackedDataIndices: TypeAlias = list[DPRankPackIndices]
+
+
+def get_soft_pack_infos(data_indices: Sequence[int], num_tokens: Sequence[int], target: int) -> list[PackIndices]:
+    """Group sample indices into sequential packs without touching sample data."""
+    if len(data_indices) != len(num_tokens):
+        raise ValueError("data_indices and num_tokens must have the same length")
+
+    pack_infos: list[PackIndices] = []
+    current_indices: PackIndices = []
     current_len = 0
-    current_max = 0
 
-    for i, token_len in enumerate(num_tokens):
+    for data_index, token_len in zip(data_indices, num_tokens):
         if current_len + token_len <= target:
-            current_indices.append(i)
+            current_indices.append(int(data_index))
             current_len += token_len
-            current_max = max(current_max, token_len)
         else:
             if current_indices:
-                pack_infos.append(
-                    {
-                        "indices": current_indices,
-                        "longest": int(current_max),
-                    }
-                )
-            current_indices = [i]
+                pack_infos.append(current_indices)
+            current_indices = [int(data_index)]
             current_len = token_len
-            current_max = token_len
 
     if current_indices:
-        pack_infos.append(
-            {
-                "indices": current_indices,
-                "longest": int(current_max),
-            }
-        )
+        pack_infos.append(current_indices)
     return pack_infos
 
 
 class RLDataPacker:
+    """Build an index-only packing plan for RL training data.
+
+    The packer owns scheduling decisions only. It never creates padding tensors,
+    concatenates ``SequenceContext`` objects, or otherwise materializes a pack.
+    """
+
     def __init__(
         self,
         pack_max_length: int,
@@ -56,8 +53,6 @@ class RLDataPacker:
         data_replicate_size: int,
         optimizer_steps: int,
         pack_strategy: str = "greedy",
-        model_cfg: TransformerConfig | None = None,
-        worker_log_dir: str | None = None,
         seed: int = 42,
     ):
         self.pack_max_length = pack_max_length
@@ -65,18 +60,8 @@ class RLDataPacker:
         self.data_replicate_size = data_replicate_size
         self.optimizer_steps = optimizer_steps
         self.split_size = 1024
-        if worker_log_dir is not None:
-            self.worker_log_dir = Path(worker_log_dir) if isinstance(worker_log_dir, str) else worker_log_dir
-            self.logger = get_logger(log_dir=self.worker_log_dir, tag="TrainingController")
-        else:
-            self.logger = get_logger()
-
-        self.data_batch_properties = {
-            "is_qwen3_vl": False,
-            "has_rollout_routed_experts": False,
-            "has_rollout_logprobs": False,
-            "n_routed_experts": None,
-        }
+        self.dp_size = self.world_size // self.data_replicate_size
+        self.seed = seed
         self.strategy_map = {
             "greedy": self.greedy_pack_and_split,
             "balance": self.balance_split_and_pack,
@@ -85,307 +70,153 @@ class RLDataPacker:
         if pack_strategy not in self.strategy_map:
             raise ValueError(f"Unknown packing strategy: {pack_strategy}")
         self._impl = self.strategy_map[pack_strategy]
-        self.dp_size = self.world_size // self.data_replicate_size
-        self.padding_tokens = 0
-        self.model_cfg = model_cfg
-        self.seed = seed
 
-    def pack(self, data_batches: list[WorkerInputItem]) -> tuple[list[list[list[WorkerInputItem]]], int]:
-        self.padding_tokens = 0
-        if not data_batches:
+    def pack(self, data_lengths: Sequence[int]) -> tuple[PackedDataIndices, int]:
+        """Return ``[dp][optimizer_step][pack][sample_index]`` and padding size."""
+        if not data_lengths:
             return [], 0
-        self._set_data_batch_properties(data_batches)
-        return self._impl(data_batches), self.padding_tokens
+        for data_index, data_length in enumerate(data_lengths):
+            if data_length > self.pack_max_length:
+                raise ValueError(
+                    f"Single sample {data_index} seq len {data_length} exceeds "
+                    f"pack_max_length {self.pack_max_length}"
+                )
 
-    def native_split_and_pack(self, data_batches: list[WorkerInputItem]) -> list[list[list[WorkerInputItem]]]:
-        # 1. 预处理，保证样本数量可以被 dp_size 整除
-        if len(data_batches) % self.dp_size != 0:
-            pad_num = self.dp_size - (len(data_batches) % self.dp_size)
-            padding_item = self._create_padding_item(self.split_size, self.pack_max_length)
-            data_batches.extend([padding_item] * pad_num)
+        data_indices = list(range(len(data_lengths)))
+        packed_data_indices = self._impl(data_indices, data_lengths)
+        padding_tokens = self._count_padding_tokens(packed_data_indices, data_lengths)
+        return packed_data_indices, padding_tokens
 
-        # 2. 按照 dp_size 切分样本
-        batches_per_dp_group: list[list[WorkerInputItem]] = np.array_split(data_batches, self.dp_size)
+    def native_split_and_pack(
+        self,
+        data_indices: list[int],
+        data_lengths: Sequence[int],
+    ) -> PackedDataIndices:
+        # Use private negative indices as scheduling-only padding slots. They are
+        # removed from the returned plan and materialized as padding by workers.
+        scheduled_indices = data_indices.copy()
+        if len(scheduled_indices) % self.dp_size != 0:
+            pad_num = self.dp_size - (len(scheduled_indices) % self.dp_size)
+            scheduled_indices.extend(-(index + 1) for index in range(pad_num))
+
+        batches_per_dp_group = np.array_split(scheduled_indices, self.dp_size)
         actual_optimizer_steps = min(len(batches_per_dp_group[0]), self.optimizer_steps)
-        packed_data_batches: list[list[list[WorkerInputItem]]] = [
+        packed_data_indices: PackedDataIndices = [
             [[] for _ in range(actual_optimizer_steps)] for _ in range(self.dp_size)
         ]
         max_packs_per_step = [0] * actual_optimizer_steps
 
-        for dp_rank, dp_worker_data_batches in enumerate(batches_per_dp_group):
-            # 3. 按照 actual_optimizer_steps 切分样本
-            batches_for_optim_steps = np.array_split(dp_worker_data_batches, actual_optimizer_steps)
-            for step_idx, step_mini_batches in enumerate(batches_for_optim_steps):
-                # 4. 对每个 optimizer step 的样本进行打包
-                each_step_pack_list = self._pack(step_mini_batches, self.pack_max_length)
-                packed_data_batches[dp_rank][step_idx] = each_step_pack_list
-                max_packs_per_step[step_idx] = max(
-                    max_packs_per_step[step_idx], len(packed_data_batches[dp_rank][step_idx])
-                )
+        for dp_rank, dp_worker_indices in enumerate(batches_per_dp_group):
+            indices_for_optim_steps = np.array_split(dp_worker_indices, actual_optimizer_steps)
+            for step_idx, step_indices_array in enumerate(indices_for_optim_steps):
+                step_indices = [int(index) for index in step_indices_array]
+                packed_step_indices = self._pack_indices(step_indices, data_lengths)
+                packed_data_indices[dp_rank][step_idx] = packed_step_indices
+                max_packs_per_step[step_idx] = max(max_packs_per_step[step_idx], len(packed_step_indices))
 
-        self.logger.info(f"Gradient accumulation for each optimizer steps: {max_packs_per_step}")
+        self._align_pack_count(packed_data_indices, max_packs_per_step)
+        return packed_data_indices
 
-        # 5. padding for each worker to have same number of packs in each optimizer step
-        for step_idx in range(actual_optimizer_steps):
-            max_packs = max_packs_per_step[step_idx]
-            for dp_rank in range(self.dp_size):
-                num_current_packs = len(packed_data_batches[dp_rank][step_idx])
-                num_padding_packs = max_packs - num_current_packs
-
-                if num_padding_packs > 0:
-                    padding_items = [
-                        self._create_padding_item(self.pack_max_length, self.pack_max_length)
-                        for _ in range(num_padding_packs)
-                    ]
-                    packed_data_batches[dp_rank][step_idx].extend(padding_items)
-        return packed_data_batches
-
-    def balance_split_and_pack(self, data_batches: list[WorkerInputItem]) -> list[list[list[WorkerInputItem]]]:
-        # 1. 保证每张卡获取的样本总长度大致相等
-        max_lengths = self._get_seqlen_from_data_batches(data_batches)
-
+    def balance_split_and_pack(
+        self,
+        data_indices: list[int],
+        data_lengths: Sequence[int],
+    ) -> PackedDataIndices:
         torch_generator = torch.Generator().manual_seed(self.seed)
         random_generator = random.Random(self.seed)
-
-        indices = get_length_grouped_indices(
-            max_lengths=max_lengths,
-            group_batch_size=len(data_batches),
+        grouped_indices = get_length_grouped_indices(
+            max_lengths=list(data_lengths),
+            group_batch_size=len(data_indices),
             group_size=self.dp_size,
             torch_generator=torch_generator,
             random_generator=random_generator,
         )
 
-        partitioned_data: list[list[list[WorkerInputItem]]] = [
+        partitioned_indices: PackedDataIndices = [
             [[] for _ in range(self.optimizer_steps)] for _ in range(self.dp_size)
         ]
-
-        # 2. 根据indices将样本分配到每张卡的每个 optimizer step 上
-        for i, idx in enumerate(indices):
+        for i, data_index in enumerate(grouped_indices):
             dp_rank = i % self.dp_size
             step_idx = (i // self.dp_size) % self.optimizer_steps
-            partitioned_data[dp_rank][step_idx].append(data_batches[idx])
+            partitioned_indices[dp_rank][step_idx].append(int(data_index))
 
-        packed_data_batches: list[list[list[WorkerInputItem]]] = [
+        packed_data_indices: PackedDataIndices = [
             [[] for _ in range(self.optimizer_steps)] for _ in range(self.dp_size)
         ]
-
         max_packs_per_step = [0] * self.optimizer_steps
-
         for dp_rank in range(self.dp_size):
             for step_idx in range(self.optimizer_steps):
-                # 3. 对每个卡每个 optimizer step 的样本进行打包
-                step_data = partitioned_data[dp_rank][step_idx]
-                packed_step_data = self._pack(step_data, self.pack_max_length)
-                packed_data_batches[dp_rank][step_idx] = packed_step_data
-                max_packs_per_step[step_idx] = max(
-                    max_packs_per_step[step_idx], len(packed_data_batches[dp_rank][step_idx])
+                packed_step_indices = self._pack_indices(
+                    partitioned_indices[dp_rank][step_idx],
+                    data_lengths,
                 )
+                packed_data_indices[dp_rank][step_idx] = packed_step_indices
+                max_packs_per_step[step_idx] = max(max_packs_per_step[step_idx], len(packed_step_indices))
 
-        # 4. padding for each worker to have same number of packs in each optimizer step
-        for step_idx in range(self.optimizer_steps):
-            max_packs = max_packs_per_step[step_idx]
-            for dp_rank in range(self.dp_size):
-                num_current_packs = len(packed_data_batches[dp_rank][step_idx])
-                num_padding_packs = max_packs - num_current_packs
+        self._align_pack_count(packed_data_indices, max_packs_per_step)
+        return packed_data_indices
 
-                if num_padding_packs > 0:
-                    padding_items = [
-                        self._create_padding_item(self.pack_max_length, self.pack_max_length)
-                        for _ in range(num_padding_packs)
-                    ]
-                    packed_data_batches[dp_rank][step_idx].extend(padding_items)
-        return packed_data_batches
+    def greedy_pack_and_split(
+        self,
+        data_indices: list[int],
+        data_lengths: Sequence[int],
+    ) -> PackedDataIndices:
+        total_pack_indices = self._pack_indices(data_indices, data_lengths)
+        pad_num = math.ceil(len(total_pack_indices) / self.dp_size) * self.dp_size - len(total_pack_indices)
+        total_pack_indices.extend([[] for _ in range(pad_num)])
 
-    def greedy_pack_and_split(self, data_batches: list[WorkerInputItem]) -> list[list[list[WorkerInputItem]]]:
-        # 1. 使用贪心算法将所有样本打包成一个一维的 pack 列表。
-        total_data_batches = self._pack(data_batches, self.pack_max_length)
-        # 2. 为了均匀分配，填充整个 batch，使其总 pack 数能被 dp_size 整除。
-        dp_size = self.world_size // self.data_replicate_size
-        num_packed_data_batches = len(total_data_batches)
-        pad_num = math.ceil(num_packed_data_batches / dp_size) * dp_size - num_packed_data_batches
-        if pad_num > 0:
-            pad_data_samples = [
-                self._create_padding_item(self.pack_max_length, self.pack_max_length) for _ in range(pad_num)
-            ]
-            total_data_batches = total_data_batches + pad_data_samples
-
-        # 3. 将填充后的 pack 列表按 dp_size 和 optimizer_steps 重新分配。
-        each_dp_batches_num = len(total_data_batches) // dp_size
+        each_dp_batches_num = len(total_pack_indices) // self.dp_size
         if each_dp_batches_num < self.optimizer_steps:
-            iters_per_step = 1  # each optimizer step has at least one batch
+            iters_per_step = 1
             actual_optimizer_steps = each_dp_batches_num
         else:
             iters_per_step = math.ceil(each_dp_batches_num / self.optimizer_steps)
             actual_optimizer_steps = math.ceil(each_dp_batches_num / iters_per_step)
-        packed_data_batches: list[list[list[WorkerInputItem]]] = [
-            [[] for _ in range(actual_optimizer_steps)] for _ in range(dp_size)
+
+        packed_data_indices: PackedDataIndices = [
+            [[] for _ in range(actual_optimizer_steps)] for _ in range(self.dp_size)
         ]
-        for dp_rank in range(dp_size):
-            for step in range(actual_optimizer_steps):
-                start_idx = dp_rank * each_dp_batches_num + step * iters_per_step
+        for dp_rank in range(self.dp_size):
+            for step_idx in range(actual_optimizer_steps):
+                start_idx = dp_rank * each_dp_batches_num + step_idx * iters_per_step
                 end_idx = min(start_idx + iters_per_step, each_dp_batches_num * (dp_rank + 1))
-                packed_data_batches[dp_rank][step] = total_data_batches[start_idx:end_idx]
-        return packed_data_batches
+                packed_data_indices[dp_rank][step_idx] = total_pack_indices[start_idx:end_idx]
+        return packed_data_indices
 
-    def _get_seqlen_from_data_batches(self, data_batches: list[WorkerInputItem]) -> list[int]:
-        seqlen_list = []
-        for data in data_batches:
-            assert data["seq_ctx"].input_ids.numel() <= self.pack_max_length, (  # type: ignore[union-attr]
-                f"Single sample seq len {data['seq_ctx'].input_ids.numel()} exceeds pack_max_length {self.pack_max_length}"  # type: ignore[union-attr]
-            )
-            seqlen_list.append(data["seq_ctx"].input_ids.numel())  # type: ignore[union-attr]
-        return seqlen_list
-
-    def _set_data_batch_properties(self, data_batches: list[WorkerInputItem]):
-        if not data_batches:
-            return
-
-        first_item = data_batches[0]
-        seq_ctx = first_item["seq_ctx"]
-
-        self.data_batch_properties["is_qwen3_vl"] = (
-            seq_ctx.position_ids is not None and len(seq_ctx.position_ids.shape) == 3
-        )
-        self.data_batch_properties["has_rollout_logprobs"] = (
-            "rollout_logprobs" in first_item and first_item["rollout_logprobs"] is not None
-        )
-        self.data_batch_properties["has_rollout_routed_experts"] = seq_ctx.rollout_routed_experts is not None
-
-        language_cfg = None
-        if self.data_batch_properties["has_rollout_routed_experts"]:
-            language_cfg = self.model_cfg
-            if isinstance(self.model_cfg, BaseComposeConfig):
-                language_cfg = self.model_cfg.text_config
-
-        self.data_batch_properties["n_routed_experts"] = (
-            language_cfg.n_routed_experts if language_cfg is not None else None
-        )
-        self.logger.info(f"Data batch properties set: {self.data_batch_properties}")
-
-    def _pack(self, data_batches: list[WorkerInputItem], pack_max_length: int) -> list[WorkerInputItem]:
-        seqlen_list = self._get_seqlen_from_data_batches(data_batches)
-        total_length = sum(seqlen_list)
-        each_step_pack_list: list[WorkerInputItem] = []
-        if total_length > pack_max_length:
-            # TODO: add expand_soft pack strategy
-            pack_infos = get_soft_pack_infos(
-                data_batches,
-                seqlen_list,
-                pack_max_length,
-            )
-            for pack_info in pack_infos:
-                indices = pack_info["indices"]
-                batch4pack = [data_batches[i] for i in indices]
-                each_step_pack_list.append(self._single_pack(batch4pack, pack_max_length))
+    def _pack_indices(self, data_indices: Sequence[int], data_lengths: Sequence[int]) -> OptimizerStepPackIndices:
+        scheduled_lengths = [self._get_scheduled_length(data_index, data_lengths) for data_index in data_indices]
+        if sum(scheduled_lengths) > self.pack_max_length:
+            packs = get_soft_pack_infos(data_indices, scheduled_lengths, self.pack_max_length)
         else:
-            each_step_pack_list.append(self._single_pack(data_batches, pack_max_length))
-        return each_step_pack_list
+            packs = [[int(data_index) for data_index in data_indices]]
+        return [[data_index for data_index in pack if data_index >= 0] for pack in packs]
 
-    def _single_pack(self, data_batches: list[WorkerInputItem], pack_max_length: int) -> WorkerInputItem:
-        seq_ctx_list = [item["seq_ctx"] for item in data_batches]
-        label_list = [item["shifted_labels"] for item in data_batches]
-        advantage_list = []
-        for item in data_batches:
-            advantages = item["advantages"].reshape(1, -1)
-            advantage_list.append(advantages)
+    def _get_scheduled_length(self, data_index: int, data_lengths: Sequence[int]) -> int:
+        if data_index >= 0:
+            return data_lengths[data_index]
+        return min(self.split_size, self.pack_max_length)
 
-        rollout_logprobs_list = [
-            item["rollout_logprobs"] if self.data_batch_properties["has_rollout_logprobs"] else None
-            for item in data_batches
-        ]
-        seqlen_list = self._get_seqlen_from_data_batches(data_batches)
-        cur_length = sum(seqlen_list)
-        padding_len = pack_max_length - cur_length
+    def _align_pack_count(self, packed_data_indices: PackedDataIndices, max_packs_per_step: Sequence[int]) -> None:
+        for step_idx, max_packs in enumerate(max_packs_per_step):
+            for dp_rank in range(self.dp_size):
+                missing_packs = max_packs - len(packed_data_indices[dp_rank][step_idx])
+                packed_data_indices[dp_rank][step_idx].extend([[] for _ in range(missing_packs)])
 
-        padding_item: WorkerInputItem | None = None
-        if padding_len > 0:
-            padding_item = self._create_padding_item(padding_len, pack_max_length)
-            seq_ctx_list.append(padding_item["seq_ctx"])
-            label_list.append(padding_item["shifted_labels"])
-            advantage_list.append(padding_item["advantages"])
-            rollout_logprobs_list.append(padding_item["rollout_logprobs"])
-
-        packed_seq_ctx = SequenceContext.cat(seq_ctx_list)
-        packed_shifted_labels = torch.cat(label_list, dim=1)  # type: ignore[arg-type]
-        packed_shifted_labels = cast(torch.LongTensor, packed_shifted_labels)
-        packed_advantages = torch.cat(advantage_list, dim=1)
-        if self.data_batch_properties["has_rollout_logprobs"]:
-            cast_rollout_logprobs_list = [cast(torch.Tensor, item) for item in rollout_logprobs_list]
-            packed_rollout_logprobs = torch.cat(cast_rollout_logprobs_list, dim=1)
-        else:
-            packed_rollout_logprobs = None
-
-        optimizer_step_packs: WorkerInputItem = {
-            "seq_ctx": packed_seq_ctx,
-            "shifted_labels": packed_shifted_labels,
-            "advantages": packed_advantages,
-            "rollout_logprobs": packed_rollout_logprobs,
-        }
-        packed_input_ids = cast(torch.Tensor, packed_seq_ctx.input_ids)
-        assert packed_input_ids.numel() == pack_max_length, (
-            f"Packed seq ctx length {packed_input_ids.numel()} does not match pack_max_length {pack_max_length}"
-            f"padding input_ids length: {padding_item['seq_ctx'].input_ids.shape if padding_item else 0}"  # type: ignore[union-attr]
-        )
-        assert packed_seq_ctx.num_padding == (packed_advantages == -100).sum().item(), (
-            f"Packed seq ctx num_padding {packed_seq_ctx.num_padding} and packed advantages num_padding "
-            f"{(packed_advantages != -100).sum().item()} mismatch after packing."
-        )
-        return optimizer_step_packs
-
-    def _create_padding_item(
+    def _count_padding_tokens(
         self,
-        pad_len: int,
-        pack_max_length: int,
-    ) -> WorkerInputItem:
-        # padding input_ids
-        self.padding_tokens += pad_len
-        pad_tokens = tuple(
-            torch.zeros(1, self.split_size, dtype=torch.long, device="cpu") for _ in range(pad_len // self.split_size)
-        )
-        if pad_len % self.split_size > 0:
-            pad_tokens = pad_tokens + (torch.zeros(1, pad_len % self.split_size, dtype=torch.long, device="cpu"),)
-        pad_tokens = cast(tuple[torch.LongTensor, ...], pad_tokens)
-        pad_seq_ctx = SequenceContext.from_input_ids(pad_tokens, device="cpu")
-        pad_seq_ctx.num_padding = pad_len
+        packed_data_indices: PackedDataIndices,
+        data_lengths: Sequence[int],
+    ) -> int:
+        total_packs = 0
+        scheduled_tokens = 0
+        seen_indices: list[int] = []
+        for dp_rank_indices in packed_data_indices:
+            for step_indices in dp_rank_indices:
+                total_packs += len(step_indices)
+                for pack_indices in step_indices:
+                    seen_indices.extend(pack_indices)
+                    scheduled_tokens += sum(data_lengths[data_index] for data_index in pack_indices)
 
-        # padding mm positions_ids
-        if self.data_batch_properties["is_qwen3_vl"]:
-            _position_ids_list = []
-            for pad_token in pad_tokens:
-                _position_ids = torch.arange(pad_token.size(-1)).view(1, 1, -1).expand(3, 1, -1)
-                _position_ids_list.append(_position_ids)
-            position_ids = torch.cat(_position_ids_list, dim=-1)
-            position_ids = cast(torch.LongTensor, position_ids)
-            pad_seq_ctx.position_ids = position_ids
-
-        # padding rollout routed experts
-        if self.data_batch_properties["has_rollout_routed_experts"]:
-            assert self.data_batch_properties["n_routed_experts"], (
-                "n_routed_experts must be provided when has_rollout_routed_experts is True"
-            )
-            if pad_len == pack_max_length:
-                pad_rand_index = torch.randint(
-                    low=0, high=1, size=(1, 1, 1)
-                )  # add dummy data, true data will be initialized in train worker.fit
-            else:
-                pad_rand_index = torch.randint(
-                    low=0, high=self.data_batch_properties["n_routed_experts"], size=(pad_len, 1, 1)
-                )
-            pad_seq_ctx.rollout_routed_experts = pad_rand_index
-
-        pad_labels = cast(torch.LongTensor, torch.full((1, pad_len), -100, dtype=torch.int64, device="cpu"))
-
-        pad_advantage = torch.full((1, pad_len), -100, dtype=torch.float32, device="cpu")
-        pad_rollout_logprobs = (
-            torch.zeros(1, pad_len, dtype=torch.float32, device="cpu")
-            if self.data_batch_properties["has_rollout_logprobs"]
-            else None
-        )
-
-        padding_item: WorkerInputItem = {
-            "seq_ctx": pad_seq_ctx,
-            "shifted_labels": pad_labels,
-            "advantages": pad_advantage,
-            "rollout_logprobs": pad_rollout_logprobs,
-        }
-        return padding_item
+        if sorted(seen_indices) != list(range(len(data_lengths))):
+            raise RuntimeError("Packing plan must contain every data index exactly once")
+        return total_packs * self.pack_max_length - scheduled_tokens

--- a/xtuner/v1/rl/trainer/pack.py
+++ b/xtuner/v1/rl/trainer/pack.py
@@ -10,7 +10,7 @@ from xtuner.v1.data_proto.sequence_context import SequenceContext
 from xtuner.v1.datasets.sampler import get_length_grouped_indices
 from xtuner.v1.model.base import TransformerConfig
 from xtuner.v1.model.compose.base import BaseComposeConfig
-from xtuner.v1.rl.base.worker import WorkerInputItem
+from xtuner.v1.rl.trainer.worker import WorkerInputItem
 from xtuner.v1.utils import get_logger
 
 

--- a/xtuner/v1/rl/trainer/pack.py
+++ b/xtuner/v1/rl/trainer/pack.py
@@ -326,7 +326,7 @@ class RLDataPacker:
             f"Packed seq ctx length {packed_input_ids.numel()} does not match pack_max_length {pack_max_length}"
             f"padding input_ids length: {padding_item['seq_ctx'].input_ids.shape if padding_item else 0}"  # type: ignore[union-attr]
         )
-        assert packed_seq_ctx.num_padding == (packed_advantages != -100).sum().item(), (
+        assert packed_seq_ctx.num_padding == (packed_advantages == -100).sum().item(), (
             f"Packed seq ctx num_padding {packed_seq_ctx.num_padding} and packed advantages num_padding "
             f"{(packed_advantages != -100).sum().item()} mismatch after packing."
         )

--- a/xtuner/v1/rl/trainer/worker.py
+++ b/xtuner/v1/rl/trainer/worker.py
@@ -62,6 +62,7 @@ from xtuner.v1.utils.fsdp import release_deferred_fsdp_all_gathers
 from xtuner.v1.utils.nccl_process_group import resume_nccl_process_groups, suspend_nccl_process_groups
 
 from ..rollout_is import merge_rollout_is_metrics
+from .pack import DPRankPackIndices
 
 
 DEVICE = get_device()
@@ -585,11 +586,139 @@ class TrainingWorker(SingleAcceleratorWorker):
                 stack.enter_context(profiling_memory(memory_dir))
             yield
 
+    def _materialize_packs(
+        self,
+        data_batches: list[WorkerInputItem],
+        data_batch_indices: DPRankPackIndices,
+    ) -> list[list[WorkerInputItem]]:
+        """Select samples by index and materialize this DP rank's packs."""
+        self._set_pack_data_properties(data_batches)
+        return [
+            [self._single_pack([data_batches[index] for index in pack_indices]) for pack_indices in step_indices]
+            for step_indices in data_batch_indices
+        ]
+
+    def _set_pack_data_properties(self, data_batches: list[WorkerInputItem]) -> None:
+        self._pack_is_qwen3_vl = False
+        self._pack_has_rollout_routed_experts = False
+        self._pack_has_rollout_logprobs = False
+        self._pack_n_routed_experts: int | None = None
+        if not data_batches:
+            return
+
+        first_item = data_batches[0]
+        seq_ctx = first_item["seq_ctx"]
+        self._pack_is_qwen3_vl = seq_ctx.position_ids is not None and len(seq_ctx.position_ids.shape) == 3
+        self._pack_has_rollout_logprobs = first_item["rollout_logprobs"] is not None
+        self._pack_has_rollout_routed_experts = seq_ctx.rollout_routed_experts is not None
+
+        if self._pack_has_rollout_routed_experts:
+            language_cfg = self.config.model_cfg
+            if isinstance(language_cfg, BaseComposeConfig):
+                language_cfg = language_cfg.text_config
+            self._pack_n_routed_experts = language_cfg.n_routed_experts
+
+    def _single_pack(self, data_batches: list[WorkerInputItem]) -> WorkerInputItem:
+        pack_max_length = self.config.pack_max_length
+        seq_ctx_list = [item["seq_ctx"] for item in data_batches]
+        label_list = [item["shifted_labels"] for item in data_batches]
+        advantage_list = [item["advantages"].reshape(1, -1) for item in data_batches]
+        rollout_logprobs_list = [
+            item["rollout_logprobs"] if self._pack_has_rollout_logprobs else None for item in data_batches
+        ]
+
+        current_length = sum(item["seq_ctx"].input_ids.numel() for item in data_batches)  # type: ignore[union-attr]
+        padding_len = pack_max_length - current_length
+        padding_item: WorkerInputItem | None = None
+        if padding_len > 0:
+            padding_item = self._create_padding_item(padding_len)
+            seq_ctx_list.append(padding_item["seq_ctx"])
+            label_list.append(padding_item["shifted_labels"])
+            advantage_list.append(padding_item["advantages"])
+            rollout_logprobs_list.append(padding_item["rollout_logprobs"])
+
+        packed_seq_ctx = SequenceContext.cat(seq_ctx_list)
+        packed_shifted_labels = cast(torch.LongTensor, torch.cat(label_list, dim=1))
+        packed_advantages = torch.cat(advantage_list, dim=1)
+        if self._pack_has_rollout_logprobs:
+            packed_rollout_logprobs = torch.cat(
+                [cast(torch.Tensor, item) for item in rollout_logprobs_list],
+                dim=1,
+            )
+        else:
+            packed_rollout_logprobs = None
+
+        packed_input_ids = cast(torch.Tensor, packed_seq_ctx.input_ids)
+        padding_shape = padding_item["seq_ctx"].input_ids.shape if padding_item else 0  # type: ignore[union-attr]
+        assert packed_input_ids.numel() == pack_max_length, (
+            f"Packed seq ctx length {packed_input_ids.numel()} does not match pack_max_length {pack_max_length}; "
+            f"padding input_ids length: {padding_shape}"
+        )
+        assert packed_seq_ctx.num_padding == (packed_advantages == -100).sum().item(), (
+            f"Packed seq ctx num_padding {packed_seq_ctx.num_padding} and packed advantages padding count "
+            f"{(packed_advantages == -100).sum().item()} mismatch after packing."
+        )
+        return {
+            "seq_ctx": packed_seq_ctx,
+            "shifted_labels": packed_shifted_labels,
+            "advantages": packed_advantages,
+            "rollout_logprobs": packed_rollout_logprobs,
+        }
+
+    def _create_padding_item(self, pad_len: int) -> WorkerInputItem:
+        split_size = 1024
+        pad_tokens = tuple(
+            torch.zeros(1, split_size, dtype=torch.long, device="cpu") for _ in range(pad_len // split_size)
+        )
+        if pad_len % split_size > 0:
+            pad_tokens += (torch.zeros(1, pad_len % split_size, dtype=torch.long, device="cpu"),)
+        pad_tokens = cast(tuple[torch.LongTensor, ...], pad_tokens)
+        pad_seq_ctx = SequenceContext.from_input_ids(pad_tokens, device="cpu")
+        pad_seq_ctx.num_padding = pad_len
+
+        if self._pack_is_qwen3_vl:
+            position_ids_list = [
+                torch.arange(pad_token.size(-1)).view(1, 1, -1).expand(3, 1, -1) for pad_token in pad_tokens
+            ]
+            pad_seq_ctx.position_ids = cast(torch.LongTensor, torch.cat(position_ids_list, dim=-1))
+
+        if self._pack_has_rollout_routed_experts:
+            assert self._pack_n_routed_experts is not None
+            if pad_len == self.config.pack_max_length:
+                pad_rand_index = torch.randint(low=0, high=1, size=(1, 1, 1))
+            else:
+                pad_rand_index = torch.randint(low=0, high=self._pack_n_routed_experts, size=(pad_len, 1, 1))
+            pad_seq_ctx.rollout_routed_experts = pad_rand_index
+
+        return {
+            "seq_ctx": pad_seq_ctx,
+            "shifted_labels": cast(
+                torch.LongTensor,
+                torch.full((1, pad_len), -100, dtype=torch.int64, device="cpu"),
+            ),
+            "advantages": torch.full((1, pad_len), -100, dtype=torch.float32, device="cpu"),
+            "rollout_logprobs": (
+                torch.zeros(1, pad_len, dtype=torch.float32, device="cpu")
+                if self._pack_has_rollout_logprobs
+                else None
+            ),
+        }
+
     @ray_method
-    def fit(self, data_batches: list[list[WorkerInputItem]], rollout_idx: int) -> WorkerLogItem:
+    def fit(
+        self,
+        data_batch_refs: list[ray.ObjectRef],
+        data_batch_indices: DPRankPackIndices,
+        rollout_idx: int,
+    ) -> WorkerLogItem:
         # NOTE: sglang会清除logger handle, 重新创建
         self.logger = get_logger(log_dir=self.log_dir, tag="TrainingWorker")
         loss_cfg: BaseRLLossConfig = self.config.loss_cfg
+        raw_data_batches = cast(list[WorkerInputItem], ray.get(data_batch_refs[0]))
+        data_batches = self._materialize_packs(raw_data_batches, data_batch_indices)
+        del raw_data_batches
+        del data_batch_refs
+        del data_batch_indices
         num_optimizer_steps = len(data_batches)
         actual_optimizer_steps = min(num_optimizer_steps, self.config.optimizer_steps)
         assert num_optimizer_steps == actual_optimizer_steps, (
@@ -1029,7 +1158,8 @@ class TrainingWorker(SingleAcceleratorWorker):
     @ray_method
     def get_dp_rank(self) -> int:
         """Get the data parallel rank for this worker."""
-        return self.data_mesh["dp"].get_rank()
+        data_replicate_size = self._engine.data_replicate_size * self.sp_mesh.size()
+        return self.rank // data_replicate_size
 
     @ray_method
     def get_model_cfg(self):

--- a/xtuner/v1/rl/trainer/worker.py
+++ b/xtuner/v1/rl/trainer/worker.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import math
 import os
 import time
 from contextlib import contextmanager
@@ -9,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Iterable,
     List,
+    Literal,
     Sequence,
     TypedDict,
     cast,
@@ -149,6 +149,7 @@ class WorkerConfig(BaseModel):
     log_dir: str | Path | None = None
     update_weight_bucket_size_in_gb: float = 0.5  # 512MB
     seed: None | int = None  # if None, use RLTrainer seed
+    pack_strategy: Literal["greedy", "balance", "native"] = "greedy"
     profile_step: list[int] | int | None = None  # 1-based global RL train_step ids to profile.
     profile_time: bool = True
     profile_memory: bool = False
@@ -585,16 +586,17 @@ class TrainingWorker(SingleAcceleratorWorker):
             yield
 
     @ray_method
-    def fit(self, data_batches: list[WorkerInputItem], rollout_idx: int) -> WorkerLogItem:
+    def fit(self, data_batches: list[list[WorkerInputItem]], rollout_idx: int) -> WorkerLogItem:
         # NOTE: sglang会清除logger handle, 重新创建
         self.logger = get_logger(log_dir=self.log_dir, tag="TrainingWorker")
         loss_cfg: BaseRLLossConfig = self.config.loss_cfg
-        num_batches = len(data_batches)
-        iters_per_step = math.ceil(num_batches / self._optimizer_steps)
-        if num_batches < self._optimizer_steps:
-            self.logger.info(
-                f"Optimizer only step once because num_batches {num_batches} < optimizer_steps {self._optimizer_steps}."
-            )
+        num_optimizer_steps = len(data_batches)
+        actual_optimizer_steps = min(num_optimizer_steps, self.config.optimizer_steps)
+        assert num_optimizer_steps == actual_optimizer_steps, (
+            f"data_batches num {num_optimizer_steps} must be equal to optimizer_steps {actual_optimizer_steps}"
+        )
+        packed_batch_num_per_step = [len(step_data_batches) for step_data_batches in data_batches]
+        flat_data_batches = [data for step_data_batches in data_batches for data in step_data_batches]
 
         # Update seq_ctx: pixel_values, rollout_routed_experts
         # Init loss_ctx: shifted_labels, advantages, rollout_logprobs
@@ -602,7 +604,7 @@ class TrainingWorker(SingleAcceleratorWorker):
         loss_ctx_list: list[BaseRLLossContext] = []
         mtp_loss_ctx_list: list[list[MTPLossContext]] = []
         prepare_inputs_begin = time.perf_counter()
-        for data in data_batches:
+        for data in flat_data_batches:
             # update seq_ctx
             seq_ctx = data["seq_ctx"]
             pixel_values = seq_ctx.pixel_values
@@ -669,6 +671,7 @@ class TrainingWorker(SingleAcceleratorWorker):
         )
 
         del data_batches
+        del flat_data_batches
 
         # When sp_mesh.size() > 1, get the sp_split shifted_labels and rollout_logprobs
         shifted_labels_list = [loss_ctx.loss_kwargs.shifted_labels for loss_ctx in loss_ctx_list]
@@ -767,21 +770,23 @@ class TrainingWorker(SingleAcceleratorWorker):
         batched_loss_ctx_list: list[BaseRLLossContext] = []
         batched_mtp_loss_ctx_list: list[list[MTPLossContext]] = []
         LossContext = loss_cfg.loss_ctx_cls
-        for i in range(0, len(loss_ctx_list), iters_per_step):
-            batches_loss_ctx = loss_ctx_list[i : i + iters_per_step]
+        start_idx = 0
+        for num_packs_this_step in packed_batch_num_per_step:
+            end_idx = start_idx + num_packs_this_step
+            batches_loss_ctx = loss_ctx_list[start_idx:end_idx]
             batched_loss_ctx_list.extend(
                 LossContext.build_batches(batches_loss_ctx)  # type: ignore[arg-type]
             )
 
             if self.mtp_config is not None:
-                batches_seq_ctx = seq_ctx_list[i : i + iters_per_step]
+                batches_seq_ctx = seq_ctx_list[start_idx:end_idx]
                 cu_seq_lens_list = [seq_ctx.cu_seq_lens_q for seq_ctx in batches_seq_ctx]
                 # mtp_loss_ctx_list: list[list[MTPLossContext]], outer=batch, inner=mtp_depth
                 num_mtp_depths = len(mtp_loss_ctx_list[0]) if mtp_loss_ctx_list else 0
                 for mtp_idx in range(num_mtp_depths):
                     depth_mtp_loss_ctxs: list[LMHeadLossContext] = [
                         mtp_loss_ctx_list[j][mtp_idx]
-                        for j in range(i, min(i + iters_per_step, len(mtp_loss_ctx_list)))
+                        for j in range(start_idx, min(end_idx, len(mtp_loss_ctx_list)))
                     ]
                     batched_mtp_depth_ctxs = cast(
                         list[MTPLossContext],
@@ -793,17 +798,20 @@ class TrainingWorker(SingleAcceleratorWorker):
                     )
                     # Append each depth's batched ctx to the corresponding batch index
                     for batch_offset, mtp_ctx in enumerate(batched_mtp_depth_ctxs):
-                        global_batch_idx = i + batch_offset
+                        global_batch_idx = start_idx + batch_offset
                         if global_batch_idx >= len(batched_mtp_loss_ctx_list):
                             batched_mtp_loss_ctx_list.append([mtp_ctx])
                         else:
                             batched_mtp_loss_ctx_list[global_batch_idx].append(mtp_ctx)
+            start_idx = end_idx
 
         # train optimizer steps
-        for i in range(0, len(seq_ctx_list), iters_per_step):
+        start_idx = 0
+        for step_idx, num_packs_this_step in enumerate(packed_batch_num_per_step):
+            end_idx = start_idx + num_packs_this_step
             global_train_step = self._global_train_step + 1
-            batches_seq_ctx = seq_ctx_list[i : i + iters_per_step]
-            batches_loss_ctx = batched_loss_ctx_list[i : i + iters_per_step]
+            batches_seq_ctx = seq_ctx_list[start_idx:end_idx]
+            batches_loss_ctx = batched_loss_ctx_list[start_idx:end_idx]
 
             engine_input = [
                 ModelItem(seq_ctx=seq_ctx, loss_ctx={"lm": loss_ctx})
@@ -811,7 +819,7 @@ class TrainingWorker(SingleAcceleratorWorker):
             ]
 
             if self.mtp_config is not None:
-                batches_mtp_loss_ctxs = batched_mtp_loss_ctx_list[i : i + iters_per_step]
+                batches_mtp_loss_ctxs = batched_mtp_loss_ctx_list[start_idx:end_idx]
                 engine_input = [
                     ModelItem(
                         seq_ctx=seq_ctx,
@@ -833,7 +841,7 @@ class TrainingWorker(SingleAcceleratorWorker):
                 OffloadManager().clear()
             self.logger.debug(
                 f"Rank{self.rank} Rollout {rollout_idx} GlobalStep {global_train_step} "
-                f"train_step[{i}].engine_train_step elapsed={time.perf_counter() - train_step_begin:.4f}s"
+                f"train_step[{step_idx}].engine_train_step elapsed={time.perf_counter() - train_step_begin:.4f}s"
             )
             mtp_grad_metrics: dict[str, float] = {}
             if self._mtp_trainable_parameters:
@@ -881,9 +889,10 @@ class TrainingWorker(SingleAcceleratorWorker):
                 for key, value in train_log_item.items()
                 if not key.startswith("reduced_train_policy_") and key != "max_ratio"
             )
-            log_str = f"Rank{self.rank} Rollout {rollout_idx} Step {i}: " + log_str
+            log_str = f"Rank{self.rank} Rollout {rollout_idx} Step {step_idx}: " + log_str
             self.logger.info(log_str)
             self._global_train_step = global_train_step
+            start_idx = end_idx
 
         self._rollout_step += 1
         if self._sft_dataloader is not None and self._rollout_step % self._rollout_steps_per_sft == 0:
@@ -1018,9 +1027,18 @@ class TrainingWorker(SingleAcceleratorWorker):
         return self._engine.data_replicate_size * self.sp_mesh.size()
 
     @ray_method
+    def get_dp_rank(self) -> int:
+        """Get the data parallel rank for this worker."""
+        return self.data_mesh["dp"].get_rank()
+
+    @ray_method
     def get_model_cfg(self):
         model_cfg = self._engine.model_cfg
         return model_cfg
+
+    @ray_method
+    def get_worker_cfg(self) -> WorkerConfig:
+        return self.config
 
     def _clear_cublas_workspaces(self) -> None:
         clear_fn = getattr(torch._C, "_cuda_clearCublasWorkspaces", None)

--- a/xtuner/v1/train/rl_trainer.py
+++ b/xtuner/v1/train/rl_trainer.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import os
-import random
 import re
 import time
 from dataclasses import asdict, dataclass
@@ -42,8 +41,8 @@ from xtuner.v1.rl.replay_buffer import (
 from xtuner.v1.rl.rollout.controller import RolloutControllerProxy
 from xtuner.v1.rl.rollout.worker import RolloutConfig
 from xtuner.v1.rl.trace import TraceConfig, close_trace, configure_trace
-from xtuner.v1.rl.trainer.controller import TrainingController
-from xtuner.v1.rl.trainer.worker import WorkerConfig, WorkerLogItem
+from xtuner.v1.rl.trainer.controller import TrainingController, TrainingLogInfo
+from xtuner.v1.rl.trainer.worker import WorkerConfig, WorkerInputItem, WorkerLogItem
 from xtuner.v1.rl.utils import (
     AcceleratorResourcesConfig,
     AutoAcceleratorWorkers,
@@ -980,11 +979,15 @@ class BaseRLTrainer:
         self.logger.info(f"Prepared {len(data_batches)} training data batches")
 
         with timer("training", step_timer_dict):
-            workers_log_item: list[WorkerLogItem] = self.train_controller.fit(
+            training_log_info: TrainingLogInfo = self.train_controller.fit(
                 data_batches,
                 pack_max_length=self._train_worker_cfg.pack_max_length,
                 rollout_idx=train_step,
             )
+        workers_log_item = training_log_info["worker_log_infos"]
+        step_timer_dict["pack_time"] = training_log_info["pack_time"]
+        step_timer_dict["train_time"] = training_log_info["train_time"]
+        data_info["padding_tokens"] = training_log_info["padding_tokens"]
 
         self._release_trace_sessions_after_train_batch(train_batch)
 
@@ -1166,10 +1169,10 @@ class BaseRLTrainer:
                     multi_info_cast = cast(dict | None, multimodal_train_info)
                     seq_ctx = get_train_seq_ctx(input_ids_t, position_ids, multi_info_cast)
 
-                    data_dict = {
+                    data_dict: WorkerInputItem = {
                         "seq_ctx": seq_ctx,
                         "shifted_labels": shifted_labels_t,
-                        "advantage": actual_advantages,
+                        "advantages": torch.tensor(actual_advantages, dtype=torch.float32),
                         "rollout_logprobs": rollout_logprobs,
                     }
 
@@ -1246,19 +1249,16 @@ class BaseRLTrainer:
                 multi_info_cast = cast(dict | None, multimodal_train_info)
                 seq_ctx = get_train_seq_ctx(input_ids_t, position_ids, multi_info_cast, len(response_ids) - 1)  # type: ignore[arg-type]
 
-                data_dict = {
+                data_dict: WorkerInputItem = {
                     "seq_ctx": seq_ctx,
                     "shifted_labels": shifted_labels_t,
-                    "advantage": actual_advantages,
+                    "advantages": torch.tensor(actual_advantages[:-1], dtype=torch.float32),
                     "rollout_logprobs": rollout_logprobs,
                 }
 
                 seq_ctx.rollout_routed_experts = group[i].routed_experts  # n,layer*expert
 
                 data_batches.append(data_dict)
-        if not XTUNER_DETERMINISTIC:
-            random.shuffle(data_batches)
-
         # rewards/* report the per-session reward distribution; batch_size/training_samples below
         # still use rewards_list (per-segment) so counts reflect the actual training samples.
         rewards_t = torch.tensor(cluster_rewards_list).float() if cluster_rewards_list else torch.tensor([0.0]).float()


### PR DESCRIPTION
## 概述
本 PR 为 RL 训练引入了可配置的数据 Pack 能力，并将 Pack 规划与实际 Tensor 拼接进行了解耦。`RLDataPacker` 现在只生成如下结构的索引规划：[dp_rank][optimizer_step][pack][sample_index]。实际的**数据获取、Tensor 拼接和 Padding 操作**由各个 TrainingWorker 在本地完成。

## 主要改动
- 新增 RLDataPacker，支持三种 Pack 策略：
    - greedy
    - balance
    - native
- RLDataPacker 只负责：
    - 根据样本长度生成 Pack 索引
    - 将样本分配到不同 DP Rank
    - 按 Optimizer Step 对 Pack 进行划分
    - 统计 Padding Token 数量
- 将实际 Pack 逻辑移动到 TrainingWorker：
    - 根据索引获取原始样本
    - 执行 SequenceContext.cat
    - 拼接 Labels、Advantages 和 Rollout Logprobs
    - 创建 Padding Tensor
    - 补齐 VLM Position IDs
    - 补齐 Routed Experts 数据
- 原始训练 Batch 只写入 Ray Object Store 一次，并通过嵌套的 ObjectRef 共享给各个 Training Worker。
- TrainingController.fit 新增以下统计信息：
    - Pack 耗时
    - 训练耗时
    - Padding Token 数量

## 数据流程

BaseRLTrainer
  │
  ├─ 生成 WorkerInputItem 列表
  │
  ▼
TrainingController
  ├─ 提取样本长度
  ├─ 生成仅包含索引的 Pack Plan
  └─ 将原始 Batch 写入 Ray Object Store
  │
  ▼
TrainingWorker
  ├─ 获取原始 Batch
  ├─ 根据分配到的索引选择样本
  ├─ 执行实际 Pack 和 Padding
  └─ 按规划执行 Optimizer Step