### PR TITLE
[Feature] Add fused option for AdamW

### DIFF
--- a/examples/v1/config/sft_glm5p2.py
+++ b/examples/v1/config/sft_glm5p2.py
@@ -99,6 +99,7 @@ elif optimizer == "adamw":
     optim_cfg = AdamWConfig(
         lr=lr,
         foreach=_get_bool_env("ADAMW_FOREACH", False),
+        fused=_get_bool_env("ADAMW_FUSED", False),
         swap_optimizer=_get_bool_env("SWAP_OPTIMIZER", False),
     )
 else:

--- a/xtuner/v1/config/optim.py
+++ b/xtuner/v1/config/optim.py
@@ -32,9 +32,12 @@ class AdamWConfig(OptimConfig):
     betas: Annotated[Tuple[float, float], Parameter(help="Beta coefficients for Adam optimizer")] = (0.9, 0.95)
     eps: Annotated[float, Parameter(help="Epsilon value for numerical stability in Adam optimizer")] = 1e-8
     foreach: Annotated[Optional[bool], Parameter(help="Use foreach implementation for AdamW")] = None
+    fused: Annotated[Optional[bool], Parameter(help="Use fused implementation for AdamW")] = None
     swap_optimizer: Annotated[Optional[bool], Parameter(help="Swap optimizer states to host memory.")] = False
 
     def build(self, model):
+        if self.foreach and self.fused:
+            raise ValueError("AdamW foreach and fused implementations are mutually exclusive")
         params = [p for p in model.parameters() if p.requires_grad]
 
         trainable_parameters_names = model.trainable_parameters()
@@ -61,9 +64,16 @@ class AdamWConfig(OptimConfig):
                 eps=self.eps,
                 weight_decay=self.weight_decay,
                 foreach=self.foreach,
+                fused=self.fused,
             )
         return torch.optim.AdamW(
-            params, lr=self.lr, betas=self.betas, eps=self.eps, weight_decay=self.weight_decay, foreach=self.foreach
+            params,
+            lr=self.lr,
+            betas=self.betas,
+            eps=self.eps,
+            weight_decay=self.weight_decay,
+            foreach=self.foreach,
+            fused=self.fused,
         )
 
 


### PR DESCRIPTION
Expose the fused setting through AdamWConfig and the GLM-5.2 SFT example. Forward it to both optimizer paths and reject incompatible foreach/fused combinations.