### PR TITLE
[Fix] Reduce ChunkLoss memory usage with detached LM heads

### DIFF
--- a/tests/loss/test_chunk_loss.py
+++ b/tests/loss/test_chunk_loss.py
@@ -1,0 +1,90 @@
+import traceback
+from unittest.mock import patch
+
+import torch
+
+from xtuner.v1.loss.chunk_loss import ChunkLoss
+
+
+def _loss_forward(hidden_states, head_weight, head_bias, scale):
+    assert head_bias is None
+    logits = hidden_states @ head_weight.T
+    loss = logits.square().sum() * scale
+    return loss, (None, {"logits_max": logits.detach().max()})
+
+
+def _reference_loss(hidden_states, head_weight, scales, chunk_size):
+    hidden_states_chunks = torch.split(hidden_states, chunk_size, dim=1)
+    return sum(
+        _loss_forward(hidden_states_chunk, head_weight, None, scale)[0]
+        for hidden_states_chunk, scale in zip(hidden_states_chunks, scales, strict=True)
+    )
+
+
+def test_chunk_loss_matches_reference_with_trainable_head():
+    torch.manual_seed(0)
+    chunk_size = 3
+    scales = [0.5, 1.25, 0.75]
+    upstream_gradient = 0.37
+    hidden_states = torch.randn(2, 7, 4, dtype=torch.float32)
+    head_weight = torch.randn(6, 4, dtype=torch.float32)
+
+    reference_hidden_states = hidden_states.clone().requires_grad_()
+    reference_head_weight = head_weight.clone().requires_grad_()
+    reference_loss = _reference_loss(reference_hidden_states, reference_head_weight, scales, chunk_size)
+    reference_loss.backward(gradient=torch.tensor(upstream_gradient, dtype=torch.float32))
+
+    chunk_hidden_states = hidden_states.clone().requires_grad_()
+    chunk_head_weight = head_weight.clone().requires_grad_()
+    chunk_loss, _ = ChunkLoss.apply(
+        chunk_hidden_states,
+        chunk_head_weight,
+        None,
+        _loss_forward,
+        scales,
+        chunk_size,
+    )
+    chunk_loss.backward(gradient=torch.tensor(upstream_gradient, dtype=torch.float32))
+
+    torch.testing.assert_close(chunk_loss, reference_loss)
+    torch.testing.assert_close(chunk_hidden_states.grad, reference_hidden_states.grad)
+    torch.testing.assert_close(chunk_head_weight.grad, reference_head_weight.grad)
+
+
+def test_chunk_loss_skips_weight_grad_allocation_for_detached_head():
+    torch.manual_seed(1)
+    chunk_size = 2
+    scales = [0.25, 1.5, 0.75]
+    upstream_gradient = 0.41
+    hidden_states = torch.randn(1, 5, 3, dtype=torch.float32)
+    head_weight = torch.randn(8, 3, dtype=torch.float32)
+
+    reference_hidden_states = hidden_states.clone().requires_grad_()
+    reference_loss = _reference_loss(reference_hidden_states, head_weight, scales, chunk_size)
+    reference_loss.backward(gradient=torch.tensor(upstream_gradient, dtype=torch.float32))
+
+    chunk_hidden_states = hidden_states.clone().requires_grad_()
+    direct_zeros_like_calls = []
+    original_zeros_like = torch.zeros_like
+
+    def track_zeros_like(*args, **kwargs):
+        caller = traceback.extract_stack(limit=2)[0]
+        if caller.filename.endswith("xtuner/v1/loss/chunk_loss.py"):
+            direct_zeros_like_calls.append(caller)
+        return original_zeros_like(*args, **kwargs)
+
+    with patch("xtuner.v1.loss.chunk_loss.torch.zeros_like", new=track_zeros_like):
+        chunk_loss, _ = ChunkLoss.apply(
+            chunk_hidden_states,
+            head_weight,
+            None,
+            _loss_forward,
+            scales,
+            chunk_size,
+        )
+        chunk_loss.backward(gradient=torch.tensor(upstream_gradient, dtype=torch.float32))
+
+    torch.testing.assert_close(chunk_loss, reference_loss)
+    torch.testing.assert_close(chunk_hidden_states.grad, reference_hidden_states.grad)
+    assert head_weight.grad is None
+    assert direct_zeros_like_calls == []

--- a/xtuner/v1/loss/chunk_loss.py
+++ b/xtuner/v1/loss/chunk_loss.py
@@ -21,7 +21,8 @@ class ChunkLoss(torch.autograd.Function):
         device = hidden_states.device
         accumulated_loss = torch.tensor(0.0, device=device)
         grad_inputs = torch.empty_like(hidden_states)
