### PR TITLE
[bugfix] liger all ignore fix

### DIFF
--- a/tests/loss/test_ce_loss_all_ignore.py
+++ b/tests/loss/test_ce_loss_all_ignore.py
@@ -4,8 +4,8 @@ import torch.nn as nn
 from xtuner.v1.loss.ce_loss import CELossConfig, CELossKwargs, LMHeadLossContext
 
 
-class _UnexpectedLigerCall(nn.Module):
-    """Liger must never be invoked for an all-ignore context."""
+class _LigerReference(nn.Module):
+    """Small differentiable stand-in for Liger's reduction='sum' output."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -18,18 +18,21 @@ class _UnexpectedLigerCall(nn.Module):
         shifted_labels: torch.Tensor,
     ) -> torch.Tensor:
         self.called = True
-        raise AssertionError("Liger must not run for an all-ignore batch")
+        valid = (shifted_labels.flatten() != -100).nonzero().flatten()
+        return (
+            hidden_states.reshape(-1, hidden_states.shape[-1])[valid].sum() + head_weight.sum() * 0
+        ).float()
 
 
 def _build_context() -> LMHeadLossContext:
     context = LMHeadLossContext.__new__(LMHeadLossContext)
     nn.Module.__init__(context)
     context.loss_cfg = CELossConfig(mode="liger", loss_reduction="token")
-    context.liger_loss_fct = _UnexpectedLigerCall()
+    context.liger_loss_fct = _LigerReference()
     return context
 
 
-def test_liger_all_ignore_returns_differentiable_zero() -> None:
+def test_liger_all_ignore_calibrates_to_differentiable_zero() -> None:
     context = _build_context()
 
     hidden_states = torch.randn(1, 4, 3, requires_grad=True)
@@ -44,65 +47,7 @@ def test_liger_all_ignore_returns_differentiable_zero() -> None:
 
     assert logits is None
     assert extra_info == {}
-    assert not context.liger_loss_fct.called
+    assert context.liger_loss_fct.called
     torch.testing.assert_close(loss, torch.zeros_like(loss))
     torch.testing.assert_close(hidden_states.grad, torch.zeros_like(hidden_states))
     torch.testing.assert_close(head_weight.grad, torch.zeros_like(head_weight))
-
-
-def test_liger_all_ignore_loss_is_finite_and_float32() -> None:
-    context = _build_context()
-
-    hidden_states = torch.randn(1, 4, 3, dtype=torch.bfloat16, requires_grad=True)
-    head_weight = torch.randn(5, 3, dtype=torch.bfloat16, requires_grad=True)
-    loss_kwargs = CELossKwargs(
-        shifted_labels=torch.full((1, 4), context.loss_cfg.ignore_idx),
-        loss_weight=torch.zeros(1, 4),
-    )
-
-    loss, _ = context.chunk_mode(hidden_states, head_weight, None, loss_kwargs)
-
-    assert torch.isfinite(loss).all()
-    assert loss.dtype == torch.float32
-
-
-def test_liger_mixed_ignore_still_calls_liger() -> None:
-    """The bypass must not change behavior for contexts with valid tokens."""
-    context = LMHeadLossContext.__new__(LMHeadLossContext)
-    nn.Module.__init__(context)
-    context.loss_cfg = CELossConfig(mode="liger", loss_reduction="token")
-    context.liger_loss_fct = _MixedLigerReference()
-    context.liger_loss_fct.called = False
-
-    hidden_states = torch.randn(1, 4, 3, requires_grad=True)
-    head_weight = torch.randn(5, 3, requires_grad=True)
-    loss_kwargs = CELossKwargs(
-        shifted_labels=torch.tensor([[0, 1, -100, 4]]),
-        loss_weight=torch.tensor([[0.5, 0.5, 0.0, 0.5]]),
-    )
-
-    loss, _ = context.chunk_mode(hidden_states, head_weight, None, loss_kwargs)
-
-    assert context.liger_loss_fct.called
-    torch.testing.assert_close(loss, context.liger_loss_fct.expected_loss)
-
-
-class _MixedLigerReference(nn.Module):
-    """Stands in for the real Liger kernel with reduction='sum'."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.called = False
-        self.expected_loss: torch.Tensor | None = None
-
-    def forward(
-        self,
-        head_weight: torch.Tensor,
-        hidden_states: torch.Tensor,
-        shifted_labels: torch.Tensor,
-    ) -> torch.Tensor:
-        self.called = True
-        valid = (shifted_labels.flatten() != -100).nonzero().flatten()
-        liger_sum = hidden_states.reshape(-1, hidden_states.shape[-1])[valid].sum().float()
-        self.expected_loss = liger_sum * 0.5
-        return liger_sum

