### PR TITLE
[Feature] Add SonicMoE support

### DIFF
--- a/docs/design/model/sonicmoe.md
+++ b/docs/design/model/sonicmoe.md
@@ -1,0 +1,68 @@
+# SonicMoE integration design
+
+## Layering
+
+The integration follows XTuner's model/module/ops split:
+
+- `xtuner/v1/model/moe`: declares the model-level backend choice, validates combinations with EP/FP8/router options,
+  and selects compile targets. It must not import the optional `sonicmoe` package directly.
+- `xtuner/v1/module/moe_backend`: implements the routed-expert execution strategy. It owns configuration, input
+  validation, weight-layout views, routing-mode selection, and composition with `MoEBlock`.
+- `xtuner/v1/ops/moe`: owns tensor algorithms and third-party kernel boundaries. It contains Token Rounding metadata
+  construction and the optional official SonicMoE functional call.
+
+SonicMoE does not own parameters. XTuner continues to own `gate.weight`, `fused_w1w3`, and `fused_w2`, preserving
+optimizer, FSDP, state-dict, and HuggingFace checkpoint behavior.
+
+Install the optional dependency with `pip install -e '.[sonicmoe]'` and select the backend on any `MoEConfig`:
+
+```python
+config = Qwen3MoE30BA3Config(expert_backend="sonicmoe")
+```
+
+## Token Rounding
+
+Token Rounding is explicitly enabled with:
+
+```python
+config = Qwen3MoE30BA3Config(
+    expert_backend="sonicmoe",
+    sonicmoe_cfg=SonicMoEBackendConfig(
+        routing_mode="token_rounding",
+        rounding_mode="nearest",  # nearest | up | down
+        rounding_quantum=128,
+    ),
+)
+```
+
+The implementation follows the official SonicMoE benchmark algorithm:
+
+1. Obtain full softmax router probabilities and original token-choice top-k expert ids.
+2. Count original assignments per expert and round each count to a multiple of the configured quantum.
+3. Rank original assignments ahead of non-top-k candidates for every expert.
+4. For round-up, add the highest-scoring non-top-k candidates; for round-down, remove the lowest-priority original
+   assignments; nearest chooses the closest tile count.
+5. Sort the selected variable-length assignments by token id and pass them to `moe_general_routing_inputs`.
+6. Gather final scores from the full router probabilities so gradients still propagate to router logits. The discrete
+   selection priority is detached.
+
+The initial implementation permits Token Rounding only with a non-grouped softmax `GreedyRouterConfig`,
+`norm_topk_prob=True`, and `router_scaling_factor=1.0`, matching the official routing semantics.
+
+## torch.compile
+
+The default SonicMoE compile plan compiles the decoder's attention, router, shared-expert, and post-MoE computation
+with `MoEDecoderLayer.forward(fullgraph=False)`. The official SonicMoE functional call is a deliberate Dynamo graph
+boundary because it already owns optimized CUDA/CuTe kernels and a custom backward.
+
+This design provides a stable compiled training path without tracing through third-party Python internals or
+reimplementing the official backward. A future fullgraph integration should require an official stable
+`torch.library`/fake-tensor contract.
+
+## Current constraints
+
+- CUDA BF16 and SwiGLU only.
+- `ep_size=1` and `expert_tp_size=1`; no dispatcher, EP, or ExpertTP path yet.
+- No SonicMoE FP8 path.
+- General routing supports existing XTuner routers; Token Rounding has the stricter router constraints above.
+- Token Rounding changes routing semantics and remains opt-in.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,10 @@ rl = [
   "uvicorn",
   "mathruler",
   "pylatexenc",
-  "checkpoint-engine[p2p]"
+  "checkpoint-engine[p2p]",
+]
+sonicmoe = [
+  "sonic-moe>=0.1.2,<0.2",
 ]
 video = [
   "decord",
@@ -93,7 +96,8 @@ all = [
   "parametrize",
   "mathruler",
   "pylatexenc",
-  "flash-linear-attention==0.4.2"
+  "flash-linear-attention==0.4.2",
+  "sonic-moe>=0.1.2,<0.2",
 ]
 
 [tool.mypy]

--- a/tests/module/test_sonicmoe_backend.py
+++ b/tests/module/test_sonicmoe_backend.py
@@ -1,0 +1,677 @@
+import importlib.util
+import os
+import types
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from pydantic import ValidationError
+from torch import nn
+from torch.distributed.tensor import DTensor
+
+from xtuner._testing import DeterministicDDPTestCase
+from xtuner.v1.config import FSDPConfig
+from xtuner.v1.data_proto import SequenceContext
+from xtuner.v1.loss.ce_loss import CELossConfig
+from xtuner.v1.model.moe.moe import MoEConfig
+from xtuner.v1.model.moe.qwen3 import Qwen3MoE30BA3Config
+from xtuner.v1.module.attention import MHAConfig
+from xtuner.v1.module.decoder_layer.moe_decoder_layer import MoEDecoderLayer
+from xtuner.v1.module.moe_backend import SonicMoEBackend, SonicMoEBackendConfig
+from xtuner.v1.module.router.greedy import GreedyRouterConfig
+from xtuner.v1.module.router.noaux_router import NoAuxRouterConfig
+from xtuner.v1.ops.moe.sonicmoe import SonicMoEOp
+from xtuner.v1.ops.moe.token_rounding import build_token_rounding_metadata
+
+
+SONICMOE_AVAILABLE = importlib.util.find_spec("sonicmoe") is not None
+
+
+def _stub_sonicmoe_decoder_layer() -> MoEDecoderLayer:
+    layer = MoEDecoderLayer.__new__(MoEDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.experts = types.SimpleNamespace(uses_sonicmoe=True)  # type: ignore[assignment]
+
+    def pre_moe_forward(self, hidden_states, **_):
+        marker = int(hidden_states.flatten()[0])
+        router_results = {
+            "logits": torch.full((1, 2), marker, dtype=torch.float32),
+            "router_weights": torch.full((1, 2), marker + 1, dtype=torch.float32),
+            "topk_ids": torch.full((1, 1), marker + 2, dtype=torch.int64),
+        }
+        return hidden_states + 10, hidden_states + 20, router_results
+
+    def sonicmoe_forward(self, hidden_states, residual, router_results):
+        del router_results
+        return hidden_states + residual
+
+    layer._pre_moe_forward = types.MethodType(pre_moe_forward, layer)  # type: ignore[method-assign]
+    layer._sonicmoe_forward = types.MethodType(sonicmoe_forward, layer)  # type: ignore[method-assign]
+    return layer
+
+
+def test_sonicmoe_decoder_preserves_router_result_contract():
+    layer = _stub_sonicmoe_decoder_layer()
+    hidden_states = [torch.tensor([[[1.0]]]), torch.tensor([[[2.0]]])]
+    position_embeddings = [(torch.empty(0), torch.empty(0))] * 2
+    seq_ctx = [object(), object()]
+
+    single_output = layer._forward(
+        hidden_states[0],
+        seq_ctx=seq_ctx[0],  # type: ignore[arg-type]
+        position_embeddings=position_embeddings[0],
+    )
+    assert len(single_output) == 4
+    torch.testing.assert_close(single_output[3], torch.tensor([[3]], dtype=torch.int64))
+
+    micro_batch_output = layer._sonicmoe_micro_batch_forward(
+        hidden_states,
+        seq_ctx_list=seq_ctx,  # type: ignore[arg-type]
+        position_embeddings_list=position_embeddings,
+    )
+    assert len(micro_batch_output) == 8
+    torch.testing.assert_close(micro_batch_output[6], torch.tensor([[3]], dtype=torch.int64))
+    torch.testing.assert_close(micro_batch_output[7], torch.tensor([[4]], dtype=torch.int64))
+
+
+def _mock_backend(monkeypatch: pytest.MonkeyPatch, captured: dict | None = None) -> SonicMoEBackend:
+    activation = object()
+
+    def fake_forward(*args, **kwargs):
+        if captured is not None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            captured["activation"] = activation
+        x, router_scores, _, expert_indices, w1, b1, w2, b2, num_experts, *_ = args
+        zero = router_scores.sum().to(x.dtype) + w1.sum() + w2.sum()
+        if b1 is not None and b2 is not None:
+            zero = zero + b1.sum() + b2.sum()
+        output = x + zero * 0
+        frequency = expert_indices.long().bincount(minlength=num_experts).to(torch.int32)
+        return output, frequency
+
+    monkeypatch.setattr(
+        SonicMoEOp,
+        "_resolve_official_api",
+        staticmethod(lambda: (fake_forward, activation)),
+    )
+    return SonicMoEBackend(SonicMoEBackendConfig())
+
+
+def _reference_moe(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    w1w3: torch.Tensor,
+    w2: torch.Tensor,
+    b1w3: torch.Tensor | None,
+    b2: torch.Tensor | None,
+) -> torch.Tensor:
+    output = torch.zeros_like(hidden_states)
+    for expert_idx in range(w1w3.shape[0]):
+        token_idx, topk_slot = torch.where(topk_ids == expert_idx)
+        if token_idx.numel() == 0:
+            continue
+        gate, up = F.linear(
+            hidden_states[token_idx],
+            w1w3[expert_idx],
+            None if b1w3 is None else b1w3[expert_idx],
+        ).chunk(2, dim=-1)
+        expert_output = F.linear(
+            F.silu(gate) * up,
+            w2[expert_idx],
+            None if b2 is None else b2[expert_idx],
+        )
+        expert_output = expert_output * topk_weights[token_idx, topk_slot, None]
+        output = output.index_add(0, token_idx, expert_output.to(output.dtype))
+    return output
+
+
+def _reference_general_routing_moe(
+    hidden_states: torch.Tensor,
+    router_scores: torch.Tensor,
+    token_indices: torch.Tensor,
+    expert_indices: torch.Tensor,
+    w1w3: torch.Tensor,
+    w2: torch.Tensor,
+) -> torch.Tensor:
+    output = torch.zeros_like(hidden_states)
+    for expert_idx in range(w1w3.shape[0]):
+        positions = expert_indices == expert_idx
+        selected_tokens = token_indices[positions].long()
+        if selected_tokens.numel() == 0:
+            continue
+        gate, up = F.linear(hidden_states[selected_tokens], w1w3[expert_idx]).chunk(2, dim=-1)
+        expert_output = F.linear(F.silu(gate) * up, w2[expert_idx])
+        output = output.index_add(
+            0,
+            selected_tokens,
+            expert_output * router_scores[positions, None].to(expert_output.dtype),
+        )
+    return output
+
+
+class _SonicMoECompileWrapper(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.num_experts = 4
+        self.top_k = 2
+        self.backend = SonicMoEBackend(
+            SonicMoEBackendConfig(
+                routing_mode="token_rounding",
+                rounding_mode="nearest",
+                rounding_quantum=8,
+            )
+        )
+        self.w1w3 = nn.Parameter(torch.randn(4, 256, 256, dtype=torch.bfloat16) * 0.02)
+        self.w2 = nn.Parameter(torch.randn(4, 256, 128, dtype=torch.bfloat16) * 0.02)
+
+    def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
+        router_weights = router_logits.softmax(dim=-1, dtype=torch.float32)
+        topk_weights, topk_ids = router_weights.topk(self.top_k, dim=-1)
+        output, _ = self.backend(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            router_weights=router_weights,
+            fused_w1w3=self.w1w3,
+            fused_w2=self.w2,
+            training=True,
+        )
+        return output
+
+
+def test_sonicmoe_config_rejects_unsupported_options():
+    valid = Qwen3MoE30BA3Config(expert_backend="sonicmoe")
+    assert valid.ep_size == 1
+    assert valid.dispatcher is None
+    assert valid.compile_cfg is None
+
+    with pytest.raises(ValidationError, match="ep_size=1"):
+        Qwen3MoE30BA3Config(expert_backend="sonicmoe", ep_size=2, compile_cfg=False)
+    with pytest.raises(ValidationError, match="expert_tp_size=1"):
+        Qwen3MoE30BA3Config(expert_backend="sonicmoe", expert_tp_size=2, compile_cfg=False)
+    with pytest.raises(ValidationError, match="dispatcher must be None"):
+        Qwen3MoE30BA3Config(expert_backend="sonicmoe", dispatcher="all2all", compile_cfg=False)
+
+    compiled = Qwen3MoE30BA3Config(expert_backend="sonicmoe", compile_cfg=True)
+    assert compiled.compile_cfg is True
+
+    token_rounding = SonicMoEBackendConfig(
+        routing_mode="token_rounding",
+        rounding_mode="nearest",
+        rounding_quantum=128,
+    )
+    rounded = Qwen3MoE30BA3Config(expert_backend="sonicmoe", sonicmoe_cfg=token_rounding)
+    assert rounded.sonicmoe_cfg == token_rounding
+
+    noaux = NoAuxRouterConfig(
+        scoring_func="sigmoid",
+        router_scaling_factor=1.0,
+        norm_topk_prob=True,
+        n_group=1,
+        topk_group=1,
+    )
+    with pytest.raises(ValidationError, match="GreedyRouterConfig"):
+        Qwen3MoE30BA3Config(
+            expert_backend="sonicmoe",
+            sonicmoe_cfg=token_rounding,
+            router=noaux,
+        )
+
+    with pytest.raises(ValidationError, match="norm_topk_prob=True"):
+        Qwen3MoE30BA3Config(
+            expert_backend="sonicmoe",
+            sonicmoe_cfg=token_rounding,
+            router=GreedyRouterConfig(
+                scoring_func="softmax",
+                norm_topk_prob=False,
+                router_scaling_factor=1.0,
+            ),
+        )
+
+
+def test_sonicmoe_rejects_cpu_input(monkeypatch: pytest.MonkeyPatch):
+    backend = _mock_backend(monkeypatch)
+    with pytest.raises(RuntimeError, match="CUDA-only"):
+        backend(
+            hidden_states=torch.empty(2, 16, dtype=torch.bfloat16),
+            topk_ids=torch.zeros(2, 1, dtype=torch.int64),
+            topk_weights=torch.ones(2, 1, dtype=torch.float32),
+            fused_w1w3=torch.empty(2, 32, 16, dtype=torch.bfloat16),
+            fused_w2=torch.empty(2, 16, 16, dtype=torch.bfloat16),
+        )
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="SonicMoE requires CUDA")
+def test_sonicmoe_official_call_contract(monkeypatch: pytest.MonkeyPatch):
+    captured: dict = {}
+    backend = _mock_backend(monkeypatch, captured)
+    num_tokens, hidden_size = 5, 32
+    num_experts, topk, intermediate_size = 4, 2, 16
+    hidden_states = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+    topk_ids = torch.tensor([[3, 1], [0, 2], [1, 3], [2, 0], [0, 1]], device="cuda")
+    topk_weights = torch.rand(num_tokens, topk, device="cuda", dtype=torch.bfloat16)
+    w1w3 = torch.randn(
+        num_experts,
+        2 * intermediate_size,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    w2 = torch.randn(
+        num_experts,
+        hidden_size,
+        intermediate_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    b1w3 = torch.randn(num_experts, 2 * intermediate_size, device="cuda", dtype=torch.bfloat16)
+    b2 = torch.randn(num_experts, hidden_size, device="cuda", dtype=torch.bfloat16)
+
+    output, frequency = backend(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        fused_w1w3=w1w3,
+        fused_w2=w2,
+        fused_w1w3_bias=b1w3,
+        fused_w2_bias=b2,
+        training=False,
+    )
+
+    args = captured["args"]
+    assert args[0] is hidden_states
+    torch.testing.assert_close(
+        args[1],
+        topk_weights.float().reshape(-1),
+    )
+    torch.testing.assert_close(
+        args[2],
+        torch.arange(num_tokens, device="cuda", dtype=torch.int32).repeat_interleave(topk),
+    )
+    torch.testing.assert_close(args[3], topk_ids.to(torch.int32).reshape(-1))
+    assert args[4].shape == (2 * intermediate_size, hidden_size, num_experts)
+    assert args[4].stride() == (hidden_size, 1, 2 * intermediate_size * hidden_size)
+    assert args[5] is b1w3
+    assert args[6].shape == (hidden_size, intermediate_size, num_experts)
+    assert args[6].stride() == (intermediate_size, 1, hidden_size * intermediate_size)
+    assert args[7] is b2
+    assert args[8] == num_experts
+    assert args[9] is None
+    assert args[10] is captured["activation"]
+    assert args[11] is True
+    assert captured["kwargs"] == {"concat_layout": True}
+    torch.testing.assert_close(output, hidden_states)
+    torch.testing.assert_close(frequency, topk_ids.reshape(-1).bincount(minlength=num_experts).to(torch.int32))
+
+
+class TestTokenRounding:
+    @pytest.mark.parametrize("rounding_mode", ["nearest", "up", "down"])
+    def test_metadata_matches_official_algorithm(self, rounding_mode: str):
+        torch.manual_seed(7)
+        num_tokens, num_experts, top_k, quantum = 17, 5, 2, 4
+        router_weights = torch.randn(num_tokens, num_experts, dtype=torch.float32).softmax(dim=-1)
+        topk_values, topk_ids = router_weights.topk(top_k, dim=-1)
+
+        actual = build_token_rounding_metadata(
+            router_weights,
+            topk_ids,
+            num_experts=num_experts,
+            rounding_quantum=quantum,
+            rounding_mode=rounding_mode,  # type: ignore[arg-type]
+        )
+
+        expert_frequency = torch.bincount(topk_ids.reshape(-1), minlength=num_experts).to(torch.int32)
+        if rounding_mode == "up":
+            rounded_frequency = torch.ceil(expert_frequency / quantum).to(torch.int32) * quantum
+        elif rounding_mode == "down":
+            rounded_frequency = expert_frequency // quantum * quantum
+        else:
+            rounded_frequency = torch.round(expert_frequency / quantum).to(torch.int32) * quantum
+        rounded_frequency = rounded_frequency.clamp(max=num_tokens)
+
+        topk_priority = topk_values / topk_values.sum(dim=-1, keepdim=True)
+        combined_priority = router_weights.scatter(1, topk_ids, topk_priority).detach() - 1
+        combined_priority.scatter_(1, topk_ids, topk_priority)
+        ranked_tokens = combined_priority.argsort(dim=0, descending=True).to(torch.int32)
+        mask = torch.arange(num_tokens, dtype=torch.int32)[:, None] < rounded_frequency[None, :]
+        expected_tokens = ranked_tokens[mask]
+        expected_experts = torch.arange(num_experts, dtype=torch.int32)[None, :].expand(num_tokens, -1)[mask]
+        order = expected_tokens.argsort()
+        expected_tokens = expected_tokens[order]
+        expected_experts = expected_experts[order]
+        expected_scores = router_weights[expected_tokens.long(), expected_experts.long()].float().contiguous()
+
+        actual_scores, actual_tokens, actual_experts = actual
+        torch.testing.assert_close(actual_tokens, expected_tokens)
+        torch.testing.assert_close(actual_experts, expected_experts)
+        torch.testing.assert_close(actual_scores, expected_scores)
+        torch.testing.assert_close(
+            actual_experts.long().bincount(minlength=num_experts).to(torch.int32),
+            rounded_frequency,
+        )
+        assert torch.all(actual_tokens[:-1] <= actual_tokens[1:])
+
+    def test_rounding_scores_keep_router_gradient(self):
+        logits = torch.randn(12, 4, dtype=torch.float32, requires_grad=True)
+        router_weights = logits.softmax(dim=-1)
+        topk_ids = router_weights.topk(2, dim=-1).indices
+        router_scores, _, _ = build_token_rounding_metadata(
+            router_weights,
+            topk_ids,
+            num_experts=4,
+            rounding_quantum=4,
+            rounding_mode="up",
+        )
+        router_scores.sum().backward()
+        assert logits.grad is not None
+        assert torch.isfinite(logits.grad).all()
+        assert torch.count_nonzero(logits.grad) > 0
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="SonicMoE requires CUDA")
+    @pytest.mark.skipif(not SONICMOE_AVAILABLE, reason="official sonic-moe package is not installed")
+    def test_compiled_wrapper_matches_eager(self):
+        torch.manual_seed(11)
+        module = _SonicMoECompileWrapper().cuda().train()
+        hidden_states = torch.randn(32, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        router_logits = torch.randn(32, 4, device="cuda", dtype=torch.float32, requires_grad=True)
+        grad_output = torch.randn_like(hidden_states)
+
+        eager_output = module(hidden_states, router_logits)
+        eager_output.backward(grad_output)
+        eager_hidden_grad = hidden_states.grad.detach().clone()
+        eager_router_grad = router_logits.grad.detach().clone()
+        eager_parameter_grads = []
+        for parameter in module.parameters():
+            assert parameter.grad is not None
+            eager_parameter_grads.append(parameter.grad.detach().clone())
+
+        module.zero_grad(set_to_none=True)
+        compiled_hidden = hidden_states.detach().clone().requires_grad_()
+        compiled_router = router_logits.detach().clone().requires_grad_()
+        compiled_module = torch.compile(module, fullgraph=False)
+        compiled_output = compiled_module(compiled_hidden, compiled_router)
+        compiled_output.backward(grad_output)
+
+        torch.testing.assert_close(compiled_output, eager_output, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(compiled_hidden.grad, eager_hidden_grad, rtol=3e-2, atol=3e-2)
+        torch.testing.assert_close(compiled_router.grad, eager_router_grad, rtol=1e-4, atol=1e-5)
+        for parameter, eager_grad in zip(module.parameters(), eager_parameter_grads):
+            assert parameter.grad is not None
+            torch.testing.assert_close(parameter.grad, eager_grad, rtol=3e-2, atol=3e-2)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="SonicMoE requires CUDA")
+    @pytest.mark.skipif(not SONICMOE_AVAILABLE, reason="official sonic-moe package is not installed")
+    def test_official_forward_backward_matches_rounded_reference(self):
+        torch.manual_seed(23)
+        num_tokens, hidden_size = 32, 256
+        num_experts, top_k, intermediate_size = 4, 2, 128
+        hidden_states = (
+            torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16) * 0.1
+        ).requires_grad_()
+        router_logits = torch.randn(num_tokens, num_experts, device="cuda", dtype=torch.float32, requires_grad=True)
+        router_weights = router_logits.softmax(dim=-1)
+        topk_weights, topk_ids = router_weights.topk(top_k, dim=-1)
+        w1w3 = (
+            torch.randn(num_experts, 2 * intermediate_size, hidden_size, device="cuda", dtype=torch.bfloat16) * 0.02
+        ).requires_grad_()
+        w2 = (
+            torch.randn(num_experts, hidden_size, intermediate_size, device="cuda", dtype=torch.bfloat16) * 0.02
+        ).requires_grad_()
+
+        ref_hidden = hidden_states.detach().clone().requires_grad_()
+        ref_logits = router_logits.detach().clone().requires_grad_()
+        ref_w1w3 = w1w3.detach().clone().requires_grad_()
+        ref_w2 = w2.detach().clone().requires_grad_()
+
+        backend = SonicMoEBackend(
+            SonicMoEBackendConfig(
+                routing_mode="token_rounding",
+                rounding_mode="nearest",
+                rounding_quantum=8,
+            )
+        )
+        output, expert_frequency = backend(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            router_weights=router_weights,
+            fused_w1w3=w1w3,
+            fused_w2=w2,
+            training=True,
+        )
+
+        ref_router_weights = ref_logits.softmax(dim=-1)
+        ref_scores, ref_tokens, ref_experts = build_token_rounding_metadata(
+            ref_router_weights,
+            topk_ids,
+            num_experts=num_experts,
+            rounding_quantum=8,
+            rounding_mode="nearest",
+        )
+        reference = _reference_general_routing_moe(
+            ref_hidden,
+            ref_scores,
+            ref_tokens,
+            ref_experts,
+            ref_w1w3,
+            ref_w2,
+        )
+
+        grad_output = torch.randn_like(output)
+        output.backward(grad_output)
+        reference.backward(grad_output)
+
+        torch.testing.assert_close(output, reference, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(
+            expert_frequency,
+            ref_experts.long().bincount(minlength=num_experts).to(torch.int32),
+        )
+        for actual, expected in (
+            (hidden_states, ref_hidden),
+            (router_logits, ref_logits),
+            (w1w3, ref_w1w3),
+            (w2, ref_w2),
+        ):
+            assert actual.grad is not None and expected.grad is not None
+            torch.testing.assert_close(actual.grad, expected.grad, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="SonicMoE requires CUDA")
+def test_sonicmoe_empty_tokens_keep_parameters_in_autograd(monkeypatch: pytest.MonkeyPatch):
+    backend = _mock_backend(monkeypatch)
+    hidden_states = torch.empty(0, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    topk_ids = torch.empty(0, 2, device="cuda", dtype=torch.int64)
+    topk_weights = torch.empty(0, 2, device="cuda", dtype=torch.float32, requires_grad=True)
+    w1w3 = torch.randn(4, 32, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    w2 = torch.randn(4, 32, 16, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+
+    output, frequency = backend(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        fused_w1w3=w1w3,
+        fused_w2=w2,
+    )
+    output.sum().backward()
+
+    assert output.shape == hidden_states.shape
+    torch.testing.assert_close(frequency, torch.zeros(4, device="cuda", dtype=torch.int32))
+    for tensor in (hidden_states, topk_weights, w1w3, w2):
+        assert tensor.grad is not None
+        assert torch.count_nonzero(tensor.grad) == 0
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("use_bias", [False, True])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="SonicMoE requires CUDA")
+@pytest.mark.skipif(not SONICMOE_AVAILABLE, reason="official sonic-moe package is not installed")
+def test_official_sonicmoe_forward_backward_parity(use_bias: bool):
+    torch.manual_seed(42)
+    num_tokens, hidden_size = 32, 256
+    num_experts, topk, intermediate_size = 4, 2, 128
+
+    hidden_states = (torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16) * 0.1).requires_grad_()
+    topk_ids = torch.randint(0, num_experts, (num_tokens, topk), device="cuda")
+    topk_weights = torch.rand(num_tokens, topk, device="cuda", dtype=torch.float32).softmax(dim=-1)
+    topk_weights.requires_grad_()
+    w1w3 = (
+        torch.randn(num_experts, 2 * intermediate_size, hidden_size, device="cuda", dtype=torch.bfloat16) * 0.02
+    ).requires_grad_()
+    w2 = (
+        torch.randn(num_experts, hidden_size, intermediate_size, device="cuda", dtype=torch.bfloat16) * 0.02
+    ).requires_grad_()
+    b1w3 = (
+        torch.randn(num_experts, 2 * intermediate_size, device="cuda", dtype=torch.bfloat16).requires_grad_()
+        if use_bias
+        else None
+    )
+    b2 = (
+        torch.randn(num_experts, hidden_size, device="cuda", dtype=torch.bfloat16).requires_grad_()
+        if use_bias
+        else None
+    )
+
+    inputs = [hidden_states, topk_weights, w1w3, w2]
+    if use_bias:
+        inputs.extend([b1w3, b2])
+    reference_inputs = [tensor.detach().clone().requires_grad_() for tensor in inputs]
+
+    backend = SonicMoEBackend(SonicMoEBackendConfig())
+    output, expert_frequency = backend(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        fused_w1w3=w1w3,
+        fused_w2=w2,
+        fused_w1w3_bias=b1w3,
+        fused_w2_bias=b2,
+        training=True,
+    )
+
+    ref_hidden, ref_topk_weights, ref_w1w3, ref_w2, *ref_biases = reference_inputs
+    ref_b1w3, ref_b2 = ref_biases if use_bias else (None, None)
+    reference = _reference_moe(
+        ref_hidden,
+        topk_ids,
+        ref_topk_weights,
+        ref_w1w3,
+        ref_w2,
+        ref_b1w3,
+        ref_b2,
+    )
+
+    grad = torch.randn_like(output)
+    output.backward(grad)
+    reference.backward(grad)
+
+    torch.testing.assert_close(output, reference, rtol=2e-2, atol=2e-2)
+    assert expert_frequency.shape == (num_experts,)
+    assert int(expert_frequency.sum()) == num_tokens * topk
+    for actual, expected in zip(inputs, reference_inputs):
+        assert actual is not None and expected is not None
+        assert actual.grad is not None and expected.grad is not None
+        # The official grouped kernel and the per-expert reference accumulate
+        # BF16 gradients in a different order. Keep FP32 routing gradients at
+        # the tighter tolerance while allowing one additional BF16 rounding
+        # interval for activations and expert parameters.
+        atol = 6e-2 if actual.grad.dtype == torch.bfloat16 else 3e-2
+        torch.testing.assert_close(actual.grad, expected.grad, rtol=3e-2, atol=atol)
+
+
+def _tiny_sonicmoe_config() -> MoEConfig:
+    return MoEConfig(
+        vocab_size=256,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        eos_token_id=0,
+        num_hidden_layers=1,
+        hidden_size=256,
+        intermediate_size=512,
+        rms_norm_eps=1e-6,
+        rope_theta=1e6,
+        hidden_act="silu",
+        attention=MHAConfig(
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=128,
+        ),
+        tie_word_embeddings=False,
+        n_routed_experts=8,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        first_k_dense_replace=0,
+        hidden_factor=1.0,
+        moe_intermediate_size=128,
+        router=GreedyRouterConfig(
+            scoring_func="softmax",
+            norm_topk_prob=True,
+            router_scaling_factor=1.0,
+        ),
+        expert_backend="sonicmoe",
+        ep_size=1,
+        dispatcher=None,
+        compile_cfg=False,
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="SonicMoE requires CUDA")
+@pytest.mark.skipif(not SONICMOE_AVAILABLE, reason="official sonic-moe package is not installed")
+class TestSonicMoEEightGpuFSDP(DeterministicDDPTestCase):
+    @property
+    def world_size(self) -> int:
+        return int(os.getenv("XTUNER_TEST_WORLD_SIZE", "8"))
+
+    def test_model_forward_backward_and_optimizer_step(self):
+        self.create_pg("cuda")
+        config = _tiny_sonicmoe_config()
+        with torch.device("meta"):
+            model = config.build()
+
+        model.fully_shard(
+            FSDPConfig(
+                ep_size=1,
+                recompute_ratio=0.0,
+                torch_compile=False,
+            )
+        )
+        model.init_weights()
+        model.train()
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+        torch.manual_seed(2026 + self.rank)
+        input_ids = torch.randint(1, config.vocab_size, (1, 17), dtype=torch.int64, device="cuda")
+        seq_ctx = SequenceContext.from_input_ids(input_ids=(input_ids[:, :-1],), device="cuda")
+        loss_cfg = CELossConfig()
+        loss_ctx = loss_cfg.build(data={"shifted_labels": input_ids[:, 1:]}, sp_mesh=None)
+        assert loss_ctx is not None
+        loss_ctx = loss_cfg.loss_ctx_cls.build_batches([loss_ctx])[0]
+
+        output = model(seq_ctx=seq_ctx, loss_ctx={"lm": loss_ctx})
+        loss = output["loss"]
+        assert loss is not None and torch.isfinite(loss)
+        loss.backward()
+
+        expert_grad_count = 0
+        for name, parameter in model.named_parameters():
+            if ".experts.fused_" not in name:
+                continue
+            assert parameter.grad is not None, f"missing expert gradient for {name}"
+            grad = parameter.grad.to_local() if isinstance(parameter.grad, DTensor) else parameter.grad
+            assert torch.isfinite(grad).all(), f"non-finite expert gradient for {name}"
+            expert_grad_count += 1
+        assert expert_grad_count == 2
+
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+
+        passed = torch.tensor(1, device="cuda", dtype=torch.int32)
+        dist.all_reduce(passed, op=dist.ReduceOp.SUM)
+        assert int(passed) == self.world_size

--- a/tests/profiler/qwen35_sonicmoe_fsdp_benchmark.py
+++ b/tests/profiler/qwen35_sonicmoe_fsdp_benchmark.py
@@ -1,0 +1,1054 @@
+"""Qwen3.5 MoE FSDP benchmark for XTuner grouped GEMM vs SonicMoE.
+
+This is intentionally a standalone profiler rather than a pytest test: the
+default invocation builds the complete 40-layer, 35B-parameter text model and
+requires one 8-GPU node.
+
+The SonicMoE run uses general (dropless) routing and preserves every native
+top-k assignment. Token rounding is deliberately outside the scope of this
+benchmark and will be covered by a separate profiler.
+
+The two runs either load the same HuggingFace checkpoint or deterministically
+initialize the requested model shape, and reuse the exact same per-rank token
+batches. Each measured step performs forward and backward but does not update
+parameters. Keeping weights fixed makes every one of the 10 steps a direct
+numerical comparison of the two expert implementations. Every measured step is
+atomically persisted; accuracy covers all 10 steps while the performance
+comparison uses the 10th step only.
+
+Example:
+    XTUNER_DETERMINISTIC=true torchrun --nproc-per-node 8 \
+      tests/profiler/qwen35_sonicmoe_fsdp_benchmark.py \
+      --model-path /path/to/Qwen3.5-35B-A3B \
+      --output /path/to/qwen35_sonicmoe_fsdp_benchmark.json \
+      --steps 10 --warmup-steps 5 --deterministic
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+import torch.distributed as dist
+from mmengine.runner import set_random_seed
+
+from xtuner.v1.config import FSDPConfig
+from xtuner.v1.data_proto import SequenceContext
+from xtuner.v1.loss.ce_loss import CELossConfig
+from xtuner.v1.model.moe.qwen3_5_text import Qwen3_5_VLTextMoE35BA3BConfig
+from xtuner.v1.module.attention import GatedDeltaNet, GatedDeltaNetConfig, MHAConfig
+from xtuner.v1.module.moe_backend import SonicMoEBackendConfig
+from xtuner.v1.utils import default_init_weights, init_params, set_deterministic
+from xtuner.v1.utils.misc import clean_param_name, monkey_patch_hf_modules_cache
+
+
+Backend = Literal["grouped_gemm", "sonicmoe"]
+
+# Values from Qwen/Qwen3.5-35B-A3B config.json.  Failing early here prevents a
+# future config drift from silently turning this into a different benchmark.
+OFFICIAL_SHAPE = {
+    "vocab_size": 248320,
+    "num_hidden_layers": 40,
+    "hidden_size": 2048,
+    "n_routed_experts": 256,
+    "n_shared_experts": 1,
+    "num_experts_per_tok": 8,
+    "moe_intermediate_size": 512,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 2,
+    "attention_head_dim": 256,
+    "linear_num_key_heads": 16,
+    "linear_num_value_heads": 32,
+    "linear_key_head_dim": 128,
+    "linear_value_head_dim": 128,
+}
+
+
+def _rank() -> int:
+    return dist.get_rank() if dist.is_initialized() else 0
+
+
+def _print_rank0(message: str) -> None:
+    if _rank() == 0:
+        print(message, flush=True)
+
+
+def _atomic_write_json(output: Path, payload: dict[str, Any]) -> None:
+    """Write JSON atomically so readers never observe a partially written file."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_output = output.with_suffix(output.suffix + ".tmp")
+    with temporary_output.open("w", encoding="utf-8") as file:
+        json.dump(payload, file, ensure_ascii=False, indent=2)
+    os.replace(temporary_output, output)
+
+
+def _progress_path(output: str, backend: Backend, suffix: str) -> Path:
+    path = Path(output)
+    return path.with_name(f"{path.stem}.{backend}.{suffix}.json")
+
+
+def _init_distributed(deterministic: bool) -> tuple[int, int, int]:
+    if deterministic:
+        os.environ.setdefault("NCCL_ALGO", "Ring")
+        os.environ.setdefault("NCCL_PROTO", "Simple")
+        os.environ.setdefault("NCCL_NUM_CHANNELS", "1")
+        set_deterministic()
+
+    dist.init_process_group(backend="cpu:gloo,cuda:nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank % torch.cuda.device_count()))
+    torch.cuda.set_device(local_rank)
+    torch.accelerator.set_device_index(local_rank)
+
+    communication_warmup = torch.ones(4, device="cuda")
+    dist.all_reduce(communication_warmup)
+    return rank, world_size, local_rank
+
+
+def _requested_shape(args: argparse.Namespace) -> dict[str, int]:
+    return {
+        "vocab_size": args.vocab_size,
+        "num_hidden_layers": args.num_layers,
+        "hidden_size": args.hidden_size,
+        "n_routed_experts": args.num_routed_experts,
+        "n_shared_experts": args.num_shared_experts,
+        "num_experts_per_tok": args.top_k,
+        "moe_intermediate_size": args.expert_intermediate_size,
+        "num_attention_heads": args.num_attention_heads,
+        "num_key_value_heads": args.num_key_value_heads,
+        "attention_head_dim": args.attention_head_dim,
+        "linear_num_key_heads": args.linear_num_key_heads,
+        "linear_num_value_heads": args.linear_num_value_heads,
+        "linear_key_head_dim": args.linear_key_head_dim,
+        "linear_value_head_dim": args.linear_value_head_dim,
+    }
+
+
+def _validate_requested_shape(config: Qwen3_5_VLTextMoE35BA3BConfig, args: argparse.Namespace) -> None:
+    actual = {
+        "vocab_size": config.vocab_size,
+        "num_hidden_layers": config.num_hidden_layers,
+        "hidden_size": config.hidden_size,
+        "n_routed_experts": config.n_routed_experts,
+        "n_shared_experts": config.n_shared_experts,
+        "num_experts_per_tok": config.num_experts_per_tok,
+        "moe_intermediate_size": config.moe_intermediate_size,
+        "num_attention_heads": config.attention.num_attention_heads,
+        "num_key_value_heads": config.attention.num_key_value_heads,
+        "attention_head_dim": config.attention.head_dim,
+        "linear_num_key_heads": config.linear_attention.num_key_heads,
+        "linear_num_value_heads": config.linear_attention.num_value_heads,
+        "linear_key_head_dim": config.linear_attention.key_head_dim,
+        "linear_value_head_dim": config.linear_attention.value_head_dim,
+    }
+    expected = _requested_shape(args)
+    if actual != expected:
+        raise AssertionError(f"Qwen3.5 benchmark shape mismatch: expected={expected}, actual={actual}")
+
+    if config.layers_type != [
+        "linear_attention" if (idx + 1) % 4 else "full_attention" for idx in range(args.num_layers)
+    ]:
+        raise AssertionError(
+            "Qwen3.5 layer schedule must be 3 linear-attention layers followed by 1 full-attention layer"
+        )
+
+
+def _make_token_batches(
+    *,
+    rank: int,
+    count: int,
+    seq_len: int,
+    micro_batch_size: int,
+    vocab_size: int,
+    data_seed: int,
+) -> tuple[list[torch.Tensor], str]:
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(data_seed + rank * 1_000_003)
+    batches: list[torch.Tensor] = []
+    digest = hashlib.sha256()
+    for _ in range(count):
+        tokens = torch.randint(
+            0,
+            vocab_size,
+            (micro_batch_size, seq_len + 1),
+            generator=generator,
+            dtype=torch.long,
+        )
+        batches.append(tokens)
+        digest.update(tokens.numpy().tobytes())
+    return batches, digest.hexdigest()
+
+
+def _build_config(args: argparse.Namespace, backend: Backend) -> Qwen3_5_VLTextMoE35BA3BConfig:
+    config = Qwen3_5_VLTextMoE35BA3BConfig(
+        vocab_size=args.vocab_size,
+        num_hidden_layers=args.num_layers,
+        max_window_layers=args.num_layers,
+        hidden_size=args.hidden_size,
+        attention=MHAConfig(
+            with_gate=True,
+            num_attention_heads=args.num_attention_heads,
+            num_key_value_heads=args.num_key_value_heads,
+            head_dim=args.attention_head_dim,
+            qk_norm=True,
+            rms_norm_eps=1e-6,
+            rms_norm_type="zero_centered",
+            sliding_window=1024,
+        ),
+        linear_attention=GatedDeltaNetConfig(
+            num_value_heads=args.linear_num_value_heads,
+            num_key_heads=args.linear_num_key_heads,
+            key_head_dim=args.linear_key_head_dim,
+            value_head_dim=args.linear_value_head_dim,
+            conv_kernel_dim=4,
+            hidden_act="silu",
+            rms_norm_eps=1e-6,
+        ),
+        n_routed_experts=args.num_routed_experts,
+        n_shared_experts=args.num_shared_experts,
+        num_experts_per_tok=args.top_k,
+        moe_intermediate_size=args.expert_intermediate_size,
+        expert_backend=backend,
+        sonicmoe_cfg=SonicMoEBackendConfig(routing_mode=args.sonic_routing_mode),
+        lm_loss_cfg=CELossConfig(mode="chunk", chunk_size=args.loss_chunk_size),
+        compile_cfg=None if args.compile else False,
+    )
+    config.ep_size = 1
+    config.dispatcher = None
+    _validate_requested_shape(config, args)
+    return config
+
+
+@torch.no_grad()
+def _init_synthetic_weights(model: torch.nn.Module) -> None:
+    """Initialize all parameters, including GatedDeltaNet's custom tensors."""
+    initialized = default_init_weights(model)
+    for module_name, module in model.named_modules():
+        if not isinstance(module, GatedDeltaNet):
+            continue
+        init_params(module.dt_bias, torch.nn.init.ones_)
+        init_params(module.A_log, lambda tensor: tensor.uniform_(0.0, 16.0).log_())
+        initialized.add(clean_param_name(f"{module_name}.dt_bias"))
+        initialized.add(clean_param_name(f"{module_name}.A_log"))
+
+    parameter_names = {clean_param_name(name) for name, _ in model.named_parameters()}
+    if missing := parameter_names - initialized:
+        raise RuntimeError(f"Synthetic initialization did not cover parameters: {sorted(missing)}")
+
+
+def _build_model(args: argparse.Namespace, backend: Backend) -> tuple[torch.nn.Module, dict[str, Any]]:
+    config = _build_config(args, backend)
+
+    fsdp_config = FSDPConfig(
+        ep_size=1,
+        cpu_offload=False,
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.bfloat16,
+        recompute_ratio=args.recompute_ratio,
+        torch_compile=args.compile,
+    )
+
+    set_random_seed(args.model_seed, deterministic=args.deterministic)
+    with torch.device("meta"):
+        model = config.build()
+    global_parameter_count = sum(parameter.numel() for parameter in model.parameters())
+    estimated_active_parameter_count = round(
+        sum(
+            (
+                parameter.numel() * args.top_k / args.num_routed_experts
+                if ".experts." in clean_param_name(name)
+                else parameter.numel()
+            )
+            for name, parameter in model.named_parameters()
+        )
+    )
+
+    model = model.fully_shard(fsdp_config=fsdp_config)
+    set_random_seed(args.model_seed, deterministic=args.deterministic)
+    if args.synthetic_weights:
+        _init_synthetic_weights(model)
+        load_info = {
+            "weight_source": "deterministic_synthetic_initialization",
+            "model_seed": args.model_seed,
+            "global_parameter_count": global_parameter_count,
+            "estimated_active_parameter_count": estimated_active_parameter_count,
+            "loaded_key_count": 0,
+            "unloaded_key_count": 0,
+            "ignored_checkpoint_key_count": 0,
+        }
+    else:
+        loaded_keys, unloaded_keys, missing_keys = model.from_hf(args.model_path, strict=False)
+        if unloaded_keys:
+            examples = sorted(unloaded_keys)[:20]
+            raise RuntimeError(f"Checkpoint did not initialize {len(unloaded_keys)} XTuner parameters: {examples}")
+        load_info = {
+            "weight_source": "huggingface_checkpoint",
+            "global_parameter_count": global_parameter_count,
+            "estimated_active_parameter_count": estimated_active_parameter_count,
+            "loaded_key_count": len(loaded_keys),
+            "unloaded_key_count": len(unloaded_keys),
+            # Missing keys are checkpoint entries not consumed by the text-only
+            # model, chiefly the vision tower and projector.
+            "ignored_checkpoint_key_count": len(missing_keys),
+        }
+    model.train()
+    return model, load_info
+
+
+def _build_step_inputs(
+    model: torch.nn.Module,
+    token_batches: list[torch.Tensor],
+) -> list[tuple[SequenceContext, dict[str, Any]]]:
+    """Build and globally calibrate every micro-batch in one training step."""
+    raw_batches: list[dict[str, Any]] = []
+    for tokens in token_batches:
+        raw_batches.append(
+            {
+                "seq_ctx": SequenceContext.from_input_ids(input_ids=(tokens[:, :-1],), device="cpu"),
+                "shifted_labels": tokens[:, 1:],
+            }
+        )
+
+    loss_contexts = model.build_loss_ctx_batch(raw_batches, sp_mesh=None)
+    return [(raw["seq_ctx"].to("cuda"), loss_ctx) for raw, loss_ctx in zip(raw_batches, loss_contexts)]
+
+
+def _total_loss(outputs: Any) -> torch.Tensor:
+    loss = torch.zeros((), dtype=torch.float32, device="cuda")
+    for key in type(outputs).model_fields:
+        value = getattr(outputs, key)
+        if "loss" in key and isinstance(value, torch.Tensor):
+            loss = loss + value.float()
+    return loss
+
+
+def _local_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    if hasattr(tensor, "to_local"):
+        tensor = tensor.to_local()
+    return tensor
+
+
+def _find_probes(model: torch.nn.Module, num_layers: int) -> dict[str, torch.nn.Parameter]:
+    suffixes = (
+        "layers.0.gate.weight",
+        "layers.0.experts.fused_w1w3.weight",
+        "layers.0.experts.fused_w2.weight",
+        f"layers.{num_layers - 1}.experts.fused_w2.weight",
+    )
+    found: dict[str, torch.nn.Parameter] = {}
+    for name, parameter in model.named_parameters():
+        name = clean_param_name(name)
+        for suffix in suffixes:
+            if name.endswith(suffix):
+                found[suffix] = parameter
+    missing = sorted(set(suffixes) - set(found))
+    if missing:
+        raise RuntimeError(f"Could not resolve numerical probe parameters: {missing}")
+    return found
+
+
+@torch.no_grad()
+def _probe_tensors(probes: dict[str, torch.nn.Parameter], *, gradients: bool) -> dict[str, dict[str, float]]:
+    result: dict[str, dict[str, float]] = {}
+    for name, parameter in probes.items():
+        tensor = parameter.grad if gradients else parameter
+        if tensor is None:
+            raise RuntimeError(f"Probe {name} has no gradient")
+        local = _local_tensor(tensor).detach().float()
+        values = torch.stack(
+            (
+                local.sum(dtype=torch.float64),
+                torch.square(local.to(torch.float64)).sum(),
+                local.abs().max().to(torch.float64),
+            )
+        ).to("cuda")
+        dist.all_reduce(values[:2], op=dist.ReduceOp.SUM)
+        dist.all_reduce(values[2:], op=dist.ReduceOp.MAX)
+        result[name] = {
+            "sum": float(values[0].item()),
+            "l2": math.sqrt(max(float(values[1].item()), 0.0)),
+            "absmax": float(values[2].item()),
+        }
+    return result
+
+
+def _global_loss(value: torch.Tensor) -> float:
+    """Sum per-rank CE contributions already normalized by the global token count."""
+    reduced = value.detach().float().clone()
+    dist.all_reduce(reduced, op=dist.ReduceOp.SUM)
+    return float(reduced.item())
+
+
+def _global_max_milliseconds(milliseconds: float) -> float:
+    value = torch.tensor(milliseconds, dtype=torch.float64, device="cuda")
+    dist.all_reduce(value, op=dist.ReduceOp.MAX)
+    return float(value.item())
+
+
+def _one_step(
+    model: torch.nn.Module,
+    token_batches: list[torch.Tensor],
+    *,
+    timed: bool,
+) -> tuple[float, float]:
+    step_inputs = _build_step_inputs(model, token_batches)
+    model.zero_grad(set_to_none=True)
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    total_loss = torch.zeros((), dtype=torch.float32, device="cuda")
+    for seq_ctx, loss_ctx in step_inputs:
+        outputs = model(seq_ctx=seq_ctx, loss_ctx=loss_ctx)
+        if hasattr(outputs, "free_nongrad_feature"):
+            outputs.free_nongrad_feature()
+        loss = _total_loss(outputs)
+        loss.backward()
+        total_loss += loss.detach()
+    end.record()
+    end.synchronize()
+    elapsed_ms = _global_max_milliseconds(start.elapsed_time(end)) if timed else 0.0
+    global_loss = _global_loss(total_loss)
+    return global_loss, elapsed_ms
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    index = min(int(math.ceil(quantile * len(ordered))) - 1, len(ordered) - 1)
+    return ordered[max(index, 0)]
+
+
+def _resume_signature(args: argparse.Namespace, backend: Backend) -> dict[str, Any]:
+    """Fields that must match before persisted benchmark steps can be reused."""
+    return {
+        "backend": backend,
+        "model_shape": _requested_shape(args),
+        "synthetic_weights": args.synthetic_weights,
+        "model_path": args.model_path,
+        "model_seed": args.model_seed,
+        "data_seed": args.data_seed,
+        "sequence_length": args.seq_len,
+        "global_batch_size": args.global_batch_size,
+        "micro_batch_size": args.micro_batch_size,
+        "gradient_accumulation_steps": args.gradient_accumulation_steps,
+        "steps": args.steps,
+        "warmup_steps": args.warmup_steps,
+        "recompute_ratio": args.recompute_ratio,
+        "compile": args.compile,
+        "sonic_routing_mode": args.sonic_routing_mode,
+    }
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def _run_backend(
+    args: argparse.Namespace,
+    backend: Backend,
+    token_batches: list[torch.Tensor],
+    input_hashes: list[str],
+) -> dict[str, Any]:
+    result_path = _progress_path(args.output, backend, "result")
+    progress_path = _progress_path(args.output, backend, "progress")
+    signature = _resume_signature(args, backend)
+    if args.resume and result_path.exists():
+        completed = _load_json(result_path)
+        legacy_compatible = (
+            completed.get("backend") == backend
+            and completed.get("input_sha256_by_rank") == input_hashes
+            and len(completed.get("steps", ())) == args.steps
+            and len(completed.get("gradient_probes", ())) == args.steps
+        )
+        if (
+            completed.get("resume_signature") == signature and len(completed.get("steps", ())) == args.steps
+        ) or legacy_compatible:
+            _print_rank0(f"[{backend}] reusing completed result from {result_path}")
+            dist.barrier()
+            return completed
+
+    weight_source = "deterministic synthetic weights" if args.synthetic_weights else args.model_path
+    _print_rank0(f"[{backend}] building full FSDP model with {weight_source} ...")
+    load_started = time.perf_counter()
+    model, load_info = _build_model(args, backend)
+    probes = _find_probes(model, args.num_layers)
+    parameter_probes = _probe_tensors(probes, gradients=False)
+    dist.barrier()
+    load_seconds = time.perf_counter() - load_started
+
+    micro_batches_per_step = args.gradient_accumulation_steps
+    for warmup_step in range(args.warmup_steps):
+        begin = warmup_step * micro_batches_per_step
+        end = begin + micro_batches_per_step
+        _one_step(model, token_batches[begin:end], timed=False)
+        _print_rank0(f"[{backend}] warmup {warmup_step + 1}/{args.warmup_steps}")
+
+    model.zero_grad(set_to_none=True)
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    losses: list[float] = []
+    step_milliseconds: list[float] = []
+    gradient_probes: list[dict[str, dict[str, float]]] = []
+    step_records: list[dict[str, float | int]] = []
+    resumed_max_allocated_gib = 0.0
+    resumed_max_reserved_gib = 0.0
+
+    if args.resume and progress_path.exists():
+        progress = _load_json(progress_path)
+        compatible = (
+            progress.get("schema_version") == 2
+            and progress.get("resume_signature") == signature
+            and progress.get("input_sha256_by_rank") == input_hashes
+            and progress.get("parameter_probes") == parameter_probes
+            and len(progress.get("steps", ())) == len(progress.get("gradient_probes", ()))
+            and len(progress.get("steps", ())) <= args.steps
+        )
+        if compatible:
+            step_records = progress["steps"]
+            losses = [float(record["loss"]) for record in step_records]
+            step_milliseconds = [float(record["step_milliseconds"]) for record in step_records]
+            gradient_probes = progress["gradient_probes"]
+            resumed_max_allocated_gib = float(progress.get("max_memory_allocated_gib_so_far", 0.0))
+            resumed_max_reserved_gib = float(progress.get("max_memory_reserved_gib_so_far", 0.0))
+            _print_rank0(f"[{backend}] resumed {len(step_records)}/{args.steps} persisted steps")
+        else:
+            _print_rank0(f"[{backend}] ignoring incompatible legacy progress at {progress_path}")
+
+    for step in range(len(step_records), args.steps):
+        global_step = args.warmup_steps + step
+        begin = global_step * micro_batches_per_step
+        end = begin + micro_batches_per_step
+        loss, elapsed_ms = _one_step(model, token_batches[begin:end], timed=True)
+        losses.append(loss)
+        step_milliseconds.append(elapsed_ms)
+        gradient_probes.append(_probe_tensors(probes, gradients=True))
+        samples_per_second = args.global_batch_size * 1000.0 / elapsed_ms
+        tokens_per_second = args.global_batch_size * args.seq_len * 1000.0 / elapsed_ms
+        tokens_per_second_per_card = tokens_per_second / dist.get_world_size()
+        step_records.append(
+            {
+                "step": step + 1,
+                "loss": loss,
+                "step_milliseconds": elapsed_ms,
+                "global_samples_per_second": samples_per_second,
+                "global_tokens_per_second": tokens_per_second,
+                "tokens_per_second_per_card": tokens_per_second_per_card,
+            }
+        )
+        if step == 0 or (step + 1) % args.log_interval == 0 or step + 1 == args.steps:
+            _print_rank0(
+                f"[{backend}] step={step + 1}/{args.steps} loss={loss:.8f} "
+                f"time={elapsed_ms:.3f}ms "
+                f"samples/s={samples_per_second:.4f} "
+                f"global_tokens/s={tokens_per_second:.2f} "
+                f"tokens/s/card={tokens_per_second_per_card:.2f}"
+            )
+        current_peaks = torch.tensor(
+            (
+                torch.cuda.max_memory_allocated() / 2**30,
+                torch.cuda.max_memory_reserved() / 2**30,
+            ),
+            dtype=torch.float64,
+            device="cuda",
+        )
+        dist.all_reduce(current_peaks, op=dist.ReduceOp.MAX)
+        if _rank() == 0:
+            current_mean_ms = statistics.fmean(step_milliseconds)
+            current_max_allocated_gib = max(resumed_max_allocated_gib, float(current_peaks[0].item()))
+            current_max_reserved_gib = max(resumed_max_reserved_gib, float(current_peaks[1].item()))
+            _atomic_write_json(
+                progress_path,
+                {
+                    "schema_version": 2,
+                    "resume_signature": signature,
+                    "backend": backend,
+                    "routing_mode": args.sonic_routing_mode if backend == "sonicmoe" else "native_topk",
+                    "steps_completed": step + 1,
+                    "steps_total": args.steps,
+                    "latest_loss": loss,
+                    "mean_step_ms_so_far": current_mean_ms,
+                    "global_samples_per_second_so_far": args.global_batch_size * 1000.0 / current_mean_ms,
+                    "global_tokens_per_second_so_far": (
+                        args.global_batch_size * args.seq_len * 1000.0 / current_mean_ms
+                    ),
+                    "tokens_per_second_per_card_so_far": (
+                        args.global_batch_size * args.seq_len * 1000.0 / current_mean_ms / dist.get_world_size()
+                    ),
+                    "steps": step_records,
+                    "gradient_probes": gradient_probes,
+                    "input_sha256_by_rank": input_hashes,
+                    "parameter_probes": parameter_probes,
+                    "max_memory_allocated_gib_so_far": current_max_allocated_gib,
+                    "max_memory_reserved_gib_so_far": current_max_reserved_gib,
+                },
+            )
+
+    allocated = torch.tensor(torch.cuda.max_memory_allocated() / 2**30, dtype=torch.float64, device="cuda")
+    reserved = torch.tensor(torch.cuda.max_memory_reserved() / 2**30, dtype=torch.float64, device="cuda")
+    dist.all_reduce(allocated, op=dist.ReduceOp.MAX)
+    dist.all_reduce(reserved, op=dist.ReduceOp.MAX)
+
+    max_allocated_gib = max(resumed_max_allocated_gib, float(allocated.item()))
+    max_reserved_gib = max(resumed_max_reserved_gib, float(reserved.item()))
+    mean_ms = statistics.fmean(step_milliseconds)
+    result = {
+        "schema_version": 2,
+        "resume_signature": signature,
+        "backend": backend,
+        "routing_mode": args.sonic_routing_mode if backend == "sonicmoe" else "native_topk",
+        "load_seconds": load_seconds,
+        "load_info": load_info,
+        "input_sha256_by_rank": input_hashes,
+        "parameter_probes": parameter_probes,
+        "losses": losses,
+        "gradient_probes": gradient_probes,
+        "step_milliseconds": step_milliseconds,
+        "steps": step_records,
+        "last_step": step_records[-1],
+        "performance": {
+            "mean_step_ms": mean_ms,
+            "median_step_ms": statistics.median(step_milliseconds),
+            "p90_step_ms": _percentile(step_milliseconds, 0.90),
+            "global_samples_per_second": args.global_batch_size * 1000.0 / mean_ms,
+            "global_tokens_per_second": args.global_batch_size * args.seq_len * 1000.0 / mean_ms,
+            "tokens_per_second_per_card": (
+                args.global_batch_size * args.seq_len * 1000.0 / mean_ms / dist.get_world_size()
+            ),
+            "max_memory_allocated_gib": max_allocated_gib,
+            "max_memory_reserved_gib": max_reserved_gib,
+        },
+    }
+
+    if _rank() == 0:
+        _atomic_write_json(result_path, result)
+
+    del probes, model
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch._dynamo.reset()
+    dist.barrier()
+    return result
+
+
+def _relative_difference(lhs: float, rhs: float) -> float:
+    return abs(lhs - rhs) / max(abs(lhs), 1e-12)
+
+
+def _compare(native: dict[str, Any], sonic: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    if native["input_sha256_by_rank"] != sonic["input_sha256_by_rank"]:
+        raise AssertionError("Native and SonicMoE runs did not use identical input batches")
+    if native["parameter_probes"] != sonic["parameter_probes"]:
+        raise AssertionError("Native and SonicMoE runs did not start from identical checkpoint weights")
+
+    if len(native["losses"]) != args.steps or len(sonic["losses"]) != args.steps:
+        raise AssertionError(
+            f"Expected {args.steps} measured losses per backend, got "
+            f"native={len(native['losses'])}, sonicmoe={len(sonic['losses'])}"
+        )
+    loss_abs = [abs(a - b) for a, b in zip(native["losses"], sonic["losses"])]
+    loss_rel = [_relative_difference(a, b) for a, b in zip(native["losses"], sonic["losses"])]
+    loss_within_tolerance = [
+        diff <= args.accuracy_atol + args.accuracy_rtol * abs(reference)
+        for diff, reference in zip(loss_abs, native["losses"])
+    ]
+    per_step_loss = [
+        {
+            "step": step,
+            "native_loss": native_loss,
+            "sonicmoe_loss": sonic_loss,
+            "absolute_difference": absolute_difference,
+            "relative_difference": relative_difference,
+            "within_tolerance": within_tolerance,
+        }
+        for step, (native_loss, sonic_loss, absolute_difference, relative_difference, within_tolerance) in enumerate(
+            zip(native["losses"], sonic["losses"], loss_abs, loss_rel, loss_within_tolerance), start=1
+        )
+    ]
+    gradient_abs: list[float] = []
+    gradient_rel: list[float] = []
+    gradient_l2_abs: list[float] = []
+    gradient_l2_rel: list[float] = []
+    for native_step, sonic_step in zip(native["gradient_probes"], sonic["gradient_probes"]):
+        for name in native_step:
+            for statistic_name in ("sum", "l2", "absmax"):
+                a = native_step[name][statistic_name]
+                b = sonic_step[name][statistic_name]
+                gradient_abs.append(abs(a - b))
+                gradient_rel.append(_relative_difference(a, b))
+                if statistic_name == "l2":
+                    gradient_l2_abs.append(abs(a - b))
+                    gradient_l2_rel.append(_relative_difference(a, b))
+
+    native_ms = native["last_step"]["step_milliseconds"]
+    sonic_ms = sonic["last_step"]["step_milliseconds"]
+    speedup_ratio = native_ms / sonic_ms
+    world_size = dist.get_world_size()
+    accuracy_comparable = args.sonic_routing_mode == "general"
+    return {
+        "strictly_identical_inputs": True,
+        "strictly_identical_checkpoint_probes": True,
+        "strictly_identical_initial_parameter_probes": True,
+        "accuracy_comparable": accuracy_comparable,
+        "accuracy_note": (
+            "general routing preserves native top-k assignments"
+            if accuracy_comparable
+            else "token rounding intentionally changes expert assignments; numerical equivalence is not expected"
+        ),
+        "loss": {
+            "measurement_scope": f"steps_1_to_{args.steps}_inclusive",
+            "num_steps": args.steps,
+            "mean_absolute_difference": statistics.fmean(loss_abs),
+            "max_absolute_difference": max(loss_abs),
+            "mean_relative_difference": statistics.fmean(loss_rel),
+            "max_relative_difference": max(loss_rel),
+            "within_tolerance_all_steps": all(loss_within_tolerance),
+            "per_step": per_step_loss,
+        },
+        "gradient_probe": {
+            "mean_absolute_difference": statistics.fmean(gradient_abs),
+            "max_absolute_difference": max(gradient_abs),
+            "mean_relative_difference": statistics.fmean(gradient_rel),
+            "max_relative_difference": max(gradient_rel),
+            "l2_norm_mean_absolute_difference": statistics.fmean(gradient_l2_abs),
+            "l2_norm_max_absolute_difference": max(gradient_l2_abs),
+            "l2_norm_mean_relative_difference": statistics.fmean(gradient_l2_rel),
+            "l2_norm_max_relative_difference": max(gradient_l2_rel),
+            "note": (
+                "L2-norm differences are the stable gradient comparison; relative differences of signed sums "
+                "can become arbitrarily large when cancellation makes the reference sum nearly zero."
+            ),
+        },
+        "performance": {
+            "measurement_scope": f"step_{args.steps}_only",
+            "measurement_step": args.steps,
+            "native_step_ms": native_ms,
+            "sonicmoe_step_ms": sonic_ms,
+            "native_global_samples_per_second": args.global_batch_size * 1000.0 / native_ms,
+            "sonicmoe_global_samples_per_second": args.global_batch_size * 1000.0 / sonic_ms,
+            "native_global_tokens_per_second": args.global_batch_size * args.seq_len * 1000.0 / native_ms,
+            "sonicmoe_global_tokens_per_second": args.global_batch_size * args.seq_len * 1000.0 / sonic_ms,
+            "native_tokens_per_second_per_card": (
+                args.global_batch_size * args.seq_len * 1000.0 / native_ms / world_size
+            ),
+            "sonicmoe_tokens_per_second_per_card": (
+                args.global_batch_size * args.seq_len * 1000.0 / sonic_ms / world_size
+            ),
+            "speedup_ratio": speedup_ratio,
+            "latency_reduction_percent": (1.0 - sonic_ms / native_ms) * 100.0,
+            "throughput_improvement_percent": (speedup_ratio - 1.0) * 100.0,
+        },
+    }
+
+
+def _render_comparison_report(
+    native: dict[str, Any],
+    sonic: dict[str, Any],
+    comparison: dict[str, Any],
+    args: argparse.Namespace,
+) -> str:
+    """Render a concise report suitable for both logs and a Markdown file."""
+    native_last = native["last_step"]
+    sonic_last = sonic["last_step"]
+    perf = comparison["performance"]
+    accuracy = comparison["loss"]
+    accuracy_rows = [
+        (
+            f"| {row['step']} | {row['native_loss']:.8f} | {row['sonicmoe_loss']:.8f} | "
+            f"{row['absolute_difference']:.8e} | {row['relative_difference']:.8e} | "
+            f"{row['within_tolerance']} |"
+        )
+        for row in accuracy["per_step"]
+    ]
+    lines = [
+        f"# {args.model_label}：原生 MoE 与 SonicMoE Dropless 对比",
+        "",
+        f"精度统计：第 1–{args.steps} 步；性能统计：仅第 {args.steps} 步。",
+        f"模型结构：layers={args.num_layers}，hidden_size={args.hidden_size}，"
+        f"routed_experts={args.num_routed_experts}，shared_experts={args.num_shared_experts}，"
+        f"expert_size={args.expert_intermediate_size}，top_k={args.top_k}。",
+        f"实际参数量：总参数={native['load_info']['global_parameter_count']:,}，"
+        f"估算激活参数={native['load_info']['estimated_active_parameter_count']:,}。",
+        f"配置：seq_len={args.seq_len}，global_batch_size={args.global_batch_size}，"
+        f"micro_batch_size={args.micro_batch_size}，gradient_accumulation_steps={args.gradient_accumulation_steps}，"
+        "FSDP=8，EP/SP/TP=1，BF16，Token Rounding=关闭。",
+        f"权重来源：{'确定性合成初始化' if args.synthetic_weights else args.model_path}。",
+        "",
+        f"| 后端 | 第 {args.steps} 步耗时 (ms) | 第 {args.steps} 步全局样本吞吐 (samples/s) | "
+        f"第 {args.steps} 步单卡 TPS (tokens/s/card) | 第 {args.steps} 步全局 Token 吞吐 (tokens/s) | "
+        f"{args.steps} 步平均 Loss | 峰值显存 (GiB) |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+        (
+            f"| Qwen3.5 原生 grouped_gemm | {native_last['step_milliseconds']:.3f} | "
+            f"{native_last['global_samples_per_second']:.4f} | "
+            f"{native_last['tokens_per_second_per_card']:.2f} | "
+            f"{native_last['global_tokens_per_second']:.2f} | {statistics.fmean(native['losses']):.8f} | "
+            f"{native['performance']['max_memory_allocated_gib']:.3f} |"
+        ),
+        (
+            f"| SonicMoE general/dropless | {sonic_last['step_milliseconds']:.3f} | "
+            f"{sonic_last['global_samples_per_second']:.4f} | "
+            f"{sonic_last['tokens_per_second_per_card']:.2f} | "
+            f"{sonic_last['global_tokens_per_second']:.2f} | {statistics.fmean(sonic['losses']):.8f} | "
+            f"{sonic['performance']['max_memory_allocated_gib']:.3f} |"
+        ),
+        "",
+        f"- SonicMoE 加速比：**{perf['speedup_ratio']:.4f}x**",
+        f"- 吞吐提升：**{perf['throughput_improvement_percent']:.2f}%**",
+        f"- 步耗时下降：**{perf['latency_reduction_percent']:.2f}%**",
+        f"- {args.steps} 步最大 Loss 绝对差：**{accuracy['max_absolute_difference']:.8e}**",
+        f"- {args.steps} 步 Loss 全部通过容差：**{accuracy['within_tolerance_all_steps']}**",
+        f"- 梯度探针 L2 范数最大相对差：" f"**{comparison['gradient_probe']['l2_norm_max_relative_difference']:.8e}**",
+        "- 输入数据 SHA256 和初始参数探针均要求完全一致。",
+        "- 本测试执行前向和反向但不更新参数，以避免优化器累计差异干扰 kernel 数值对比。",
+        "",
+        f"## 第 1–{args.steps} 步 Loss 精度明细",
+        "",
+        "| Step | 原生 Loss | SonicMoE Loss | 绝对差 | 相对差 | 通过容差 |",
+        "|---:|---:|---:|---:|---:|:---:|",
+        *accuracy_rows,
+    ]
+    return "\n".join(lines)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model-path",
+        default=os.environ.get("QWEN3_5_MOE_PATH"),
+        help="HuggingFace checkpoint path; defaults to QWEN3_5_MOE_PATH.",
+    )
+    parser.add_argument("--model-label", default="Qwen/Qwen3.5-35B-A3B")
+    parser.add_argument(
+        "--synthetic-weights",
+        action="store_true",
+        help="Initialize weights deterministically instead of loading --model-path; intended for shape benchmarks.",
+    )
+    parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume compatible atomically persisted formal steps after an external job interruption.",
+    )
+    parser.add_argument("--steps", type=int, default=10)
+    parser.add_argument("--warmup-steps", type=int, default=5)
+    parser.add_argument("--seq-len", type=int, default=8192)
+    parser.add_argument("--global-batch-size", type=int, default=512)
+    parser.add_argument("--micro-batch-size", type=int, default=1)
+    parser.add_argument("--num-layers", type=int, default=40)
+    parser.add_argument("--hidden-size", type=int, default=OFFICIAL_SHAPE["hidden_size"])
+    parser.add_argument("--vocab-size", type=int, default=OFFICIAL_SHAPE["vocab_size"])
+    parser.add_argument("--num-attention-heads", type=int, default=OFFICIAL_SHAPE["num_attention_heads"])
+    parser.add_argument("--num-key-value-heads", type=int, default=OFFICIAL_SHAPE["num_key_value_heads"])
+    parser.add_argument("--attention-head-dim", type=int, default=OFFICIAL_SHAPE["attention_head_dim"])
+    parser.add_argument("--linear-num-key-heads", type=int, default=OFFICIAL_SHAPE["linear_num_key_heads"])
+    parser.add_argument("--linear-num-value-heads", type=int, default=OFFICIAL_SHAPE["linear_num_value_heads"])
+    parser.add_argument("--linear-key-head-dim", type=int, default=OFFICIAL_SHAPE["linear_key_head_dim"])
+    parser.add_argument("--linear-value-head-dim", type=int, default=OFFICIAL_SHAPE["linear_value_head_dim"])
+    parser.add_argument("--num-routed-experts", type=int, default=OFFICIAL_SHAPE["n_routed_experts"])
+    parser.add_argument("--num-shared-experts", type=int, default=OFFICIAL_SHAPE["n_shared_experts"])
+    parser.add_argument("--expert-intermediate-size", type=int, default=OFFICIAL_SHAPE["moe_intermediate_size"])
+    parser.add_argument("--top-k", type=int, default=OFFICIAL_SHAPE["num_experts_per_tok"])
+    parser.add_argument("--declared-total-parameters", type=int)
+    parser.add_argument("--declared-active-parameters", type=int)
+    parser.add_argument("--loss-chunk-size", type=int, default=128)
+    parser.add_argument("--recompute-ratio", type=float, default=1.0)
+    parser.add_argument("--model-seed", type=int, default=20260820)
+    parser.add_argument("--data-seed", type=int, default=20260821)
+    parser.add_argument("--log-interval", type=int, default=1)
+    parser.add_argument("--accuracy-atol", type=float, default=2e-2)
+    parser.add_argument("--accuracy-rtol", type=float, default=2e-2)
+    parser.add_argument("--compile", action="store_true")
+    parser.add_argument("--deterministic", action="store_true")
+    parser.add_argument(
+        "--sonic-routing-mode",
+        choices=("general",),
+        default="general",
+        help="SonicMoE routing mode. This profiler intentionally supports dropless general routing only.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if (
+        args.steps <= 0
+        or args.warmup_steps < 0
+        or args.seq_len <= 0
+        or args.global_batch_size <= 0
+        or args.micro_batch_size <= 0
+    ):
+        raise ValueError(
+            "steps, seq-len, global-batch-size and micro-batch-size must be positive; "
+            "warmup-steps must be non-negative"
+        )
+    positive_shape_values = {
+        "num-layers": args.num_layers,
+        "hidden-size": args.hidden_size,
+        "vocab-size": args.vocab_size,
+        "num-attention-heads": args.num_attention_heads,
+        "num-key-value-heads": args.num_key_value_heads,
+        "attention-head-dim": args.attention_head_dim,
+        "linear-num-key-heads": args.linear_num_key_heads,
+        "linear-num-value-heads": args.linear_num_value_heads,
+        "linear-key-head-dim": args.linear_key_head_dim,
+        "linear-value-head-dim": args.linear_value_head_dim,
+        "num-routed-experts": args.num_routed_experts,
+        "expert-intermediate-size": args.expert_intermediate_size,
+        "top-k": args.top_k,
+    }
+    invalid_shape_values = {name: value for name, value in positive_shape_values.items() if value <= 0}
+    if args.num_shared_experts < 0:
+        invalid_shape_values["num-shared-experts"] = args.num_shared_experts
+    if invalid_shape_values:
+        raise ValueError(f"Model shape values must be positive (shared experts may be zero): {invalid_shape_values}")
+    if args.num_attention_heads % args.num_key_value_heads:
+        raise ValueError("num-attention-heads must be divisible by num-key-value-heads")
+    if args.linear_num_value_heads % args.linear_num_key_heads:
+        raise ValueError("linear-num-value-heads must be divisible by linear-num-key-heads")
+    if args.top_k > args.num_routed_experts:
+        raise ValueError("top-k cannot exceed num-routed-experts")
+    if not args.synthetic_weights:
+        if args.model_path is None:
+            raise FileNotFoundError(
+                "Set --model-path or QWEN3_5_MOE_PATH to a complete HuggingFace checkpoint, "
+                "or use --synthetic-weights."
+            )
+        if not Path(args.model_path).is_dir():
+            raise FileNotFoundError(f"Qwen3.5 checkpoint directory does not exist: {args.model_path}.")
+
+    monkey_patch_hf_modules_cache()
+    rank, world_size, local_rank = _init_distributed(args.deterministic)
+    if world_size != 8:
+        raise RuntimeError(f"This benchmark requires exactly 8 processes/GPUs, got world_size={world_size}")
+    sequences_per_micro_step = world_size * args.micro_batch_size
+    if args.global_batch_size % sequences_per_micro_step != 0:
+        raise ValueError(
+            "global-batch-size must be divisible by world-size * micro-batch-size; "
+            f"got {args.global_batch_size} % ({world_size} * {args.micro_batch_size})"
+        )
+    args.gradient_accumulation_steps = args.global_batch_size // sequences_per_micro_step
+    set_random_seed(args.model_seed, deterministic=args.deterministic)
+
+    if rank == 0:
+        _atomic_write_json(
+            Path(args.output).with_name(f"{Path(args.output).stem}.status.json"),
+            {
+                "status": "started",
+                "model": args.model_label,
+                "model_shape": _requested_shape(args),
+                "weight_source": (
+                    "deterministic_synthetic_initialization" if args.synthetic_weights else args.model_path
+                ),
+                "sequence_length": args.seq_len,
+                "global_batch_size": args.global_batch_size,
+                "micro_batch_size": args.micro_batch_size,
+                "gradient_accumulation_steps": args.gradient_accumulation_steps,
+                "steps": args.steps,
+                "warmup_steps": args.warmup_steps,
+                "accuracy_scope": f"steps_1_to_{args.steps}_inclusive",
+                "performance_scope": f"step_{args.steps}_only",
+                "routing": "general_dropless",
+                "token_rounding": False,
+            },
+        )
+
+    batches, local_input_hash = _make_token_batches(
+        rank=rank,
+        count=(args.warmup_steps + args.steps) * args.gradient_accumulation_steps,
+        seq_len=args.seq_len,
+        micro_batch_size=args.micro_batch_size,
+        vocab_size=args.vocab_size,
+        data_seed=args.data_seed,
+    )
+    input_hashes: list[str | None] = [None] * world_size
+    dist.all_gather_object(input_hashes, local_input_hash)
+    resolved_hashes = [value for value in input_hashes if value is not None]
+
+    _print_rank0(
+        "[benchmark] "
+        f"world_size={world_size} local_rank0={local_rank} model={args.model_label} "
+        f"layers={args.num_layers} hidden_size={args.hidden_size} vocab_size={args.vocab_size} "
+        f"routed_experts={args.num_routed_experts} shared_experts={args.num_shared_experts} "
+        f"expert_size={args.expert_intermediate_size} top_k={args.top_k} seq_len={args.seq_len} "
+        f"global_batch_size={args.global_batch_size} micro_batch_size={args.micro_batch_size} "
+        f"gradient_accumulation_steps={args.gradient_accumulation_steps} "
+        f"steps={args.steps} warmup={args.warmup_steps} FSDP=on EP=off SP=off TP=off "
+        f"compile={args.compile} recompute_ratio={args.recompute_ratio} routing={args.sonic_routing_mode}"
+    )
+    native = _run_backend(args, "grouped_gemm", batches, resolved_hashes)
+    sonic = _run_backend(args, "sonicmoe", batches, resolved_hashes)
+    comparison = _compare(native, sonic, args)
+    report = _render_comparison_report(native, sonic, comparison, args)
+
+    payload = {
+        "schema_version": 2,
+        "model": args.model_label,
+        "model_shape": _requested_shape(args),
+        "declared_parameter_scale": {
+            "total_parameters": args.declared_total_parameters,
+            "active_parameters": args.declared_active_parameters,
+        },
+        "scope": (f"complete {args.num_layers}-layer text model; forward+backward; fixed weights; no optimizer step"),
+        "parallelism": {"fsdp": 8, "ep": 1, "sp": 1, "tp": 1},
+        "batching": {
+            "sequence_length": args.seq_len,
+            "global_batch_size": args.global_batch_size,
+            "micro_batch_size": args.micro_batch_size,
+            "gradient_accumulation_steps": args.gradient_accumulation_steps,
+            "global_tokens_per_step": args.global_batch_size * args.seq_len,
+        },
+        "dtype": "bfloat16",
+        "arguments": vars(args),
+        "environment": {
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "gpu": torch.cuda.get_device_name(0),
+            "world_size": world_size,
+        },
+        "native": native,
+        "sonicmoe": sonic,
+        "comparison": comparison,
+    }
+    if rank == 0:
+        output = Path(args.output)
+        _atomic_write_json(output, payload)
+
+        report_output = output.with_suffix(".md")
+        temporary_report = report_output.with_suffix(report_output.suffix + ".tmp")
+        temporary_report.write_text(report + "\n", encoding="utf-8")
+        os.replace(temporary_report, report_output)
+        _atomic_write_json(
+            output.with_name(f"{output.stem}.status.json"),
+            {
+                "status": "completed",
+                "benchmark_output": str(output),
+                "benchmark_report": str(report_output),
+            },
+        )
+        print("\n" + report + "\n", flush=True)
+        print("BENCHMARK_RESULT=" + json.dumps(comparison, ensure_ascii=False), flush=True)
+        print(f"BENCHMARK_OUTPUT={output}", flush=True)
+        print(f"BENCHMARK_REPORT={report_output}", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"BENCHMARK_ERROR rank={os.environ.get('RANK', 'unknown')}: {error}", file=sys.stderr, flush=True)
+        raise

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -9,7 +9,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from cyclopts import Parameter
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 from torch import nn
 from torch.distributed._functional_collectives import all_reduce
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
@@ -73,6 +73,7 @@ from xtuner.v1.module.decoder_layer.moe_decoder_layer import (
     MoEDecoderLayerOutput,
     MoEGate,
 )
+from xtuner.v1.module.moe_backend import SonicMoEBackendConfig
 from xtuner.v1.module.mtp import MTPBlock, MTPConfig, MTPLayer
 from xtuner.v1.utils import (
     get_device,
@@ -110,6 +111,12 @@ MOE_NON_EP_COMPILE_CFG: dict[str, TorchCompileOption] = {
 
 MOE_EP_COMPILE_CFG = MOE_NON_EP_COMPILE_CFG.copy()
 MOE_EP_COMPILE_CFG.pop("xtuner.v1.module.decoder_layer.moe_decoder_layer.MoEDecoderLayer.forward")
+
+SONICMOE_COMPILE_CFG = MOE_NON_EP_COMPILE_CFG.copy()
+SONICMOE_COMPILE_CFG.pop("xtuner.v1.module.decoder_layer.moe_decoder_layer.MoEBlock.forward")
+SONICMOE_COMPILE_CFG["xtuner.v1.module.decoder_layer.moe_decoder_layer.MoEDecoderLayer.forward"] = TorchCompileOption(
+    fullgraph=False
+)
 
 
 class MoEModelOutputs(ModelOutputs):
@@ -168,6 +175,8 @@ class MoEConfig(TransformerConfig):
     router_compute_dtype: Literal["float32", "native"] = "float32"
     moe_bias: bool = False
     moe_act_fn_cfg: MoEActFnConfig = MoEActFnConfig()
+    expert_backend: Annotated[Literal["grouped_gemm", "sonicmoe"], Parameter(group="moe")] = "grouped_gemm"
+    sonicmoe_cfg: SonicMoEBackendConfig = SonicMoEBackendConfig()
     mtp_config: MTPConfig | None = None
     freeze_routers: bool = False
     router_async_offload: bool = False
@@ -177,6 +186,37 @@ class MoEConfig(TransformerConfig):
     # Compose models call `self.embed_tokens` multiple times per step, so default to
     # keeping it unsharded after forward to avoid repeated all-gathers.
     embed_reshard_after_forward: bool = True
+
+    @model_validator(mode="after")
+    def _validate_expert_backend(self) -> Self:
+        if self.expert_backend != "sonicmoe":
+            return self
+
+        if self.ep_size != 1:
+            raise ValueError("The initial SonicMoE integration requires ep_size=1; EP support is not implemented yet.")
+        if self.expert_tp_size != 1:
+            raise ValueError(
+                "The initial SonicMoE integration requires expert_tp_size=1; "
+                "ExpertTP support is not implemented yet."
+            )
+        if self.dispatcher is not None:
+            raise ValueError("SonicMoE owns token dispatch internally, so dispatcher must be None.")
+        if self.float8_cfg is not None:
+            raise ValueError("The initial SonicMoE integration supports BF16 only; float8_cfg must be None.")
+        if self.moe_act_fn_cfg.act_type != "swiglu":
+            raise ValueError("The initial SonicMoE integration supports the SwiGLU expert activation only.")
+        if self.sonicmoe_cfg.routing_mode == "token_rounding":
+            if not isinstance(self.router, GreedyRouterConfig):
+                raise ValueError("SonicMoE token rounding requires GreedyRouterConfig.")
+            if self.router.scoring_func != "softmax":
+                raise ValueError("SonicMoE token rounding requires softmax router scores.")
+            if self.router.use_grouped_router:
+                raise ValueError("SonicMoE token rounding does not support grouped expert selection.")
+            if not self.router.norm_topk_prob:
+                raise ValueError("SonicMoE token rounding requires norm_topk_prob=True.")
+            if self.router.router_scaling_factor != 1.0:
+                raise ValueError("SonicMoE token rounding requires router_scaling_factor=1.0.")
+        return self
 
     def build(self) -> "MoE":
         from xtuner.v1.model.moe.moe import MoE
@@ -1150,6 +1190,8 @@ class MoE(BaseModel):
                     router_config=config.router,
                     router_compute_dtype=config.router_compute_dtype,
                     moe_act_fn_cfg=config.moe_act_fn_cfg,
+                    expert_backend=config.expert_backend,
+                    sonicmoe_cfg=config.sonicmoe_cfg,
                     float8_cfg=config.float8_cfg,
                     layer_idx=layer_idx,
                     dispatcher=config.dispatcher,
@@ -1217,6 +1259,8 @@ class MoE(BaseModel):
                 router_config=config.router,
                 router_compute_dtype=config.router_compute_dtype,
                 moe_act_fn_cfg=config.moe_act_fn_cfg,
+                expert_backend=config.expert_backend,
+                sonicmoe_cfg=config.sonicmoe_cfg,
                 float8_cfg=config.float8_cfg,
                 layer_idx=config.num_hidden_layers + i,
                 dispatcher=config.dispatcher,
@@ -1415,6 +1459,8 @@ class MoE(BaseModel):
     @property
     @override
     def default_compile_cfg(self) -> dict[str, TorchCompileOption]:
+        if self.config.expert_backend == "sonicmoe":
+            return SONICMOE_COMPILE_CFG
         if use_moe_ep_compile_cfg(self.config):
             return MOE_EP_COMPILE_CFG
         return MOE_NON_EP_COMPILE_CFG

--- a/xtuner/v1/model/moe/moe.py
+++ b/xtuner/v1/model/moe/moe.py
@@ -196,8 +196,7 @@ class MoEConfig(TransformerConfig):
             raise ValueError("The initial SonicMoE integration requires ep_size=1; EP support is not implemented yet.")
         if self.expert_tp_size != 1:
             raise ValueError(
-                "The initial SonicMoE integration requires expert_tp_size=1; "
-                "ExpertTP support is not implemented yet."
+                "The initial SonicMoE integration requires expert_tp_size=1; ExpertTP support is not implemented yet."
             )
         if self.dispatcher is not None:
             raise ValueError("SonicMoE owns token dispatch internally, so dispatcher must be None.")

--- a/xtuner/v1/model/moe/qwen3_5_text.py
+++ b/xtuner/v1/model/moe/qwen3_5_text.py
@@ -40,6 +40,9 @@ MOE_NON_EP_COMPILE_CFG: dict[str, TorchCompileOption] = {
 MOE_EP_COMPILE_CFG = MOE_NON_EP_COMPILE_CFG.copy()
 MOE_EP_COMPILE_CFG.pop("xtuner.v1.module.decoder_layer.moe_decoder_layer.MoEDecoderLayer.forward")
 
+SONICMOE_COMPILE_CFG = MOE_NON_EP_COMPILE_CFG.copy()
+SONICMOE_COMPILE_CFG.pop("xtuner.v1.module.decoder_layer.moe_decoder_layer.MoEBlock.forward")
+
 
 class Qwen3_5_VLTextMoE(Qwen3VLTextMoE):
     def to_hf_key_list(self, key: str) -> list[str]:
@@ -164,6 +167,8 @@ class Qwen3_5_VLTextMoE(Qwen3VLTextMoE):
     @property
     @override
     def default_compile_cfg(self) -> dict[str, TorchCompileOption]:
+        if self.config.expert_backend == "sonicmoe":
+            return SONICMOE_COMPILE_CFG
         if use_moe_ep_compile_cfg(self.config):
             return MOE_EP_COMPILE_CFG
         else:

--- a/xtuner/v1/module/decoder_layer/moe_decoder_layer.py
+++ b/xtuner/v1/module/decoder_layer/moe_decoder_layer.py
@@ -34,6 +34,7 @@ from xtuner.v1.module.dispatcher import (
     build_dispatcher,
 )
 from xtuner.v1.module.grouped_linear.moe_group_linear import build_grouped_linear
+from xtuner.v1.module.moe_backend import SonicMoEBackendConfig
 from xtuner.v1.module.rope import RopeScalingConfig
 from xtuner.v1.ops.act_fn import get_act_fn
 from xtuner.v1.utils import ForwardState
@@ -182,8 +183,19 @@ class MoEBlock(nn.Module):
         float8_cfg: Float8Config | None = None,
         moe_act_fn_cfg: MoEActFnConfig,
         ep_tp_mesh: DeviceMesh | None = None,
+        expert_backend: Literal["grouped_gemm", "sonicmoe"] = "grouped_gemm",
+        sonicmoe_cfg: SonicMoEBackendConfig | None = None,
     ):
         super().__init__()
+        if expert_backend == "sonicmoe":
+            if ep_mesh is not None and ep_mesh.size() > 1:
+                raise ValueError("The initial SonicMoE integration does not support EP.")
+            if expert_tp_mesh is not None and expert_tp_mesh.size() > 1:
+                raise ValueError("The initial SonicMoE integration does not support ExpertTP.")
+            if float8_cfg is not None:
+                raise ValueError("The initial SonicMoE integration does not support FP8.")
+            if moe_act_fn_cfg.act_type != "swiglu":
+                raise ValueError("The initial SonicMoE integration supports SwiGLU only.")
         self.hidden_size = hidden_size
         self.intermediate_size = moe_intermediate_size
         self.num_routed_experts = n_routed_experts
@@ -214,6 +226,69 @@ class MoEBlock(nn.Module):
             ep_tp_mesh=ep_tp_mesh,
         )
         self.moe_act = moe_act_fn_cfg.build()
+        self.sonicmoe = (sonicmoe_cfg or SonicMoEBackendConfig()).build() if expert_backend == "sonicmoe" else None
+
+    @property
+    def uses_sonicmoe(self) -> bool:
+        """Return whether this expert block uses the SonicMoE backend.
+
+        Returns:
+            bool: Whether SonicMoE is enabled.
+        """
+        return self.sonicmoe is not None
+
+    @staticmethod
+    def _local_parameter(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+
+    def forward_routed(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        router_weights: torch.Tensor,
+        *,
+        decoding: bool = False,
+    ) -> torch.Tensor:
+        """Run SonicMoE directly from XTuner's unpermuted router output.
+
+        Args:
+            hidden_states (torch.Tensor): Unpermuted expert input with shape ``[T, H]``.
+            topk_ids (torch.Tensor): Original top-k expert ids with shape ``[T, K]``.
+            topk_weights (torch.Tensor): Original top-k router weights with shape ``[T, K]``.
+            router_weights (torch.Tensor): Full router weights with shape ``[T, E]``.
+            decoding (bool): Whether the call is an inference decode step.
+
+        Returns:
+            torch.Tensor: Combined routed-expert output with shape ``[T, H]``.
+        """
+        if self.sonicmoe is None:
+            raise RuntimeError("forward_routed is only available when expert_backend='sonicmoe'.")
+
+        w1w3 = self._local_parameter(self.fused_w1w3.weight).view(
+            self.num_routed_experts, 2 * self.intermediate_size, self.hidden_size
+        )
+        w2 = self._local_parameter(self.fused_w2.weight).view(
+            self.num_routed_experts, self.hidden_size, self.intermediate_size
+        )
+        w1w3_bias = None
+        w2_bias = None
+        if self.fused_w1w3.moe_bias:
+            w1w3_bias = self._local_parameter(self.fused_w1w3.bias)
+            w2_bias = self._local_parameter(self.fused_w2.bias)
+
+        output, _ = self.sonicmoe(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            router_weights=router_weights,
+            fused_w1w3=w1w3,
+            fused_w2=w2,
+            fused_w1w3_bias=w1w3_bias,
+            fused_w2_bias=w2_bias,
+            training=self.training and not decoding,
+        )
+        return output
 
     def forward(self, x, tokens_per_expert, decoding):
         gate_up_out = self.fused_w1w3(x, tokens_per_expert, decoding)
@@ -249,6 +324,8 @@ class MoEDecoderLayer(nn.Module):
         router_config: GreedyRouterConfig | NoAuxRouterConfig,
         router_compute_dtype: Literal["float32", "native"] = "float32",
         moe_act_fn_cfg: MoEActFnConfig,
+        expert_backend: Literal["grouped_gemm", "sonicmoe"] = "grouped_gemm",
+        sonicmoe_cfg: SonicMoEBackendConfig | None = None,
         float8_cfg: Float8Config | None = None,
         layer_idx: int = 0,
         dispatcher: Literal["deepep", "all2all", "agrs"] | None,
@@ -257,6 +334,8 @@ class MoEDecoderLayer(nn.Module):
         ep_tp_mesh: DeviceMesh | None = None,
     ):
         super().__init__()
+        if expert_backend == "sonicmoe" and dispatcher is not None:
+            raise ValueError("SonicMoE owns local token dispatch, so dispatcher must be None in the initial version.")
         self.ep_mesh = ep_mesh
         self.ep_tp_mesh = ep_tp_mesh
         self.hidden_size = hidden_size
@@ -314,20 +393,24 @@ class MoEDecoderLayer(nn.Module):
             float8_cfg=float8_cfg,
             moe_act_fn_cfg=moe_act_fn_cfg,
             ep_tp_mesh=ep_tp_mesh,
+            expert_backend=expert_backend,
+            sonicmoe_cfg=sonicmoe_cfg,
         )
         # TODO: (yehaochen) Maybe should be replaced by build_dispatcher
         process_group = ep_mesh.get_group() if ep_mesh is not None else None
         tp_group = expert_tp_mesh.get_group() if expert_tp_mesh is not None else None
         ep_tp_group = ep_tp_mesh._flatten().get_group() if ep_tp_mesh is not None else None
-        self.dispatcher = build_dispatcher(
-            dispatcher=dispatcher,
-            n_routed_experts=n_routed_experts,
-            ep_group=process_group,
-            tp_group=tp_group,
-            ep_tp_group=ep_tp_group,
-            training_dtype="fp8" if float8_cfg is not None else "bf16",
-            generate_dtype=generate_config.dtype if generate_config is not None else "bf16",
-        )
+        self.dispatcher = None
+        if not self.experts.uses_sonicmoe:
+            self.dispatcher = build_dispatcher(
+                dispatcher=dispatcher,
+                n_routed_experts=n_routed_experts,
+                ep_group=process_group,
+                tp_group=tp_group,
+                ep_tp_group=ep_tp_group,
+                training_dtype="fp8" if float8_cfg is not None else "bf16",
+                generate_dtype=generate_config.dtype if generate_config is not None else "bf16",
+            )
 
     def forward(
         self,
@@ -435,6 +518,20 @@ class MoEDecoderLayer(nn.Module):
         )
 
         origin_shape = hidden_states.shape
+
+        if self.experts.uses_sonicmoe:
+            hidden_states = self._sonicmoe_forward(
+                hidden_states=hidden_states,
+                residual=residual,
+                router_results=router_results,
+            )
+            return self._build_output(
+                hidden_states=hidden_states,
+                router_results=router_results,
+                attn_outputs=attn_outputs,
+            )
+
+        assert self.dispatcher is not None
 
         # reshape hidden_states to (batch_size * seq_len, hidden_size)
         # ProberList.before_dispatch(
@@ -545,6 +642,15 @@ class MoEDecoderLayer(nn.Module):
         position_embeddings_list: list[tuple[torch.Tensor, torch.Tensor]],
         attention_kwargs_list: list[dict[str, object]] | None = None,
     ) -> MoEDecoderLayerMicroBatchOutput:
+        if self.experts.uses_sonicmoe:
+            return self._sonicmoe_micro_batch_forward(
+                hidden_states_list=hidden_states_list,
+                seq_ctx_list=seq_ctx_list,
+                position_embeddings_list=position_embeddings_list,
+                attention_kwargs_list=attention_kwargs_list,
+            )
+
+        assert self.dispatcher is not None
         origin_shape = hidden_states_list[0].shape
         assert all(hidden_states.shape == origin_shape for hidden_states in hidden_states_list), (
             "All hidden states should have the same shape"
@@ -702,6 +808,74 @@ class MoEDecoderLayer(nn.Module):
             "router_weights": [router_results["router_weights"] for router_results in router_results_list],
             "router_topk_ids": [router_results["topk_ids"] for router_results in router_results_list],
         }
+
+    def _sonicmoe_micro_batch_forward(
+        self,
+        hidden_states_list: list[torch.Tensor],
+        seq_ctx_list: list[SequenceContext],
+        position_embeddings_list: list[tuple[torch.Tensor, torch.Tensor]],
+        attention_kwargs_list: list[dict[str, object]] | None = None,
+    ) -> MoEDecoderLayerMicroBatchOutput:
+        """Execute intra-layer micro-batches without the EP dispatcher pipeline."""
+        origin_shape = hidden_states_list[0].shape
+        assert all(hidden_states.shape == origin_shape for hidden_states in hidden_states_list), (
+            "All hidden states should have the same shape"
+        )
+
+        hidden_states_out_list: list[torch.Tensor] = []
+        router_results_list: list[RouterResults] = []
+        attn_outputs_list: list[AttnOutputs] = []
+        if attention_kwargs_list is None:
+            attention_kwargs_list = [{} for _ in hidden_states_list]
+        assert len(attention_kwargs_list) == len(hidden_states_list)
+        for hidden_states, attention_kwargs, seq_ctx, position_embeddings in zip(
+            hidden_states_list,
+            attention_kwargs_list,
+            seq_ctx_list,
+            position_embeddings_list,
+        ):
+            residual, expert_inputs, router_results, attn_outputs = self._pre_moe_forward(
+                hidden_states=hidden_states,
+                seq_ctx=seq_ctx,
+                position_embeddings=position_embeddings,
+                state=ForwardState.TRAINING,
+                attention_kwargs=attention_kwargs,
+            )
+            output = self._sonicmoe_forward(
+                hidden_states=expert_inputs,
+                residual=residual,
+                router_results=router_results,
+            )
+            hidden_states_out_list.append(output)
+            router_results_list.append(router_results)
+            attn_outputs_list.append(attn_outputs)
+
+        return self._build_micro_batch_output(
+            hidden_states_list=hidden_states_out_list,
+            router_results_list=router_results_list,
+            attn_outputs_list=attn_outputs_list,
+        )
+
+    def _sonicmoe_forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        router_results: RouterResults,
+    ) -> torch.Tensor:
+        combined_hidden_states = self.experts.forward_routed(
+            hidden_states.view(-1, hidden_states.shape[-1]),
+            router_results["topk_ids"],
+            router_results["topk_weights"],
+            router_results["router_weights"],
+        ).view_as(hidden_states)
+        shared_experts_out = (
+            self._shared_experts_forward(hidden_states=hidden_states) if self.n_shared_experts > 0 else None
+        )
+        return self._post_moe_forward(
+            combined_hidden_states=combined_hidden_states,
+            residual=residual,
+            shared_experts_out=shared_experts_out,
+        )
 
     def _pre_moe_forward(
         self,

--- a/xtuner/v1/module/moe_backend/__init__.py
+++ b/xtuner/v1/module/moe_backend/__init__.py
@@ -1,0 +1,5 @@
+from .config import SonicMoEBackendConfig
+from .sonicmoe import SonicMoEBackend
+
+
+__all__ = ["SonicMoEBackend", "SonicMoEBackendConfig"]

--- a/xtuner/v1/module/moe_backend/config.py
+++ b/xtuner/v1/module/moe_backend/config.py
@@ -1,0 +1,35 @@
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+if TYPE_CHECKING:
+    from .sonicmoe import SonicMoEBackend
+
+
+class SonicMoEBackendConfig(BaseModel):
+    """Configuration for the official SonicMoE routed-expert backend.
+
+    Args:
+        routing_mode (Literal["general", "token_rounding"]): Routing metadata
+            policy. General preserves the model's fixed top-k assignments.
+        rounding_mode (Literal["nearest", "up", "down"]): Token rounding
+            direction.
+        rounding_quantum (int): Expert token-count tile size.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    routing_mode: Literal["general", "token_rounding"] = "general"
+    rounding_mode: Literal["nearest", "up", "down"] = "nearest"
+    rounding_quantum: int = Field(default=128, gt=0)
+
+    def build(self) -> "SonicMoEBackend":
+        """Build a SonicMoE expert backend.
+
+        Returns:
+            SonicMoEBackend: Configured expert backend module.
+        """
+        from .sonicmoe import SonicMoEBackend
+
+        return SonicMoEBackend(self)

--- a/xtuner/v1/module/moe_backend/sonicmoe.py
+++ b/xtuner/v1/module/moe_backend/sonicmoe.py
@@ -98,8 +98,7 @@ class SonicMoEBackend(nn.Module):
                 )
             if fused_w2_bias.shape != (num_experts, hidden_size):
                 raise ValueError(
-                    f"fused_w2_bias must have shape {(num_experts, hidden_size)}, "
-                    f"got {tuple(fused_w2_bias.shape)}."
+                    f"fused_w2_bias must have shape {(num_experts, hidden_size)}, got {tuple(fused_w2_bias.shape)}."
                 )
             if fused_w1w3_bias.device != hidden_states.device or fused_w2_bias.device != hidden_states.device:
                 raise ValueError("SonicMoE expert biases must be on the same CUDA device as hidden_states.")

--- a/xtuner/v1/module/moe_backend/sonicmoe.py
+++ b/xtuner/v1/module/moe_backend/sonicmoe.py
@@ -1,0 +1,166 @@
+import torch
+from torch import nn
+
+from xtuner.v1.ops.moe.sonicmoe import SonicMoEOp
+from xtuner.v1.ops.moe.token_rounding import build_token_rounding_metadata
+
+from .config import SonicMoEBackendConfig
+
+
+class SonicMoEBackend(nn.Module):
+    """Adapter for the official ``sonicmoe`` general-routing API.
+
+    Parameters remain owned by XTuner. This object only translates XTuner's
+    routing result and expert-weight layout to SonicMoE's functional API, so
+    state-dict and HuggingFace checkpoint keys remain unchanged.
+
+    Args:
+        config (SonicMoEBackendConfig): SonicMoE routing configuration.
+    """
+
+    def __init__(self, config: SonicMoEBackendConfig):
+        super().__init__()
+        self.config = config
+        self._op = SonicMoEOp()
+
+    def forward(
+        self,
+        *,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        router_weights: torch.Tensor | None = None,
+        fused_w1w3: torch.Tensor,
+        fused_w2: torch.Tensor,
+        fused_w1w3_bias: torch.Tensor | None = None,
+        fused_w2_bias: torch.Tensor | None = None,
+        training: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run a complete routed expert MLP through SonicMoE.
+
+        Args:
+            hidden_states (torch.Tensor): Unpermuted token states with shape ``[T, H]``.
+            topk_ids (torch.Tensor): Selected global expert ids with shape ``[T, K]``.
+            topk_weights (torch.Tensor): Selected routing weights with shape ``[T, K]``.
+            router_weights (torch.Tensor | None): Full router weights with shape ``[T, E]``. Required
+                by token rounding and ignored by general routing.
+            fused_w1w3 (torch.Tensor): XTuner concatenated gate/up weights ``[E, 2I, H]``.
+            fused_w2 (torch.Tensor): XTuner down-projection weights ``[E, H, I]``.
+            fused_w1w3_bias (torch.Tensor | None): Optional gate/up bias.
+            fused_w2_bias (torch.Tensor | None): Optional down-projection bias.
+            training (bool): Whether to enable SonicMoE's training path.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor]: Combined expert output and executed token count per expert.
+        """
+        if not hidden_states.is_cuda:
+            raise RuntimeError("The SonicMoE backend is CUDA-only.")
+        if hidden_states.dtype != torch.bfloat16:
+            raise TypeError(f"The initial SonicMoE integration supports bfloat16 only, got {hidden_states.dtype}.")
+        if hidden_states.ndim != 2:
+            raise ValueError(f"hidden_states must have shape [T, H], got {tuple(hidden_states.shape)}.")
+        if topk_ids.ndim != 2 or topk_weights.shape != topk_ids.shape:
+            raise ValueError(
+                "topk_ids and topk_weights must have the same [T, K] shape, "
+                f"got {tuple(topk_ids.shape)} and {tuple(topk_weights.shape)}."
+            )
+        if topk_ids.shape[0] != hidden_states.shape[0]:
+            raise ValueError("The token dimension of routing results must match hidden_states.")
+        if fused_w1w3.ndim != 3 or fused_w2.ndim != 3:
+            raise ValueError("SonicMoE expert weights must be logical [E, 2I, H] and [E, H, I] tensors.")
+
+        tensors = (topk_ids, topk_weights, fused_w1w3, fused_w2)
+        if any(tensor.device != hidden_states.device for tensor in tensors):
+            raise ValueError("All SonicMoE inputs and expert weights must be on the same CUDA device.")
+        if fused_w1w3.dtype != torch.bfloat16 or fused_w2.dtype != torch.bfloat16:
+            raise TypeError("The initial SonicMoE integration requires bfloat16 expert weights.")
+
+        num_experts, gate_up_features, hidden_size = fused_w1w3.shape
+        if num_experts > 32768:
+            raise ValueError(f"SonicMoE supports at most 32768 experts, got {num_experts}.")
+        if gate_up_features % 2 != 0:
+            raise ValueError("SwiGLU gate/up output dimension must be even.")
+        intermediate_size = gate_up_features // 2
+        if fused_w2.shape != (num_experts, hidden_size, intermediate_size):
+            raise ValueError(
+                "Incompatible SonicMoE expert weight shapes: "
+                f"w1w3={tuple(fused_w1w3.shape)}, w2={tuple(fused_w2.shape)}."
+            )
+        if hidden_states.shape[1] != hidden_size:
+            raise ValueError("hidden_states hidden dimension does not match the expert weights.")
+        if (fused_w1w3_bias is None) != (fused_w2_bias is None):
+            raise ValueError("SonicMoE requires both expert biases to be present or both to be absent.")
+        if fused_w1w3_bias is not None and fused_w2_bias is not None:
+            if fused_w1w3_bias.shape != (num_experts, gate_up_features):
+                raise ValueError(
+                    f"fused_w1w3_bias must have shape {(num_experts, gate_up_features)}, "
+                    f"got {tuple(fused_w1w3_bias.shape)}."
+                )
+            if fused_w2_bias.shape != (num_experts, hidden_size):
+                raise ValueError(
+                    f"fused_w2_bias must have shape {(num_experts, hidden_size)}, "
+                    f"got {tuple(fused_w2_bias.shape)}."
+                )
+            if fused_w1w3_bias.device != hidden_states.device or fused_w2_bias.device != hidden_states.device:
+                raise ValueError("SonicMoE expert biases must be on the same CUDA device as hidden_states.")
+            if fused_w1w3_bias.dtype != torch.bfloat16 or fused_w2_bias.dtype != torch.bfloat16:
+                raise TypeError("The initial SonicMoE integration requires bfloat16 expert biases.")
+
+        if hidden_states.shape[0] == 0:
+            zero = hidden_states.sum() + fused_w1w3.sum() + fused_w2.sum()
+            zero = zero + topk_weights.sum().to(hidden_states.dtype)
+            if router_weights is not None:
+                zero = zero + router_weights.sum().to(hidden_states.dtype)
+            if fused_w1w3_bias is not None and fused_w2_bias is not None:
+                zero = zero + fused_w1w3_bias.sum() + fused_w2_bias.sum()
+            expert_frequency = torch.zeros(num_experts, dtype=torch.int32, device=hidden_states.device)
+            return hidden_states + zero * 0, expert_frequency
+
+        if self.config.routing_mode == "token_rounding":
+            if router_weights is None:
+                raise ValueError("router_weights are required when SonicMoE token rounding is enabled.")
+            if router_weights.device != hidden_states.device:
+                raise ValueError("router_weights must be on the same CUDA device as hidden_states.")
+            router_scores, token_indices, expert_indices = build_token_rounding_metadata(
+                router_weights,
+                topk_ids,
+                num_experts=num_experts,
+                rounding_quantum=self.config.rounding_quantum,
+                rounding_mode=self.config.rounding_mode,
+            )
+        else:
+            num_experts_per_token = topk_ids.shape[1]
+            token_indices = torch.arange(
+                hidden_states.shape[0], device=hidden_states.device, dtype=torch.int32
+            ).repeat_interleave(num_experts_per_token)
+            expert_indices = topk_ids.reshape(-1).to(dtype=torch.int32).contiguous()
+            router_scores = topk_weights.reshape(-1).to(dtype=torch.float32).contiguous()
+
+        if router_scores.numel() == 0:
+            zero = fused_w1w3.sum() + fused_w2.sum() + router_scores.sum().to(hidden_states.dtype)
+            if fused_w1w3_bias is not None and fused_w2_bias is not None:
+                zero = zero + fused_w1w3_bias.sum() + fused_w2_bias.sum()
+            output = hidden_states * 0 + zero * 0
+            expert_frequency = torch.zeros(num_experts, dtype=torch.int32, device=hidden_states.device)
+            return output, expert_frequency
+
+        # SonicMoE expects [2I, H, E] and [H, I, E]. XTuner stores the
+        # checkpoint-compatible concatenated layout [E, 2I, H] / [E, H, I].
+        # Permuted views preserve the original Parameters and their gradients.
+        # Do not materialize contiguous copies here: SonicMoE requires the
+        # stride order produced by permuting contiguous [E, O, I] parameters.
+        sonic_w1 = fused_w1w3.permute(1, 2, 0)
+        sonic_w2 = fused_w2.permute(1, 2, 0)
+        output, expert_frequency = self._op(
+            hidden_states,
+            router_scores,
+            token_indices,
+            expert_indices,
+            sonic_w1,
+            fused_w1w3_bias,
+            sonic_w2,
+            fused_w2_bias,
+            num_experts,
+            training=training,
+        )
+        return output, expert_frequency

--- a/xtuner/v1/ops/moe/sonicmoe.py
+++ b/xtuner/v1/ops/moe/sonicmoe.py
@@ -1,0 +1,95 @@
+import importlib
+from importlib import metadata
+from typing import Callable
+
+import torch
+
+
+SonicMoEForward = Callable[..., tuple[torch.Tensor, torch.Tensor]]
+
+
+class SonicMoEOp:
+    """Low-level adapter for the official SonicMoE functional kernel.
+
+    The optional dependency is resolved once during construction, outside any
+    compiled forward graph. The call itself is intentionally a Dynamo graph
+    boundary: SonicMoE already owns the optimized CUDA/CuTe kernels and custom
+    backward, while XTuner can compile the surrounding decoder computation.
+    """
+
+    def __init__(self) -> None:
+        self._forward, self.activation_type = self._resolve_official_api()
+
+    @torch.compiler.disable
+    def __call__(
+        self,
+        hidden_states: torch.Tensor,
+        router_scores: torch.Tensor,
+        token_indices: torch.Tensor,
+        expert_indices: torch.Tensor,
+        w1: torch.Tensor,
+        b1: torch.Tensor | None,
+        w2: torch.Tensor,
+        b2: torch.Tensor | None,
+        num_experts: int,
+        *,
+        training: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Execute the official SonicMoE general-routing kernel.
+
+        Args:
+            hidden_states (torch.Tensor): Unpermuted token states.
+            router_scores (torch.Tensor): Score for every routed assignment.
+            token_indices (torch.Tensor): Token id for every assignment.
+            expert_indices (torch.Tensor): Expert id for every assignment.
+            w1 (torch.Tensor): SonicMoE up-projection weight view.
+            b1 (torch.Tensor | None): Optional up-projection bias.
+            w2 (torch.Tensor): SonicMoE down-projection weight view.
+            b2 (torch.Tensor | None): Optional down-projection bias.
+            num_experts (int): Number of routed experts.
+            training (bool): Whether to enable the official training path.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor]: Combined expert output and
+            executed token count per expert.
+        """
+        return self._forward(
+            hidden_states,
+            router_scores,
+            token_indices,
+            expert_indices,
+            w1,
+            b1,
+            w2,
+            b2,
+            num_experts,
+            None,
+            self.activation_type,
+            not training,
+            concat_layout=True,
+        )
+
+    @staticmethod
+    def _resolve_official_api() -> tuple[SonicMoEForward, object]:
+        try:
+            functional = importlib.import_module("sonicmoe.functional")
+            enums = importlib.import_module("sonicmoe.enums")
+        except Exception as e:  # noqa: BLE001 - binary dependency import errors are not stable
+            raise ImportError(
+                "The SonicMoE expert backend requires the official 'sonic-moe' package. "
+                "Install XTuner's sonicmoe optional dependency or run `pip install sonic-moe`."
+            ) from e
+
+        forward = getattr(functional, "moe_general_routing_inputs", None)
+        activation_type = getattr(enums, "ActivationType", None)
+        if not callable(forward) or activation_type is None or not hasattr(activation_type, "SWIGLU"):
+            try:
+                version = metadata.version("sonic-moe")
+            except metadata.PackageNotFoundError:
+                version = "unknown"
+            raise ImportError(
+                "The installed sonic-moe package does not expose the supported official API "
+                f"(version={version!r}). Expected sonicmoe.functional.moe_general_routing_inputs "
+                "and sonicmoe.enums.ActivationType.SWIGLU."
+            )
+        return forward, activation_type.SWIGLU

--- a/xtuner/v1/ops/moe/token_rounding.py
+++ b/xtuner/v1/ops/moe/token_rounding.py
@@ -1,0 +1,106 @@
+from typing import Literal
+
+import torch
+
+
+TokenRoundingMode = Literal["nearest", "up", "down"]
+
+
+def build_token_rounding_metadata(
+    router_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    num_experts: int,
+    rounding_quantum: int,
+    rounding_mode: TokenRoundingMode,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build SonicMoE token-rounding routing metadata.
+
+    This follows SonicMoE's token-choice rounding algorithm. Original top-k
+    assignments have priority for each expert. Rounding up may then add the
+    highest-scoring non-top-k tokens, while rounding down removes the
+    lowest-priority original assignments.
+
+    Args:
+        router_weights (torch.Tensor): Full router probabilities with shape
+            ``[num_tokens, num_experts]``.
+        topk_ids (torch.Tensor): Original token-choice expert ids with shape
+            ``[num_tokens, top_k]``.
+        num_experts (int): Number of routed experts.
+        rounding_quantum (int): Expert token-count tile size.
+        rounding_mode (TokenRoundingMode): ``"nearest"``, ``"up"``, or
+            ``"down"``.
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]: Flattened router
+        scores, token indices, and expert indices accepted by SonicMoE's
+        general-routing API.
+    """
+    if router_weights.ndim != 2 or router_weights.shape[1] != num_experts:
+        raise ValueError(
+            "router_weights must have shape [num_tokens, num_experts], "
+            f"got {tuple(router_weights.shape)} for num_experts={num_experts}."
+        )
+    if topk_ids.ndim != 2 or topk_ids.shape[0] != router_weights.shape[0]:
+        raise ValueError(
+            "topk_ids must have shape [num_tokens, top_k] with the same token dimension as router_weights."
+        )
+    if rounding_quantum <= 0:
+        raise ValueError(f"rounding_quantum must be positive, got {rounding_quantum}.")
+
+    num_tokens = router_weights.shape[0]
+    if num_tokens == 0:
+        empty_indices = torch.empty(0, dtype=torch.int32, device=router_weights.device)
+        return router_weights.new_empty(0, dtype=torch.float32), empty_indices, empty_indices.clone()
+
+    topk_ids_long = topk_ids.to(dtype=torch.long)
+    selected_priority = router_weights.gather(1, topk_ids_long)
+    selected_priority = selected_priority / selected_priority.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+
+    # Keep every original token-choice assignment ahead of every expert-choice
+    # candidate. Routing selection is discrete, so detach the priority matrix
+    # while gathering the final scores from router_weights to preserve drouter.
+    routing_priority = router_weights.detach() - 1
+    routing_priority = routing_priority.scatter(1, topk_ids_long, selected_priority.detach())
+    ranked_token_indices = routing_priority.argsort(dim=0, descending=True).to(torch.int32)
+
+    expert_frequency = torch.bincount(topk_ids_long.reshape(-1), minlength=num_experts).to(torch.int32)
+    if rounding_mode == "up":
+        rounded_frequency = (
+            torch.div(
+                expert_frequency + rounding_quantum - 1,
+                rounding_quantum,
+                rounding_mode="floor",
+            )
+            * rounding_quantum
+        )
+    elif rounding_mode == "down":
+        rounded_frequency = (
+            torch.div(
+                expert_frequency,
+                rounding_quantum,
+                rounding_mode="floor",
+            )
+            * rounding_quantum
+        )
+    elif rounding_mode == "nearest":
+        rounded_frequency = torch.round(expert_frequency.float() / rounding_quantum).to(torch.int32)
+        rounded_frequency = rounded_frequency * rounding_quantum
+    else:
+        raise ValueError(f"Unsupported token rounding mode: {rounding_mode!r}.")
+    rounded_frequency = rounded_frequency.clamp(min=0, max=num_tokens)
+
+    rank_mask = (
+        torch.arange(num_tokens, device=router_weights.device, dtype=torch.int32)[:, None] < rounded_frequency[None, :]
+    )
+    token_indices = ranked_token_indices[rank_mask]
+    expert_indices = torch.arange(num_experts, device=router_weights.device, dtype=torch.int32)[None, :].expand(
+        num_tokens, -1
+    )[rank_mask]
+
+    # SonicMoE's reduction expects assignments ordered by token id.
+    token_order = token_indices.argsort()
+    token_indices = token_indices[token_order].contiguous()
+    expert_indices = expert_indices[token_order].contiguous()
+    router_scores = router_weights[token_indices.long(), expert_indices.long()].to(torch.float32).contiguous()
+    return router_scores, token_indices, expert_indices

--- a/xtuner/v1/ops/rms_norm/gpu.py
+++ b/xtuner/v1/ops/rms_norm/gpu.py
@@ -94,8 +94,13 @@ def triton_autotune_configs():
     configs = []  # noqa: F841
     # Maximum threads per block is architecture-dependent in theory, but in reality all are 1024
     max_threads_per_block = 1024
-    # Default to warp size 32 if not defined by device
-    warp_size = getattr(torch.cuda.get_device_properties(torch.cuda.current_device()), "warp_size", 32)
+    # Default to warp size 32 when importing without an available CUDA device.
+    warp_size = 32
+    if torch.cuda.is_available():
+        try:
+            warp_size = getattr(torch.cuda.get_device_properties(torch.cuda.current_device()), "warp_size", 32)
+        except RuntimeError:
+            pass
     # Autotune for warp counts which are powers of 2 and do not exceed thread per block limit
     return [
         triton.Config({}, num_warps=warp_count)


### PR DESCRIPTION
  ## Summary

  This PR adds an optional SonicMoE expert backend for XTuner MoE models.

  The feature is disabled by default. Existing MoE configs still use `expert_backend="grouped_gemm"` unless users explicitly opt in with `expert_backend="sonicmoe"`, so the original MoE flow, dispatcher logic, checkpoint layout, and default training behavior remain unchanged.

  ## Implementation

  The implementation introduces SonicMoE as a backend adapter instead of changing XTuner’s parameter ownership or checkpoint format.

  Main changes:

  - Add `expert_backend` to `MoEConfig`, with default value `"grouped_gemm"`.
  - Add `SonicMoEBackendConfig` and `SonicMoEBackend`.
  - Add a SonicMoE op wrapper around the official `sonic-moe` package.
  - Route MoE expert execution through SonicMoE only when `expert_backend="sonicmoe"`.
  - Keep XTuner’s native expert parameters and checkpoint-compatible layout:
    - XTuner keeps `[E, 2I, H] / [E, H, I]`.
    - The SonicMoE adapter passes permuted views to SonicMoE without materializing new parameters.
  - Preserve XTuner router output contract:
    - SonicMoE consumes XTuner’s unpermuted `topk_ids` and `topk_weights`.
    - General/dropless routing preserves every native top-k assignment.
    - Optional token rounding metadata is implemented behind `sonicmoe_cfg.routing_mode="token_rounding"`.

  The initial integration intentionally validates and rejects unsupported combinations:

  - `ep_size` must be `1`.
  - `expert_tp_size` must be `1`.
  - `dispatcher` must be `None`.
  - `float8_cfg` must be `None`.
  - Expert activation must be SwiGLU.
  - SonicMoE execution is CUDA-only and BF16-only.

  ## How To Enable

  Install the optional dependency:

  ```bash
  pip install -e ".[sonicmoe]"

  Then enable SonicMoE in the MoE model config:

  model = Qwen3MoE30BA3Config(
      expert_backend="sonicmoe",
  )
```

  Optional SonicMoE routing config can be passed through sonicmoe_cfg:

```bash
  from xtuner.v1.module.moe_backend import SonicMoEBackendConfig

  model = Qwen3MoE30BA3Config(
      expert_backend="sonicmoe",
      sonicmoe_cfg=SonicMoEBackendConfig(
          routing_mode="general",
      ),
  )
```

  For token rounding mode:

```bash
  model = Qwen3MoE30BA3Config(
      expert_backend="sonicmoe",
      sonicmoe_cfg=SonicMoEBackendConfig(
          routing_mode="token_rounding",
      ),
  )
```

  Token rounding has additional validation requirements: greedy router, softmax scores, no grouped router selection, norm_topk_prob=True, and router_scaling_factor=1.0.

  ## Tests And Validation

  Added unit coverage in tests/module/test_sonicmoe_backend.py for:

  - SonicMoE config validation.
  - Default backend behavior remaining unchanged.
  - Decoder-layer SonicMoE routing path.
  - SonicMoE call contract against XTuner router outputs.
  - Empty-token behavior preserving autograd participation.
  - Official SonicMoE forward/backward parity path.
  - 8-GPU FSDP smoke/parity coverage for distributed training.

  A standalone benchmark/profiler is also added:

  tests/profiler/qwen35_sonicmoe_fsdp_benchmark.py

  It compares XTuner native grouped GEMM MoE vs SonicMoE on Qwen3.5 MoE FSDP using identical model weights and identical per-rank input batches. Each measured step performs forward and backward without optimizer update, so loss comparison is directly attributable to the expert backend implementation. The profiler emits both JSON
  results and a markdown report including loss deltas, throughput, per-step latency, and SonicMoE speedup ratio.

  Example:
```bash
  XTUNER_DETERMINISTIC=true torchrun --nproc-per-node 8 \
    tests/profiler/qwen35_sonicmoe_fsdp_benchmark.py \
    --model-path /path/to/Qwen3.5-35B-A3B \
    --output /path/to/qwen35_sonicmoe_fsdp_benchmark.json \
    --steps 10 --warmup-steps 5 --deterministic
```