-        grad_weight = torch.zeros_like(head_weight)
+        weight_requires_grad = head_weight.requires_grad
+        grad_weight = torch.zeros_like(head_weight) if weight_requires_grad else None
 
         grad_inputs_chunks = torch.split(grad_inputs, chunk_size, dim=1)
         hidden_states_chunks = torch.split(hidden_states, chunk_size, dim=1)
@@ -42,28 +43,34 @@ class ChunkLoss(torch.autograd.Function):
                 chunk_loss, (_, extra_info) = loss_forward(
                     hidden_states_chunk, head_weight, None, loss_kwargs_chunks[i]
                 )
-                if head_weight.requires_grad:
+                if weight_requires_grad:
                     chunk_grad_input, chunk_grad_weight = grad(
                         chunk_loss, (hidden_states_chunk, head_weight), allow_unused=True
                     )
                 else:
                     chunk_grad_input = grad(chunk_loss, (hidden_states_chunk,), allow_unused=True)[0]
-                    chunk_grad_weight = torch.zeros_like(head_weight)
 
             accumulated_loss.add_(chunk_loss)
             grad_inputs_chunk.copy_(chunk_grad_input)
-            grad_weight.add_(chunk_grad_weight)
+            if grad_weight is not None:
+                grad_weight.add_(chunk_grad_weight)
 
             chunked_extra_info.append(extra_info)
 
-        ctx.save_for_backward(grad_inputs, grad_weight)
+        ctx.weight_requires_grad = weight_requires_grad
+        if grad_weight is None:
+            ctx.save_for_backward(grad_inputs)
+        else:
+            ctx.save_for_backward(grad_inputs, grad_weight)
         return accumulated_loss, chunked_extra_info
 
     @staticmethod
     def backward(ctx, *grad_output):
-        grad_input, grad_weight = ctx.saved_tensors
+        grad_input = ctx.saved_tensors[0]
+        grad_weight = ctx.saved_tensors[1] if ctx.weight_requires_grad else None
         if torch.ne(grad_output[0], torch.tensor(1.0, device=grad_output[0].device)):
             grad_input = grad_input * grad_output[0]
-            grad_weight = grad_weight * grad_output[0]
+            if grad_weight is not None:
+                grad_weight = grad_weight * grad_output[0]
 
         return grad_input, grad_weight, None, None, None, None


### PR DESCRIPTION
## Summary

`ChunkLoss` currently allocates and retains a full-sized LM-head gradient tensor even when the supplied `head_weight` is detached and does not require gradients. This happens in the MTP path when `detach_mtp_lm_head_weight=True` and can waste a substantial amount of accelerator memory because the tensor scales with `vocab_size * hidden_size`.

This change makes the custom autograd function respect `head_weight.requires_grad` throughout forward and backward:

- allocate the accumulated head-weight gradient only when the weight is trainable;
- avoid allocating a zero-filled head-gradient tensor for every chunk when it is detached;
- save only the tensors needed by backward in the detached case; and
- return `None` for the head-weight gradient when no gradient was requested.

The trainable-head path keeps its existing loss and gradient behavior.

## Problem

Before this change, `ChunkLoss.forward()` unconditionally created `grad_weight = torch.zeros_like(head_weight)`. Each chunk also produced or allocated a tensor with the same shape, and the accumulated tensor was saved for backward.

For a detached LM head this work cannot contribute to optimization: PyTorch does not request a gradient for that input, and the custom backward should return `None`. Nevertheless, the implementation still paid the memory cost of one or more vocabulary-sized weight-gradient buffers. Depending on model dimensions and dtype, this can consume hundreds of MiB or more.

The existing MTP loss intentionally exercises this case by detaching the LM-head weight when `detach_mtp_lm_head_weight` is enabled.

## Implementation

- Cache whether `head_weight` requires gradients at the start of the custom forward.
- Initialize and accumulate `grad_weight` only for the trainable-head path.
- Save `grad_inputs` alone for the detached-head path and record the condition on the autograd context.
- In backward, scale and return the saved head gradient only when it exists; otherwise return `None` for `head_weight`.

This is deliberately local to `ChunkLoss`: it does not alter the chunking algorithm, numerical loss definition, MTP configuration, or public API.

## Tests

Added focused regression tests covering both modes:

- the trainable-head path matches a non-chunked reference for loss, hidden-state gradients, and head-weight gradients;
- the detached-head path matches the reference for loss and hidden-state gradients, leaves `head_weight.grad` unset, and verifies that no full-sized zero head-gradient buffer is allocated.

Validation performed:

```text
PYTHONPATH=. python -m pytest -q tests/loss/test_chunk_loss.py
2 passed

git diff --check upstream/main...fix/chunk-loss-detached-head-memory
```
