### PR TITLE
[Fix] Preserve SessionServer traces across response failures

### DIFF
--- a/tests/rl/test_session_server_trace.py
+++ b/tests/rl/test_session_server_trace.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from aiohttp import ClientConnectionResetError, web
+from aiohttp.test_utils import TestClient, TestServer
+
+from xtuner.v1.rl.rollout.session_server import SessionServer, _prepare_stream_response
+
+
+class TestSessionServerTraceHandling(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.upstream_status = 200
+        self.upstream_body = b"{}"
+
+        async def upstream_handler(_request):
+            return web.Response(
+                status=self.upstream_status,
+                content_type="application/json",
+                body=self.upstream_body,
+            )
+
+        upstream_app = web.Application()
+        upstream_app.router.add_route("*", "/{path:.*}", upstream_handler)
+        self.upstream_server = TestServer(upstream_app)
+        await self.upstream_server.start_server()
+
+        self.session_server = SessionServer.__new__(SessionServer)
+        self.session_server.worker_base_url = str(self.upstream_server.make_url("")).rstrip("/")
+        self.session_server.request_timeout = 10.0
+        self.session_server.read_bufsize = 2**20
+        self.session_server.stop_word = "<eos>"
+        self.session_server.on_request = AsyncMock(side_effect=lambda body, _fmt, **_kwargs: body)
+        self.session_server.on_response = AsyncMock(return_value=None)
+
+        proxy_app = web.Application()
+        proxy_app.router.add_route("*", "/{path:.*}", self.session_server._handle_request)
+        self.proxy_client = TestClient(TestServer(proxy_app))
+        await self.proxy_client.start_server()
+
+    async def asyncTearDown(self):
+        await self.proxy_client.close()
+        await self.upstream_server.close()
+
+    @staticmethod
+    def _request_payload():
+        return {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "session_id": "trace-session",
+        }
+
+    async def test_malformed_generation_response_fails_closed(self):
+        self.upstream_body = b'{"choices": []}'
+        self.session_server.on_response = AsyncMock(side_effect=KeyError("choices"))
+
+        response = await self.proxy_client.post("/v1/chat/completions", json=self._request_payload())
+
+        self.assertEqual(response.status, 500)
+        self.session_server.on_response.assert_awaited_once()
+
+    async def test_non_object_generation_response_fails_closed(self):
+        self.upstream_body = b"[]"
+
+        response = await self.proxy_client.post("/v1/chat/completions", json=self._request_payload())
+
+        self.assertEqual(response.status, 500)
+        self.session_server.on_response.assert_not_awaited()
+
+    async def test_non_json_generation_response_fails_closed_with_native_error(self):
+        self.upstream_body = b"not-json"
+
+        response = await self.proxy_client.post("/v1/messages", json=self._request_payload())
+
+        self.assertEqual(response.status, 500)
+        error = await response.json()
+        self.assertEqual(error["type"], "error")
+        self.assertEqual(error["error"]["type"], "internal_server_error")
+        self.session_server.on_response.assert_not_awaited()
+
+    async def test_upstream_error_is_returned_unchanged(self):
+        self.upstream_status = 400
+        self.upstream_body = b'{"type":"error","error":{"type":"bad_request","message":"unsupported"}}'
+
+        response = await self.proxy_client.post("/v1/messages", json=self._request_payload())
+
+        self.assertEqual(response.status, 400)
+        self.assertEqual(await response.read(), self.upstream_body)
+        self.session_server.on_response.assert_not_awaited()
+
+
+class TestPrepareStreamResponse(unittest.IsolatedAsyncioTestCase):
+    async def test_prepared_client_remains_alive(self):
+        response = unittest.mock.Mock()
+        response.prepare = AsyncMock(return_value=None)
+        request = unittest.mock.Mock()
+
+        self.assertTrue(await _prepare_stream_response(response, request))
+        response.prepare.assert_awaited_once_with(request)
+
+    async def test_disconnect_before_headers_marks_client_dead(self):
+        response = unittest.mock.Mock()
+        response.prepare = AsyncMock(side_effect=ClientConnectionResetError("closing transport"))
+        request = unittest.mock.Mock()
+
+        self.assertFalse(await _prepare_stream_response(response, request))
+        response.prepare.assert_awaited_once_with(request)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xtuner/v1/rl/rollout/session_server.py
+++ b/xtuner/v1/rl/rollout/session_server.py
@@ -33,6 +33,15 @@ def _is_error_payload(payload: dict) -> bool:
     return payload.get("error") is not None or payload.get("type") == "error" or payload.get("object") == "error"
 
 
+async def _prepare_stream_response(response: web.StreamResponse, request: web.Request) -> bool:
+    """Prepare downstream streaming, returning false after an early disconnect."""
+    try:
+        await response.prepare(request)
+    except (ConnectionError, ClientConnectionResetError):
+        return False
+    return True
+
+
 def _error_payload(fmt: str, message: str, status: int = 500, error_type: str = "internal_server_error") -> dict:
     """Error body in the caller's native shape.
 
@@ -619,6 +628,8 @@ class SessionServer:
             async with client.request(
                 method=request.method, url=target_url, headers=forward_headers, data=request_body
             ) as resp:
+                upstream_status = resp.status
+                trace_response = trace_enabled and upstream_status < HTTPStatus.BAD_REQUEST
                 if is_stream:
                     response_chunks: list[bytes] = []
                     response = web.StreamResponse(
@@ -629,37 +640,38 @@ class SessionServer:
                             if k.lower() not in ("transfer-encoding", "content-length", "content-encoding")
                         },
                     )
-                    await response.prepare(request)
                     # If the downstream client closes the socket mid-stream
                     # (e.g. AsyncAPIClient bails out on a finish_reason=='error'
                     # chunk after the prompt overflowed the session window),
                     # keep draining the upstream so the trace is still recorded
                     # in full but stop attempting to write to the closed socket.
-                    client_alive = True
+                    # This includes a disconnect before response headers are
+                    # prepared, not just one that happens between body chunks.
+                    client_alive = await _prepare_stream_response(response, request)
                     async for line in resp.content:
                         # Only retain chunks when we'll actually need to parse
                         # them for tracing; evaluate-mode requests skip this
                         # so memory does not grow with stream length.
-                        if trace_enabled:
+                        if trace_response:
                             response_chunks.append(line)
 
                         if request_data is not None and line.startswith(b"data: ") and line.strip() != b"data: [DONE]":
                             try:
                                 text = line.decode("utf-8")
                                 data = json.loads(text[6:])
-                                if clean_data(data):
+                                if isinstance(data, dict) and not _is_error_payload(data) and clean_data(data):
                                     line = ("data: " + json.dumps(data) + "\n").encode("utf-8")
                             except Exception:
                                 pass
 
                         # Delay [DONE] only while a training trace still needs to be exported.
-                        if client_alive and (not trace_enabled or line.strip() != b"data: [DONE]"):
+                        if client_alive and (not trace_response or line.strip() != b"data: [DONE]"):
                             try:
                                 await response.write(line)
                             except (ConnectionError, ClientConnectionResetError):
                                 client_alive = False
 
-                    raw_response = b"".join(response_chunks) if trace_enabled else b""
+                    raw_response = b"".join(response_chunks) if trace_response else b""
                 else:
                     raw_response = await resp.read()
                     final_raw_response = raw_response
@@ -667,7 +679,7 @@ class SessionServer:
                     if request_data is not None:
                         try:
                             parsed = json.loads(raw_response)
-                            if clean_data(parsed):
+                            if isinstance(parsed, dict) and not _is_error_payload(parsed) and clean_data(parsed):
                                 final_raw_response = json.dumps(parsed).encode("utf-8")
                         except Exception:
                             pass
@@ -684,9 +696,9 @@ class SessionServer:
 
         # Apply abstract on_response processing
         response_data: Optional[dict] = None
-        skip_done = bool(is_stream and not trace_enabled)
+        skip_done = bool(is_stream and not trace_response)
         session_error_msg: Optional[str] = None
-        if request_data and trace_enabled and orig_req_body is not None:
+        if request_data and trace_response and orig_req_body is not None:
             if is_stream:
                 try:
                     response_data = self._parse_stream_response(raw_response, fmt)
@@ -700,11 +712,15 @@ class SessionServer:
                     skip_done = True
             else:
                 try:
-                    response_data = json.loads(raw_response)
-                except json.JSONDecodeError:
-                    pass
-                if isinstance(response_data, dict) and _is_error_payload(response_data):
-                    response_data = None
+                    parsed_response = json.loads(raw_response)
+                    if not isinstance(parsed_response, dict):
+                        raise TypeError(
+                            f"generation response body must be a JSON object; got {type(parsed_response).__name__}"
+                        )
+                    if not _is_error_payload(parsed_response):
+                        response_data = parsed_response
+                except (json.JSONDecodeError, UnicodeDecodeError, TypeError) as exc:
+                    session_error_msg = f"SessionServer response hook failed: {type(exc).__name__}: {exc}"
 
             if response_data is not None:
                 try:


### PR DESCRIPTION
## Summary

This PR prevents trace-enabled `SessionServer` generations from being silently lost when the downstream client disconnects before response headers are prepared or when an upstream successful response cannot be recorded.

It also keeps upstream error responses out of generation trace processing and returns those errors unchanged to the client.

The endpoint-classification and proxy allowlist changes originally included in this PR have been split into #2061. This PR now contains only trace-response reliability behavior and is independently based on `upstream/main`.

## Problem

### Disconnect before response preparation

The streaming path already stopped writing after a downstream disconnect while continuing to drain the upstream response for trace completion. However, `response.prepare(request)` ran before that protected state was established. If the client disconnected before headers were prepared, the exception escaped and the upstream response was no longer drained, leaving the training trace incomplete.

### Successful but untraceable response

For a trace-enabled non-streaming request, a JSON array or non-JSON 2xx response previously left `response_data` unset and returned the successful upstream response without calling `on_response`. The client could observe or record a successful turn while the trace store had no corresponding node.

### Upstream error payloads

Non-2xx responses are capability or request errors, not successful generations. They should remain visible to the caller in their original form and must not enter response cleaning or trace hooks.

## Implementation

- Wrap downstream stream preparation in a small helper that treats connection-reset failures as a dead downstream client.
  - The proxy still drains the upstream stream.
  - Subsequent writes are skipped.
  - A complete trace can still be parsed and recorded.
- Derive `trace_response` from both the request trace flag and the upstream HTTP status.
  - Only successful generation responses are buffered and passed to `on_response`.
  - Upstream 4xx/error payloads bypass response mutation and trace hooks.
- Validate trace-enabled successful non-stream responses before recording.
  - JSON objects continue to the existing response hook.
  - JSON arrays and non-JSON bodies produce a controlled native-format `500` error instead of silently omitting the trace.
  - Structurally malformed generation objects still reach `on_response`, whose existing fail-closed error handling remains authoritative.

No endpoint allowlist, `count_tokens`, hello, or management-route policy is introduced here; those changes are isolated in #2061.

## Tests

Added focused local `aiohttp` fake-upstream tests covering:

- downstream connection loss before response headers are prepared;
- successful stream preparation;
- malformed generation envelopes reaching the response hook and failing closed;
- JSON-list and non-JSON successful responses producing controlled errors; and
- upstream 4xx bodies being returned unchanged without invoking `on_response`.

Validation performed on this topic alone:

```text
pytest -q tests/rl/test_session_server_trace.py
6 passed

ruff check xtuner/v1/rl/rollout/session_server.py tests/rl/test_session_server_trace.py
All checks passed

git diff --check upstream/main...fix/session-server-untraceable-response
```

This topic merges cleanly with #2061 in the local integration branch; the combined endpoint and trace suites pass all 12 tests.

## Scope

- No request endpoint classification or forwarding policy changes.
- No LMDeploy changes.
- No public API changes.