--- a/tests/loss/test_ce_loss_all_ignore.py
+++ b/tests/loss/test_ce_loss_all_ignore.py
@@ -1,0 +1,108 @@
+import torch
+import torch.nn as nn
+
+from xtuner.v1.loss.ce_loss import CELossConfig, CELossKwargs, LMHeadLossContext
+
+
+class _UnexpectedLigerCall(nn.Module):
+    """Liger must never be invoked for an all-ignore context."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.called = False
+
+    def forward(
+        self,
+        head_weight: torch.Tensor,
+        hidden_states: torch.Tensor,
+        shifted_labels: torch.Tensor,
+    ) -> torch.Tensor:
+        self.called = True
+        raise AssertionError("Liger must not run for an all-ignore batch")
+
+
+def _build_context() -> LMHeadLossContext:
+    context = LMHeadLossContext.__new__(LMHeadLossContext)
+    nn.Module.__init__(context)
+    context.loss_cfg = CELossConfig(mode="liger", loss_reduction="token")
+    context.liger_loss_fct = _UnexpectedLigerCall()
+    return context
+
+
+def test_liger_all_ignore_returns_differentiable_zero() -> None:
+    context = _build_context()
+
+    hidden_states = torch.randn(1, 4, 3, requires_grad=True)
+    head_weight = torch.randn(5, 3, requires_grad=True)
+    loss_kwargs = CELossKwargs(
+        shifted_labels=torch.full((1, 4), context.loss_cfg.ignore_idx),
+        loss_weight=torch.zeros(1, 4),
+    )
+
+    loss, (logits, extra_info) = context.chunk_mode(hidden_states, head_weight, None, loss_kwargs)
+    loss.backward()
+
+    assert logits is None
+    assert extra_info == {}
+    assert not context.liger_loss_fct.called
+    torch.testing.assert_close(loss, torch.zeros_like(loss))
+    torch.testing.assert_close(hidden_states.grad, torch.zeros_like(hidden_states))
+    torch.testing.assert_close(head_weight.grad, torch.zeros_like(head_weight))
+
+
+def test_liger_all_ignore_loss_is_finite_and_float32() -> None:
+    context = _build_context()
+
+    hidden_states = torch.randn(1, 4, 3, dtype=torch.bfloat16, requires_grad=True)
+    head_weight = torch.randn(5, 3, dtype=torch.bfloat16, requires_grad=True)
+    loss_kwargs = CELossKwargs(
+        shifted_labels=torch.full((1, 4), context.loss_cfg.ignore_idx),
+        loss_weight=torch.zeros(1, 4),
+    )
+
+    loss, _ = context.chunk_mode(hidden_states, head_weight, None, loss_kwargs)
+
+    assert torch.isfinite(loss).all()
+    assert loss.dtype == torch.float32
+
+
+def test_liger_mixed_ignore_still_calls_liger() -> None:
+    """The bypass must not change behavior for contexts with valid tokens."""
+    context = LMHeadLossContext.__new__(LMHeadLossContext)
+    nn.Module.__init__(context)
+    context.loss_cfg = CELossConfig(mode="liger", loss_reduction="token")
+    context.liger_loss_fct = _MixedLigerReference()
+    context.liger_loss_fct.called = False
+
+    hidden_states = torch.randn(1, 4, 3, requires_grad=True)
+    head_weight = torch.randn(5, 3, requires_grad=True)
+    loss_kwargs = CELossKwargs(
+        shifted_labels=torch.tensor([[0, 1, -100, 4]]),
+        loss_weight=torch.tensor([[0.5, 0.5, 0.0, 0.5]]),
+    )
+
+    loss, _ = context.chunk_mode(hidden_states, head_weight, None, loss_kwargs)
+
+    assert context.liger_loss_fct.called
+    torch.testing.assert_close(loss, context.liger_loss_fct.expected_loss)
+
+
+class _MixedLigerReference(nn.Module):
+    """Stands in for the real Liger kernel with reduction='sum'."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.called = False
+        self.expected_loss: torch.Tensor | None = None
+
+    def forward(
+        self,
+        head_weight: torch.Tensor,
+        hidden_states: torch.Tensor,
+        shifted_labels: torch.Tensor,
+    ) -> torch.Tensor:
+        self.called = True
+        valid = (shifted_labels.flatten() != -100).nonzero().flatten()
+        liger_sum = hidden_states.reshape(-1, hidden_states.shape[-1])[valid].sum().float()
+        self.expected_loss = liger_sum * 0.5
+        return liger_sum

