### PR TITLE
[Fix] Update flush cache worker broadcast

### DIFF
--- a/tests/rl/test_rollout_logic.py
+++ b/tests/rl/test_rollout_logic.py
@@ -455,6 +455,14 @@ class TestRolloutController(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(TimeoutError, "rollout worker recovery"):
             controller.pause_generation()
 
+    def test_flush_cache_broadcasts_to_active_workers(self):
+        controller = RolloutController.__new__(RolloutController)
+        controller._broadcast_to_workers = MagicMock(return_value=["cache_flushed"])
+
+        controller.flush_cache()
+
+        controller._broadcast_to_workers.assert_called_once_with("flush_cache", WorkerLifecycleState.ACTIVE)
+
     def test_mark_worker_groups_lifecycle_state_defaults_to_all_source_groups(self):
         controller = RolloutController.__new__(RolloutController)
         controller.registry = self._build_registry((0, 1))

--- a/xtuner/v1/rl/rollout/controller.py
+++ b/xtuner/v1/rl/rollout/controller.py
@@ -246,7 +246,7 @@ class RolloutController:
         self._broadcast_to_workers("offload", WorkerLifecycleState.ACTIVE)
 
     def flush_cache(self):
-        self._broadcast_to_active_workers("flush_cache")
+        self._broadcast_to_workers("flush_cache", WorkerLifecycleState.ACTIVE)
 
     def onload(self):
         self._broadcast_to_workers("onload_weights", WorkerLifecycleState.ACTIVE)


### PR DESCRIPTION
## Summary
- update `RolloutController.flush_cache()` to use the lifecycle-aware `_broadcast_to_workers` helper after the worker broadcast refactor
- add a regression test covering the active-worker flush-cache dispatch

## Root cause
The upstream flush-cache feature added a call to `_broadcast_to_active_workers`, while the later controller refactor renamed that helper to `_broadcast_to_workers` and missed this caller.

## Test plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=.../xtuner sandbox_rl/.venv/bin/python -m pytest -q tests/rl/test_rollout_logic.py` (61 passed)