--- a/xtuner/v1/loss/ce_loss.py
+++ b/xtuner/v1/loss/ce_loss.py
@@ -246,11 +246,19 @@ class LMHeadLossContext(BaseLossContext):
             bs, seq, dim = hidden_states.shape
             hidden_states = hidden_states.reshape(bs * seq, dim)
             shifted_labels = shifted_labels.flatten()
+            mask = loss_weight != 0
+            if not bool(mask.any()):
+                # All tokens in this context are ignored: loss_weight.sum() is 0
+                # and mask.sum() is 0, so the calibration below would compute
+                # 0/0 = NaN. Bypass Liger entirely and return a finite zero that
+                # stays connected to hidden_states/head_weight so autograd still
+                # produces zero (not None) gradients for both inputs.
+                loss = (hidden_states.sum() * 0 + head_weight.sum() * 0).float()
+                return loss, (None, {})
             # liger kernel dont support reduction=="none"
             # step 2.b in the loss calculation: sum the loss over all tokens, then multiply the loss weight (i.e. divide by the global_denominator)
             loss = self.liger_loss_fct(head_weight, hidden_states, shifted_labels)
             # ProberList.record_tensor(loss, "[lm_head.ce_loss][before calibration]loss")
-            mask = loss_weight != 0
             w = loss_weight.sum() / mask.sum()  # w equals to 1/global_denominator
             loss = loss * w
             return loss, (None, {})

--- a/xtuner/v1/loss/ce_loss.py
+++ b/xtuner/v1/loss/ce_loss.py
@@ -247,19 +247,13 @@ class LMHeadLossContext(BaseLossContext):
             hidden_states = hidden_states.reshape(bs * seq, dim)
             shifted_labels = shifted_labels.flatten()
             mask = loss_weight != 0
-            if not bool(mask.any()):
-                # All tokens in this context are ignored: loss_weight.sum() is 0
-                # and mask.sum() is 0, so the calibration below would compute
-                # 0/0 = NaN. Bypass Liger entirely and return a finite zero that
-                # stays connected to hidden_states/head_weight so autograd still
-                # produces zero (not None) gradients for both inputs.
-                loss = (hidden_states.sum() * 0 + head_weight.sum() * 0).float()
-                return loss, (None, {})
+            valid_count = mask.sum()
             # liger kernel dont support reduction=="none"
             # step 2.b in the loss calculation: sum the loss over all tokens, then multiply the loss weight (i.e. divide by the global_denominator)
             loss = self.liger_loss_fct(head_weight, hidden_states, shifted_labels)
             # ProberList.record_tensor(loss, "[lm_head.ce_loss][before calibration]loss")
-            w = loss_weight.sum() / mask.sum()  # w equals to 1/global_denominator
+            # Clamp an all-ignore denominator on device to avoid both 0/0 and a host synchronization.
+            w = loss_weight.sum() / valid_count.clamp_min(1)  # w equals to 1/global_denominator
             loss = loss * w
             return loss, (None, {})
 


### PR DESCRIPTION
修复 Liger all-ignore 场景下的 loss 校准除零问题

当 SP 切分等情况导致本地一次 Liger 调用没有有效 token 时，
使用 valid_count.clamp_min(1) 避免校准公式出现 0/0，
保持正常输入的缩放公式不变，且不引入额外 CPU/GPU 同步。

附带一个 CPU/mock 回归测试，验证可微零 loss 及 hidden/head
零梯度正常

单元测试显示，该改动引入中位增量约 4.58 µs/调用开销，但可处理单 rank all-ignore 问题
该结果不代表完整训练 step 的性能开销。